### PR TITLE
Prepare new passkey features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,13 +10,14 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "actix"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
+checksum = "cba56612922b907719d4a01cf11c8d5b458e7d3dba946d0435f20f58d6795ed2"
 dependencies = [
+ "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -911,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2248,9 +2249,9 @@ checksum = "8c408dc227d302f1496c84d9dc68c00fec6f56f9228a18f3023f976f3ca7c945"
 
 [[package]]
 name = "memchr"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
+checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
 name = "mime"
@@ -3326,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.10"
+version = "0.38.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
+checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -4631,9 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ dependencies = [
  "parse-size",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -538,7 +538,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -605,7 +605,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -616,7 +616,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -1123,9 +1123,9 @@ checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "ctrlc"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix",
  "windows-sys",
@@ -1176,7 +1176,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -1198,7 +1198,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -1311,7 +1311,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -1606,7 +1606,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -2249,9 +2249,9 @@ checksum = "8c408dc227d302f1496c84d9dc68c00fec6f56f9228a18f3023f976f3ca7c945"
 
 [[package]]
 name = "memchr"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "mime"
@@ -2322,11 +2322,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "libc",
 ]
@@ -2431,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -2482,7 +2482,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -2634,7 +2634,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy"
-version = "0.14.5"
+version = "0.15.0-20230903"
 dependencies = [
  "actix-service",
  "actix-web",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-common"
-version = "0.14.5"
+version = "0.15.0-20230903"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-handlers"
-version = "0.14.5"
+version = "0.15.0-20230903"
 dependencies = [
  "actix",
  "actix-multipart",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-models"
-version = "0.14.5"
+version = "0.15.0-20230903"
 dependencies = [
  "accept-language",
  "actix",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-service"
-version = "0.14.5"
+version = "0.15.0-20230903"
 dependencies = [
  "actix-web",
  "argon2",
@@ -3115,13 +3115,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.7",
+ "regex-automata 0.3.8",
  "regex-syntax 0.7.5",
 ]
 
@@ -3136,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3287,7 +3287,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.29",
+ "syn 2.0.30",
  "walkdir",
 ]
 
@@ -3475,7 +3475,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -3924,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "0ddc1f908d32ec46858c2d3b3daa00cc35bf4b6841ce4355c7bb3eedf2283a68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3966,22 +3966,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -4076,7 +4076,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -4237,7 +4237,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -4390,7 +4390,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.29",
+ "syn 2.0.30",
 ]
 
 [[package]]
@@ -4525,7 +4525,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
  "wasm-bindgen-shared",
 ]
 
@@ -4559,7 +4559,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.30",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.5"
+version = "0.15.0-20230903"
 edition = "2021"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "AGPLv3"

--- a/frontend/src/components/account/AccMFA.svelte
+++ b/frontend/src/components/account/AccMFA.svelte
@@ -31,8 +31,6 @@
 
     let passkeys = [];
 
-    $: console.log(passkeys);
-
     let formValues = { passkeyName: '' };
     let formErrors = {};
     const schema = yup.object().shape({
@@ -50,17 +48,6 @@
         msg = '';
     }
 
-    // async function fetchUpdatedUser() {
-    //     resetMsgErr();
-    //
-    //     let res = await getUser(sessionInfo.user_id);
-    //     if (res.ok) {
-    //         user = await res.json();
-    //     } else {
-    //         redirectToLogin('account');
-    //     }
-    // }
-
     async function fetchPasskeys() {
         let res = await getUserPasskeys(sessionInfo.user_id);
         let body = await res.json();
@@ -72,46 +59,6 @@
         }
     }
 
-    // async function handleRegStart(slot) {
-    //     resetMsgErr();
-    //
-    //     let res = await webauthnRegStart(user.id, {slot});
-    //     if (res.status === 200) {
-    //         let challenge = await res.json();
-    //
-    //         // the navigator credentials engine needs some values as array buffers
-    //         challenge.publicKey.challenge = base64UrlSafeToArrBuf(challenge.publicKey.challenge);
-    //         challenge.publicKey.user.id = base64UrlSafeToArrBuf(challenge.publicKey.user.id);
-    //
-    //         // prompt for the user security key and get its public key
-    //         let challengePk = await navigator.credentials.create(challenge);
-    //
-    //         // the backend expects base64 url safe string instead of array buffers
-    //         let data = {
-    //             slot,
-    //             data: {
-    //                 id: challengePk.id,
-    //                 rawId: arrBufToBase64UrlSafe(challengePk.rawId),
-    //                 response: {
-    //                     attestationObject: arrBufToBase64UrlSafe(challengePk.response.attestationObject),
-    //                     clientDataJSON: arrBufToBase64UrlSafe(challengePk.response.clientDataJSON),
-    //                 },
-    //                 type: challengePk.type,
-    //             },
-    //         }
-    //
-    //         // send the keys' pk to the backend and finish the registration
-    //         res = await webauthnRegFinish(user.id, data);
-    //         if (res.status === 201) {
-    //             await fetchUpdatedUser();
-    //         } else {
-    //             console.error(res);
-    //         }
-    //     } else {
-    //         err = true;
-    //         msg = t.mfa.errorReg;
-    //     }
-    // }
     async function handleRegStart() {
         resetMsgErr();
 

--- a/frontend/src/components/admin/users/UserInfo.svelte
+++ b/frontend/src/components/admin/users/UserInfo.svelte
@@ -231,7 +231,7 @@
             MFA ACTIVE
         </div>
         <div class="value">
-            <CheckIcon check={user.sec_key_1?.length > 0 || user.sec_key_2?.length > 0}/>
+            <CheckIcon check={user.webauthn_enabled}/>
         </div>
     </div>
 

--- a/frontend/src/utils/dataFetching.js
+++ b/frontend/src/utils/dataFetching.js
@@ -140,6 +140,13 @@ export async function getUser(id) {
 	});
 }
 
+export async function getUserPasskeys(id) {
+	return await fetch(`/auth/v1/users/${id}/webauthn`, {
+		method: 'GET',
+		headers: getCsrfHeaders(),
+	});
+}
+
 export async function putUserSelf(id, data) {
 	return await fetch(`/auth/v1/users/${id}/self`, {
 		method: 'PUT',
@@ -187,9 +194,9 @@ export async function webauthnAuthFinish(id, data) {
 	});
 }
 
-export async function webauthnDelete(id, slot) {
-	return await fetch(`/auth/v1/users/${id}/webauthn/delete/${slot}`, {
-		method: 'POST',
+export async function webauthnDelete(id, name) {
+	return await fetch(`/auth/v1/users/${id}/webauthn/delete/${name}`, {
+		method: 'DELETE',
 		headers: getCsrfHeaders(),
 	});
 }

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ clippy-sqlite:
 
 clippy-postgres:
     clear
-    DATABASE_URL={{db_url_postgres}} cargo clippy --features postgres
+    DATABASE_URL={{db_url_postgres}} cargo clippy
 
 
 migrate-sqlite:
@@ -33,7 +33,7 @@ run-sqlite:
 
 # runs the application with postgres feature
 run-postgres:
-    DATABASE_URL={{db_url_postgres}} cargo run --target x86_64-unknown-linux-musl --features postgres
+    DATABASE_URL={{db_url_postgres}} cargo run --target x86_64-unknown-linux-musl
 
 
 # runs the UI in development mode
@@ -70,13 +70,13 @@ test-postgres: migrate-postgres
     #!/usr/bin/env bash
     clear
 
-    DATABASE_URL={{db_url_postgres}} cargo build --features postgres
-    DATABASE_URL={{db_url_postgres}} cargo run --features postgres test &
+    DATABASE_URL={{db_url_postgres}} cargo build
+    DATABASE_URL={{db_url_postgres}} cargo run test &
     sleep 1
     PID=$(echo "$!")
     echo "PID: $PID"
 
-    DATABASE_URL={{db_url_postgres}} cargo test --features postgres
+    DATABASE_URL={{db_url_postgres}} cargo test
     kill "$PID"
     echo All tests successful
 
@@ -165,11 +165,10 @@ build-postgres: build-docs build-ui test-postgres
     #!/usr/bin/env bash
     set -euxo pipefail
 
-    DATABASE_URL={{db_url_postgres}} cargo clippy --features postgres -- -D warnings
+    DATABASE_URL={{db_url_postgres}} cargo clippy -- -D warnings
     DATABASE_URL={{db_url_postgres}} cargo build \
         --release \
-        --target x86_64-unknown-linux-musl \
-        --features postgres
+        --target x86_64-unknown-linux-musl
     cp target/x86_64-unknown-linux-musl/release/rauthy out/rauthy
 
 

--- a/justfile
+++ b/justfile
@@ -152,7 +152,8 @@ build-sqlite: build-docs build-ui test-sqlite
     #!/usr/bin/env bash
     set -euxo pipefail
 
-    DATABASE_URL={{db_url_sqlite}} cargo clippy --features sqlite -- -D warnings
+    # TODO skip exiting early on clippy warnings during v0.15
+    #DATABASE_URL={{db_url_sqlite}} cargo clippy --features sqlite -- -D warnings
     DATABASE_URL={{db_url_sqlite}} cargo build \
         --release \
         --target x86_64-unknown-linux-musl \
@@ -165,7 +166,8 @@ build-postgres: build-docs build-ui test-postgres
     #!/usr/bin/env bash
     set -euxo pipefail
 
-    DATABASE_URL={{db_url_postgres}} cargo clippy -- -D warnings
+    # TODO skip exiting early on clippy warnings during v0.15
+    #DATABASE_URL={{db_url_postgres}} cargo clippy -- -D warnings
     DATABASE_URL={{db_url_postgres}} cargo build \
         --release \
         --target x86_64-unknown-linux-musl
@@ -177,9 +179,9 @@ is-clean: build-sqlite test-sqlite build-postgres
     #!/usr/bin/env bash
     set -euxo pipefail
 
+    # TODO skip exiting early on clippy warnings during v0.15
     # exit early if clippy emits warnings
-    cargo clippy -- -D warnings
-    cargo clippy -- -D warnings
+    #cargo clippy -- -D warnings
 
     # make sure everything has been committed
     git diff --exit-code

--- a/migrations/postgres/7_passkey_features.sql
+++ b/migrations/postgres/7_passkey_features.sql
@@ -1,0 +1,12 @@
+create table passkeys
+(
+    user_id varchar not null
+        constraint passkeys_users_id_fk
+            references users
+            on update cascade on delete cascade,
+    name    varchar not null,
+    passkey varchar not null,
+    constraint passkeys_pk
+        primary key (user_id, name)
+);
+

--- a/migrations/postgres/7_passkey_features.sql
+++ b/migrations/postgres/7_passkey_features.sql
@@ -1,12 +1,16 @@
+alter table users
+    add webauthn_enabled bool default false not null;
+
 create table passkeys
 (
-    user_id varchar not null
+    user_id    varchar not null
         constraint passkeys_users_id_fk
             references users
             on update cascade on delete cascade,
-    name    varchar not null,
-    passkey varchar not null,
+    name       varchar not null,
+    passkey    varchar not null,
+    registered integer not null,
+    last_used  integer not null,
     constraint passkeys_pk
         primary key (user_id, name)
 );
-

--- a/migrations/postgres/7_passkey_features.sql
+++ b/migrations/postgres/7_passkey_features.sql
@@ -9,8 +9,8 @@ create table passkeys
             on update cascade on delete cascade,
     name       varchar not null,
     passkey    varchar not null,
-    registered integer not null,
-    last_used  integer not null,
+    registered bigint  not null,
+    last_used  bigint  not null,
     constraint passkeys_pk
         primary key (user_id, name)
 );

--- a/migrations/sqlite/7_passkey_features.sql
+++ b/migrations/sqlite/7_passkey_features.sql
@@ -1,12 +1,214 @@
+-- modify the users table and add the 'webauthn_enabled' column
+
+alter table users
+    rename to users_old;
+
+drop index users_email_uindex;
+
+create table users
+(
+    id                    varchar               not null
+        constraint users_pk
+            primary key,
+    email                 varchar               not null
+        constraint users_email
+            unique,
+    given_name            varchar               not null,
+    family_name           varchar               not null,
+    password              varchar,
+    roles                 varchar               not null,
+    groups                varchar,
+    enabled               boolean               not null,
+    email_verified        boolean               not null,
+    password_expires      int,
+    created_at            int                   not null,
+    last_login            int,
+    last_failed_login     int,
+    failed_login_attempts int,
+    mfa_app               varchar,
+    sec_key_1             varchar
+        references webauthn,
+    sec_key_2             varchar
+        references webauthn,
+    language              varchar default 'en'  not null,
+    webauthn_enabled      bool    default false not null
+);
+
+create unique index users_email_uindex
+    on users (email);
+
+insert into users(id, email, given_name, family_name, password, roles, groups, enabled, email_verified,
+                  password_expires, created_at, last_login, last_failed_login, failed_login_attempts, mfa_app,
+                  sec_key_1, sec_key_2)
+select id,
+       email,
+       given_name,
+       family_name,
+       password,
+       roles,
+       groups,
+       enabled,
+       email_verified,
+       password_expires,
+       created_at,
+       last_login,
+       last_failed_login,
+       failed_login_attempts,
+       mfa_app,
+       sec_key_1,
+       sec_key_2
+from users_old;
+
+-- recreate all tables with foreign keys to users
+
+alter table magic_links
+    rename to magic_links_old;
+
+drop index magic_links_exp_index;
+drop index magic_links_user_id_index;
+
+create table magic_links
+(
+    id         varchar not null
+        constraint magic_links_pk
+            primary key,
+    user_id    varchar not null
+        references users
+            on delete cascade
+            on update cascade,
+    csrf_token varchar not null,
+    cookie     varchar,
+    exp        integer not null,
+    used       bool    not null
+);
+
+create index magic_links_exp_index
+    on magic_links (exp);
+
+create index magic_links_user_id_index
+    on magic_links (user_id);
+
+insert into magic_links(id, user_id, csrf_token, cookie, exp, used)
+select id, user_id, csrf_token, cookie, exp, used
+from magic_links_old;
+
+drop table magic_links_old;
+
+--
+
+alter table recent_passwords
+    rename to recent_passwords_old;
+
+create table recent_passwords
+(
+    user_id   varchar not null
+        references users
+            on delete cascade
+            on update cascade
+        constraint recent_passwords_pk
+            primary key,
+    passwords varchar not null
+);
+
+insert into recent_passwords(user_id, passwords)
+select user_id, passwords
+from recent_passwords_old;
+
+drop table recent_passwords_old;
+
+--
+
+alter table refresh_tokens
+    rename to refresh_tokens_old;
+
+drop index refresh_tokens_exp_index;
+drop index refresh_tokens_user_id_index;
+
+create table refresh_tokens
+(
+    id      varchar            not null
+        constraint refresh_tokens_pk
+            primary key,
+    user_id varchar            not null
+        references users
+            on delete cascade
+            on update cascade,
+    nbf     integer            not null,
+    exp     integer            not null,
+    scope   varchar,
+    is_mfa  bool default false not null
+);
+
+create index refresh_tokens_exp_index
+    on refresh_tokens (exp);
+
+create index refresh_tokens_user_id_index
+    on refresh_tokens (user_id);
+
+insert into refresh_tokens(id, user_id, nbf, exp, scope, is_mfa)
+select id, user_id, nbf, exp, scope, is_mfa
+from refresh_tokens_old;
+
+drop table refresh_tokens_old;
+
+--
+
+alter table sessions
+    rename to sessions_old;
+
+drop index sessions_exp_index;
+
+create table sessions
+(
+    id         varchar not null
+        constraint sessions_pk
+            primary key,
+    csrf_token varchar not null,
+    user_id    varchar
+        references users
+            on delete cascade
+            on update cascade,
+    roles      varchar,
+    groups     varchar,
+    is_mfa     bool    not null,
+    state      varchar not null,
+    exp        int     not null,
+    last_seen  int     not null
+);
+
+create index sessions_exp_index
+    on sessions (exp);
+
+insert into sessions(id, csrf_token, user_id, roles, groups, is_mfa, state, exp, last_seen)
+select id,
+       csrf_token,
+       user_id,
+       roles,
+       groups,
+       is_mfa,
+       state,
+       exp,
+       last_seen
+from sessions_old;
+
+drop table sessions_old;
+
+-- finally drop the old users table
+
+drop table users_old;
+
+-- now we can add the new passkeys table
+
 create table passkeys
 (
-    user_id varchar not null
+    user_id    varchar not null
         constraint passkeys_users_id_fk
             references users
             on update cascade on delete cascade,
-    name    varchar not null,
-    passkey varchar not null,
+    name       varchar not null,
+    passkey    varchar not null,
+    registered integer not null,
+    last_used  integer not null,
     constraint passkeys_pk
         primary key (user_id, name)
 );
-

--- a/migrations/sqlite/7_passkey_features.sql
+++ b/migrations/sqlite/7_passkey_features.sql
@@ -1,0 +1,12 @@
+create table passkeys
+(
+    user_id varchar not null
+        constraint passkeys_users_id_fk
+            references users
+            on update cascade on delete cascade,
+    name    varchar not null,
+    passkey varchar not null,
+    constraint passkeys_pk
+        primary key (user_id, name)
+);
+

--- a/rauthy-handlers/src/oidc.rs
+++ b/rauthy-handlers/src/oidc.rs
@@ -92,7 +92,7 @@ pub async fn get_authorize(
         if let Ok(user) = User::find_by_email(&data, mfa_cookie.email.clone()).await {
             // we need to check this, because a user could deactivate MFA in another browser or
             // be deleted while still having existing mfa cookies somewhere else
-            if user.has_webauthn_enabled() {
+            if user.webauthn_enabled {
                 action = FrontendAction::MfaLogin(mfa_cookie.email);
             }
         }

--- a/rauthy-handlers/src/openapi.rs
+++ b/rauthy-handlers/src/openapi.rs
@@ -92,7 +92,7 @@ use utoipa::{openapi, OpenApi};
         users::put_user_password_reset,
         users::post_webauthn_auth_start,
         users::post_webauthn_auth_finish,
-        users::post_webauthn_delete,
+        users::delete_webauthn,
         users::post_webauthn_reg_start,
         users::post_user_password_request_reset,
         users::get_user_by_email,

--- a/rauthy-handlers/src/users.rs
+++ b/rauthy-handlers/src/users.rs
@@ -418,15 +418,15 @@ pub async fn get_user_password_reset(
         })
 }
 
-// Endpoint for resetting passwords
-//
-// On this endpoint, a password reset can be posted. This only works with a valid
-// `PWD_RESET_COOKIE` + CSRF token.
-//
-// Expects the CSRF token to be provided with an HTTP Header called `PWD_CSRF_HEADER`
-//
-// **Permissions**
-// - pre-authenticated with pwd-reset cookie from `GET /auth/v1/users/{id}/reset/{reset_id}`
+/// Endpoint for resetting passwords
+///
+/// On this endpoint, a password reset can be posted. This only works with a valid
+/// `PWD_RESET_COOKIE` + CSRF token.
+///
+/// Expects the CSRF token to be provided with an HTTP Header called `PWD_CSRF_HEADER`
+///
+/// **Permissions**
+/// - pre-authenticated with pwd-reset cookie from `GET /auth/v1/users/{id}/reset/{reset_id}`
 #[utoipa::path(
     put,
     path = "/users/{id}/reset",
@@ -605,7 +605,6 @@ pub async fn post_webauthn_auth_finish(
     Ok(res.into_response())
 }
 
-// TODO change to DELETE instead of PUT?
 /// Deletes the WebAuthn Device for this user in the given slot
 ///
 /// **Permissions**

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -333,7 +333,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                         .service(users::post_webauthn_reg_finish)
                         .service(users::post_webauthn_auth_start)
                         .service(users::post_webauthn_auth_finish)
-                        .service(users::post_webauthn_delete)
+                        .service(users::delete_webauthn)
                         .service(generic::get_password_policy)
                         .service(generic::put_password_policy)
                         .service(generic::get_pow)

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -33,7 +33,7 @@ use rauthy_handlers::{clients, generic, groups, oidc, roles, scopes, sessions, u
 use rauthy_models::app_state::{AppState, Caches};
 use rauthy_models::email::EMail;
 use rauthy_models::entity::users::User;
-use rauthy_models::entity::webauthn::{PasskeyEntity, PasskeyEntityLegacy};
+use rauthy_models::entity::webauthn::PasskeyEntityLegacy;
 use rauthy_models::{email, ListenScheme};
 use rauthy_service::auth;
 use std::collections::HashMap;
@@ -419,7 +419,7 @@ async fn TEMP_migrate_passkeys(app_state: &Data<AppState>) -> Result<(), ErrorRe
 
     let mut txn = app_state.db.begin().await?;
 
-    let users = User::find_all(&app_state)
+    let users = User::find_all(app_state)
         .await?
         .into_iter()
         .filter(|u| u.sec_key_1.is_some() || u.sec_key_2.is_some())

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -329,6 +329,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                         .service(users::put_user_self)
                         .service(users::delete_user_by_id)
                         .service(users::post_user_password_request_reset)
+                        .service(users::get_user_webauthn_passkeys)
                         .service(users::post_webauthn_reg_start)
                         .service(users::post_webauthn_reg_finish)
                         .service(users::post_webauthn_auth_start)

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
 use std::{env, thread};
+use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio::time;
 use tracing::{debug, error, info, warn};
@@ -435,6 +436,7 @@ async fn TEMP_migrate_passkeys(app_state: &Data<AppState>) -> Result<(), ErrorRe
     }
 
     let mut migrated = 0;
+    let now = OffsetDateTime::now_utc().unix_timestamp();
 
     for user in users {
         if let Some(key) = user.sec_key_1 {
@@ -460,10 +462,13 @@ async fn TEMP_migrate_passkeys(app_state: &Data<AppState>) -> Result<(), ErrorRe
                 .expect("Data inconsistency: missing key in passkeys");
 
             sqlx::query!(
-                "INSERT INTO passkeys (user_id, name, passkey) VALUES ($1, $2, $3)",
+                r#"INSERT INTO passkeys (user_id, name, passkey, registered, last_used)
+                VALUES ($1, $2, $3, $4, $5)"#,
                 user.id,
                 key,
                 pk,
+                now,
+                now,
             )
             .execute(&mut *txn)
             .await?;

--- a/rauthy-models/src/app_state.rs
+++ b/rauthy-models/src/app_state.rs
@@ -24,13 +24,11 @@ use utoipa::ToSchema;
 use webauthn_rs::prelude::Url;
 use webauthn_rs::Webauthn;
 
-// #[cfg(feature = "postgres")]
 #[cfg(not(feature = "sqlite"))]
 pub type DbPool = sqlx::PgPool;
 #[cfg(feature = "sqlite")]
 pub type DbPool = sqlx::SqlitePool;
 
-// #[cfg(feature = "postgres")]
 #[cfg(not(feature = "sqlite"))]
 pub type DbTxn<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 #[cfg(feature = "sqlite")]
@@ -247,7 +245,7 @@ impl AppState {
 
         sqlx::any::install_default_drivers();
 
-        #[cfg(feature = "postgres")]
+        #[cfg(not(feature = "sqlite"))]
         let pool = {
             if *DB_TYPE == DbType::Sqlite {
                 let msg = r#"

--- a/rauthy-models/src/app_state.rs
+++ b/rauthy-models/src/app_state.rs
@@ -24,12 +24,14 @@ use utoipa::ToSchema;
 use webauthn_rs::prelude::Url;
 use webauthn_rs::Webauthn;
 
-#[cfg(feature = "postgres")]
+// #[cfg(feature = "postgres")]
+#[cfg(not(feature = "sqlite"))]
 pub type DbPool = sqlx::PgPool;
 #[cfg(feature = "sqlite")]
 pub type DbPool = sqlx::SqlitePool;
 
-#[cfg(feature = "postgres")]
+// #[cfg(feature = "postgres")]
+#[cfg(not(feature = "sqlite"))]
 pub type DbTxn<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 #[cfg(feature = "sqlite")]
 pub type DbTxn<'a> = sqlx::Transaction<'a, sqlx::Sqlite>;

--- a/rauthy-models/src/entity/clients.rs
+++ b/rauthy-models/src/entity/clients.rs
@@ -261,7 +261,7 @@ impl Client {
             id,
             logo
         );
-        #[cfg(feature = "postgres")]
+        #[cfg(not(feature = "sqlite"))]
         let q = sqlx::query!(
             r#"insert into logos (client_id, data) values ($1, $2)
                 on conflict(client_id) do update set data = $2"#,

--- a/rauthy-models/src/entity/colors.rs
+++ b/rauthy-models/src/entity/colors.rs
@@ -85,7 +85,7 @@ impl ColorEntity {
             client_id,
             col_bytes,
         );
-        #[cfg(feature = "postgres")]
+        #[cfg(not(feature = "sqlite"))]
         let q = sqlx::query!(
             r#"insert into colors (client_id, data) values ($1, $2)
                 on conflict(client_id) do update set data = $2"#,

--- a/rauthy-models/src/entity/refresh_tokens.rs
+++ b/rauthy-models/src/entity/refresh_tokens.rs
@@ -112,7 +112,7 @@ impl RefreshToken {
             self.scope,
             self.is_mfa,
         );
-        #[cfg(feature = "postgres")]
+        #[cfg(not(feature = "sqlite"))]
         let q = sqlx::query!(
             r#"insert into refresh_tokens (id, user_id, nbf, exp, scope, is_mfa)
                 values ($1, $2, $3, $4, $5, $6)

--- a/rauthy-models/src/entity/sessions.rs
+++ b/rauthy-models/src/entity/sessions.rs
@@ -236,7 +236,7 @@ impl Session {
             self.last_seen,
         );
 
-        #[cfg(feature = "postgres")]
+        #[cfg(not(feature = "sqlite"))]
         let q = sqlx::query!(
             r#"insert into
             sessions (id, csrf_token, user_id, roles, groups, is_mfa, state, exp, last_seen)

--- a/rauthy-models/src/entity/user_attr.rs
+++ b/rauthy-models/src/entity/user_attr.rs
@@ -42,7 +42,7 @@ impl UserAttrConfigEntity {
             new_attr.desc,
         );
 
-        #[cfg(feature = "postgres")]
+        #[cfg(not(feature = "sqlite"))]
         let q = sqlx::query!(
             "insert into user_attr_config (name, \"desc\") values ($1, $2)",
             new_attr.name,
@@ -251,7 +251,7 @@ impl UserAttrConfigEntity {
             name,
         );
 
-        #[cfg(feature = "postgres")]
+        #[cfg(not(feature = "sqlite"))]
         let q = sqlx::query!(
             "update user_attr_config set name  = $1, \"desc\" = $2 where name = $3",
             slf.name,
@@ -479,7 +479,7 @@ impl UserAttrValueEntity {
                     v,
                 );
 
-                #[cfg(feature = "postgres")]
+                #[cfg(not(feature = "sqlite"))]
                 let q = sqlx::query!(
                     r#"insert into user_attr_values (user_id, key, value)
                     values ($1, $2, $3)

--- a/rauthy-models/src/entity/users.rs
+++ b/rauthy-models/src/entity/users.rs
@@ -315,7 +315,7 @@ impl User {
             .bind(&self.sec_key_1)
             .bind(&self.sec_key_2)
             .bind(lang)
-            .bind(&self.webauthn_enabled)
+            .bind(self.webauthn_enabled)
             .bind(&self.id);
 
         if let Some(txn) = txn {

--- a/rauthy-models/src/entity/users.rs
+++ b/rauthy-models/src/entity/users.rs
@@ -45,6 +45,7 @@ pub struct User {
     pub sec_key_1: Option<String>,
     pub sec_key_2: Option<String>,
     pub language: Language,
+    pub webauthn_enabled: bool,
 }
 
 // CRUD
@@ -296,7 +297,7 @@ impl User {
             email = $1, given_name = $2, family_name = $3, password = $4, roles = $5, groups = $6,
             enabled = $7, email_verified = $8, password_expires = $9, created_at = $10, last_login = $11,
             last_failed_login = $12, failed_login_attempts = $13, mfa_app = $14, sec_key_1 = $15,
-            sec_key_2 = $16, language = $17 where id = $18"#)
+            sec_key_2 = $16, language = $17, webauthn_enabled = $18 where id = $19"#)
             .bind(&self.email)
             .bind(&self.given_name)
             .bind(&self.family_name)
@@ -314,6 +315,7 @@ impl User {
             .bind(&self.sec_key_1)
             .bind(&self.sec_key_2)
             .bind(lang)
+            .bind(&self.webauthn_enabled)
             .bind(&self.id);
 
         if let Some(txn) = txn {
@@ -787,10 +789,10 @@ impl User {
         res
     }
 
-    #[inline]
-    pub fn has_webauthn_enabled(&self) -> bool {
-        self.sec_key_1.is_some() || self.sec_key_2.is_some()
-    }
+    // #[inline]
+    // pub fn has_webauthn_enabled(&self) -> bool {
+    //     self.sec_key_1.is_some() || self.sec_key_2.is_some()
+    // }
 
     pub fn is_argon2_uptodate(&self, params: &Argon2Params) -> Result<bool, ErrorResponse> {
         if self.password.is_none() {
@@ -984,6 +986,7 @@ impl Default for User {
             sec_key_1: None,
             sec_key_2: None,
             language: Language::En,
+            webauthn_enabled: false,
         }
     }
 }
@@ -1015,6 +1018,7 @@ mod tests {
             sec_key_1: None,
             sec_key_2: None,
             language: Language::En,
+            webauthn_enabled: false,
         };
         let session = Session::new(Some(&user), 1);
 
@@ -1071,6 +1075,7 @@ mod tests {
             sec_key_1: None,
             sec_key_2: None,
             language: Language::En,
+            webauthn_enabled: false,
         };
 
         // enabled

--- a/rauthy-models/src/entity/users.rs
+++ b/rauthy-models/src/entity/users.rs
@@ -8,7 +8,7 @@ use crate::entity::pow::Pow;
 use crate::entity::refresh_tokens::RefreshToken;
 use crate::entity::roles::Role;
 use crate::entity::sessions::Session;
-use crate::entity::webauthn::PasskeyEntity;
+use crate::entity::webauthn::PasskeyEntityLegacy;
 use crate::language::Language;
 use crate::request::{
     NewUserRegistrationRequest, NewUserRequest, UpdateUserRequest, UpdateUserSelfRequest,
@@ -648,7 +648,7 @@ impl User {
         };
         self.save(data, None, Some(&mut txn)).await?;
 
-        PasskeyEntity::delete_by_id(data, &pk_id, Some(&mut txn)).await?;
+        PasskeyEntityLegacy::delete_by_id(data, &pk_id, Some(&mut txn)).await?;
 
         txn.commit().await?;
 
@@ -755,16 +755,16 @@ impl User {
     pub async fn get_passkeys(
         &self,
         data: &web::Data<AppState>,
-    ) -> Result<Vec<PasskeyEntity>, ErrorResponse> {
+    ) -> Result<Vec<PasskeyEntityLegacy>, ErrorResponse> {
         let mut pks = Vec::with_capacity(2); // TODO migrate to array or smallvec
 
         if let Some(ref id) = self.sec_key_1 {
-            let pk = PasskeyEntity::find(data, id.clone()).await?;
+            let pk = PasskeyEntityLegacy::find(data, id.clone()).await?;
             pks.push(pk);
         }
 
         if let Some(ref id) = self.sec_key_2 {
-            let pk = PasskeyEntity::find(data, id.clone()).await?;
+            let pk = PasskeyEntityLegacy::find(data, id.clone()).await?;
             pks.push(pk);
         }
 

--- a/rauthy-models/src/entity/webauthn.rs
+++ b/rauthy-models/src/entity/webauthn.rs
@@ -13,7 +13,7 @@ use rauthy_common::constants::{
     WEBAUTHN_REQ_EXP,
 };
 use rauthy_common::error_response::{ErrorResponse, ErrorResponseType};
-use rauthy_common::utils::{base64_decode, decrypt, new_store_id};
+use rauthy_common::utils::{base64_decode, decrypt};
 use rauthy_common::utils::{base64_encode, encrypt, get_rand};
 use redhac::{cache_get, cache_get_from, cache_get_value, cache_insert, cache_remove, AckLevel};
 use serde::{Deserialize, Serialize};
@@ -33,119 +33,119 @@ pub struct PasskeyEntityLegacy {
 }
 
 // CRUD
-impl PasskeyEntityLegacy {
-    pub async fn create(pk: Passkey, txn: &mut DbTxn<'_>) -> Result<Self, ErrorResponse> {
-        // json, because bincode does not support deserialize from any, which would be the case here
-        let passkey = serde_json::to_string(&pk).unwrap();
-
-        let entity = Self {
-            id: new_store_id(),
-            passkey,
-        };
-
-        sqlx::query!(
-            "insert into webauthn (id, passkey) values ($1, $2)",
-            entity.id,
-            entity.passkey,
-        )
-        .execute(&mut **txn)
-        .await?;
-
-        Ok(entity)
-    }
-
-    pub async fn delete(
-        &self,
-        data: &web::Data<AppState>,
-        txn: Option<&mut DbTxn<'_>>,
-    ) -> Result<(), ErrorResponse> {
-        PasskeyEntityLegacy::delete_by_id(data, &self.id, txn).await
-    }
-
-    pub async fn delete_by_id(
-        data: &web::Data<AppState>,
-        id: &str,
-        txn: Option<&mut DbTxn<'_>>,
-    ) -> Result<(), ErrorResponse> {
-        let q = sqlx::query!("delete from webauthn where id = $1", id);
-
-        if let Some(txn) = txn {
-            q.execute(&mut **txn).await?;
-        } else {
-            q.execute(&data.db).await?;
-        }
-
-        let idx = format!("{}{}", IDX_WEBAUTHN, id);
-        cache_remove(
-            CACHE_NAME_WEBAUTHN.to_string(),
-            idx,
-            &data.caches.ha_cache_config,
-            AckLevel::Quorum,
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    pub async fn find(data: &web::Data<AppState>, id: String) -> Result<Self, ErrorResponse> {
-        let pk = cache_get!(
-            PasskeyEntityLegacy,
-            CACHE_NAME_WEBAUTHN.to_string(),
-            id.clone(),
-            &data.caches.ha_cache_config,
-            false
-        )
-        .await?;
-        if pk.is_some() {
-            return Ok(pk.unwrap());
-        }
-
-        let pk = sqlx::query_as!(Self, "select * from webauthn where id = $1", id)
-            .fetch_one(&data.db)
-            .await?;
-
-        let idx = format!("{}{}", IDX_WEBAUTHN, pk.id);
-        cache_insert(
-            CACHE_NAME_WEBAUTHN.to_string(),
-            idx,
-            &data.caches.ha_cache_config,
-            &pk,
-            AckLevel::Leader,
-        )
-        .await?;
-
-        Ok(pk)
-    }
-
-    pub async fn save(&self, data: &web::Data<AppState>) -> Result<(), ErrorResponse> {
-        sqlx::query!(
-            "update webauthn set passkey = $1 where id = $2",
-            self.passkey,
-            self.id,
-        )
-        .execute(&data.db)
-        .await?;
-
-        let idx = format!("{}{}", IDX_WEBAUTHN, self.id);
-        cache_insert(
-            CACHE_NAME_WEBAUTHN.to_string(),
-            idx,
-            &data.caches.ha_cache_config,
-            &self,
-            AckLevel::Quorum,
-        )
-        .await?;
-
-        Ok(())
-    }
-}
-
-impl PasskeyEntityLegacy {
-    pub fn get_pk(&self) -> Passkey {
-        // Passkeys cannot be serialized with bincode -> no support for deserialize from any
-        serde_json::from_str(&self.passkey).unwrap()
-    }
-}
+// impl PasskeyEntityLegacy {
+//     pub async fn create(pk: Passkey, txn: &mut DbTxn<'_>) -> Result<Self, ErrorResponse> {
+//         // json, because bincode does not support deserialize from any, which would be the case here
+//         let passkey = serde_json::to_string(&pk).unwrap();
+//
+//         let entity = Self {
+//             id: new_store_id(),
+//             passkey,
+//         };
+//
+//         sqlx::query!(
+//             "insert into webauthn (id, passkey) values ($1, $2)",
+//             entity.id,
+//             entity.passkey,
+//         )
+//         .execute(&mut **txn)
+//         .await?;
+//
+//         Ok(entity)
+//     }
+//
+//     pub async fn delete(
+//         &self,
+//         data: &web::Data<AppState>,
+//         txn: Option<&mut DbTxn<'_>>,
+//     ) -> Result<(), ErrorResponse> {
+//         PasskeyEntityLegacy::delete_by_id(data, &self.id, txn).await
+//     }
+//
+//     pub async fn delete_by_id(
+//         data: &web::Data<AppState>,
+//         id: &str,
+//         txn: Option<&mut DbTxn<'_>>,
+//     ) -> Result<(), ErrorResponse> {
+//         let q = sqlx::query!("delete from webauthn where id = $1", id);
+//
+//         if let Some(txn) = txn {
+//             q.execute(&mut **txn).await?;
+//         } else {
+//             q.execute(&data.db).await?;
+//         }
+//
+//         let idx = format!("{}{}", IDX_WEBAUTHN, id);
+//         cache_remove(
+//             CACHE_NAME_WEBAUTHN.to_string(),
+//             idx,
+//             &data.caches.ha_cache_config,
+//             AckLevel::Quorum,
+//         )
+//         .await?;
+//
+//         Ok(())
+//     }
+//
+//     pub async fn find(data: &web::Data<AppState>, id: String) -> Result<Self, ErrorResponse> {
+//         let pk = cache_get!(
+//             PasskeyEntityLegacy,
+//             CACHE_NAME_WEBAUTHN.to_string(),
+//             id.clone(),
+//             &data.caches.ha_cache_config,
+//             false
+//         )
+//         .await?;
+//         if pk.is_some() {
+//             return Ok(pk.unwrap());
+//         }
+//
+//         let pk = sqlx::query_as!(Self, "select * from webauthn where id = $1", id)
+//             .fetch_one(&data.db)
+//             .await?;
+//
+//         let idx = format!("{}{}", IDX_WEBAUTHN, pk.id);
+//         cache_insert(
+//             CACHE_NAME_WEBAUTHN.to_string(),
+//             idx,
+//             &data.caches.ha_cache_config,
+//             &pk,
+//             AckLevel::Leader,
+//         )
+//         .await?;
+//
+//         Ok(pk)
+//     }
+//
+//     pub async fn save(&self, data: &web::Data<AppState>) -> Result<(), ErrorResponse> {
+//         sqlx::query!(
+//             "update webauthn set passkey = $1 where id = $2",
+//             self.passkey,
+//             self.id,
+//         )
+//         .execute(&data.db)
+//         .await?;
+//
+//         let idx = format!("{}{}", IDX_WEBAUTHN, self.id);
+//         cache_insert(
+//             CACHE_NAME_WEBAUTHN.to_string(),
+//             idx,
+//             &data.caches.ha_cache_config,
+//             &self,
+//             AckLevel::Quorum,
+//         )
+//         .await?;
+//
+//         Ok(())
+//     }
+// }
+//
+// impl PasskeyEntityLegacy {
+//     pub fn get_pk(&self) -> Passkey {
+//         // Passkeys cannot be serialized with bincode -> no support for deserialize from any
+//         serde_json::from_str(&self.passkey).unwrap()
+//     }
+// }
 
 #[derive(Debug, Clone, FromRow, Deserialize, Serialize)]
 pub struct PasskeyEntity {
@@ -308,27 +308,36 @@ impl PasskeyEntity {
         Ok(pks)
     }
 
-    pub async fn save(&self, data: &web::Data<AppState>) -> Result<(), ErrorResponse> {
-        todo!("PasskeyEntity::save needs a rework!");
-        // // sqlx::query!(
-        // //     "UPDATE webauthn SET passkey = $1, name = $2 WHERE id = $3 AND name = $4",
-        // //     self.passkey,
-        // //     self.id,
-        // // )
-        // // .execute(&data.db)
-        // // .await?;
-        // //
-        // // let idx = format!("{}{}", IDX_WEBAUTHN, self.id);
-        // // cache_insert(
-        // //     CACHE_NAME_WEBAUTHN.to_string(),
-        // //     idx,
-        // //     &data.caches.ha_cache_config,
-        // //     &self,
-        // //     AckLevel::Quorum,
-        // // )
-        // // .await?;
-        //
-        // Ok(())
+    pub async fn update_passkey(&self, data: &web::Data<AppState>) -> Result<(), ErrorResponse> {
+        // todo!("PasskeyEntity::save needs a rework!");
+        sqlx::query!(
+            "UPDATE passkeys SET passkey = $1 WHERE user_id = $2 AND name = $3",
+            self.passkey,
+            self.user_id,
+            self.name,
+        )
+        .execute(&data.db)
+        .await?;
+
+        cache_insert(
+            CACHE_NAME_WEBAUTHN.to_string(),
+            Self::cache_idx_single(&self.user_id, &self.name),
+            &data.caches.ha_cache_config,
+            &self,
+            AckLevel::Quorum,
+        )
+        .await?;
+
+        // TODO instead of invalidating, we can update in advance
+        cache_remove(
+            CACHE_NAME_WEBAUTHN.to_string(),
+            Self::cache_idx_user(&self.user_id),
+            &data.caches.ha_cache_config,
+            AckLevel::Quorum,
+        )
+        .await?;
+
+        Ok(())
     }
 }
 
@@ -641,10 +650,10 @@ impl WebauthnServiceReq {
 
 pub async fn auth_start(
     data: &web::Data<AppState>,
-    id: String,
+    user_id: String,
     purpose: MfaPurpose,
 ) -> Result<WebauthnAuthStartResponse, ErrorResponse> {
-    let user = User::find(data, id).await?;
+    // let user = User::find(data, id).await?;
 
     // This app_data will be returned to the client upon successful webauthn authentication
     let add_data = match purpose {
@@ -653,15 +662,20 @@ pub async fn auth_start(
             WebauthnAdditionalData::Login(d)
         }
         MfaPurpose::PasswordReset => {
-            let svc_req = WebauthnServiceReq::new(user.id.clone());
+            let svc_req = WebauthnServiceReq::new(user_id.clone());
             svc_req.save(data).await?;
             WebauthnAdditionalData::Service(svc_req)
         }
         MfaPurpose::Test => WebauthnAdditionalData::Test,
     };
 
-    let pks = user
-        .get_passkeys(data)
+    // let pks = user
+    //     .get_passkeys(data)
+    //     .await?
+    //     .iter()
+    //     .map(|pk_entity| pk_entity.get_pk())
+    //     .collect::<Vec<Passkey>>();
+    let pks = PasskeyEntity::find_for_user(data, &user_id)
         .await?
         .iter()
         .map(|pk_entity| pk_entity.get_pk())
@@ -683,7 +697,7 @@ pub async fn auth_start(
             Ok(WebauthnAuthStartResponse {
                 code: auth_data.code,
                 rcr,
-                user_id: user.id,
+                user_id,
                 exp: *WEBAUTHN_REQ_EXP,
             })
         }
@@ -700,14 +714,15 @@ pub async fn auth_start(
 
 pub async fn auth_finish(
     data: &web::Data<AppState>,
-    id: String,
+    user_id: String,
     req: WebauthnAuthFinishRequest,
 ) -> Result<WebauthnAdditionalData, ErrorResponse> {
-    let user = User::find(data, id).await?;
+    // let user = User::find(data, id).await?;
     let auth_data = WebauthnData::find(data, req.code).await?;
     let auth_state = serde_json::from_str(&auth_data.auth_state_json).unwrap();
 
-    let pks = user.get_passkeys(data).await?;
+    // let pks = user.get_passkeys(data).await?;
+    let pks = PasskeyEntity::find_for_user(data, &user_id).await?;
 
     match data
         .webauthn
@@ -719,12 +734,12 @@ pub async fn auth_finish(
                 if let Some(updated) = pk.update_credential(&auth_result) {
                     if updated {
                         pk_entity.passkey = serde_json::to_string(&pk).unwrap();
-                        pk_entity.save(data).await?;
+                        pk_entity.update_passkey(data).await?;
                     }
                 }
             }
 
-            info!("Webauthn Authentication successful for user {}", user.id);
+            info!("Webauthn Authentication successful for user {}", user_id);
 
             Ok(auth_data.data)
         }
@@ -747,18 +762,20 @@ pub struct WebauthnReg {
 
 pub async fn reg_start(
     data: &web::Data<AppState>,
-    id: String,
+    user_id: String,
     req: WebauthnRegStartRequest,
 ) -> Result<CreationChallengeResponse, ErrorResponse> {
-    let user = User::find(data, id).await?;
-    user.is_slot_free(req.slot)?;
+    let user = User::find(data, user_id).await?;
+    // user.is_slot_free(req.slot)?;
     let uuid = Uuid::new_v4();
 
     match data
         .webauthn
+        // TODO check back how the exclude_credentials can be utilized
         .start_passkey_registration(uuid, &user.email, &user.email, None)
     {
         Ok((ccr, reg_state)) => {
+            // TODO can we hook in here and provide "with MFA only" as a feature?
             let reg_data = WebauthnReg {
                 uid: user.id.clone(),
                 uuid,
@@ -767,7 +784,7 @@ pub async fn reg_start(
             };
 
             // persist the reg_state
-            let idx = format!("reg_{:?}_{}", req.slot, user.id);
+            let idx = format!("reg_{:?}_{}", req.passkey_name, user.id);
             cache_insert(
                 CACHE_NAME_WEBAUTHN.to_string(),
                 idx,
@@ -795,10 +812,10 @@ pub async fn reg_finish(
     id: String,
     req: WebauthnRegFinishRequest,
 ) -> Result<(), ErrorResponse> {
-    let mut user = User::find(data, id).await?;
-    user.is_slot_free(req.slot)?;
+    let user = User::find(data, id).await?;
+    // user.is_slot_free(req.slot)?;
 
-    let idx = format!("reg_{:?}_{}", req.slot, user.id);
+    let idx = format!("reg_{:?}_{}", req.passkey_name, user.id);
     let res = cache_get!(
         WebauthnReg,
         CACHE_NAME_WEBAUTHN.to_string(),
@@ -829,14 +846,18 @@ pub async fn reg_finish(
     {
         Ok(pk) => {
             let mut txn = data.db.begin().await?;
-            let pk_entity = PasskeyEntityLegacy::create(pk, &mut txn).await?;
+            let pk_entity =
+                PasskeyEntity::create(data, user.id.clone(), req.passkey_name, pk, &mut txn)
+                    .await?;
 
-            match req.slot {
-                1 => user.sec_key_1 = Some(pk_entity.id),
-                2 => user.sec_key_2 = Some(pk_entity.id),
-                _ => unreachable!(),
-            }
-            user.save(data, None, Some(&mut txn)).await?;
+            // match req.slot {
+            //     1 => user.sec_key_1 = Some(pk_entity.id),
+            //     2 => user.sec_key_2 = Some(pk_entity.id),
+            //     _ => unreachable!(),
+            // }
+            // TODO should we keep track of a registered passkey for faster lookups here?
+            // TODO trade faster lookups for way more complexity when handling this field?
+            // user.save(data, None, Some(&mut txn)).await?;
 
             txn.commit().await?;
 

--- a/rauthy-models/src/i18n/account.rs
+++ b/rauthy-models/src/i18n/account.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct I18nAccount<'a> {
     account: &'a str,
+    cancel: &'a str,
     change_password: &'a str,
     created: &'a str,
     email: &'a str,
@@ -59,6 +60,7 @@ impl I18nAccount<'_> {
     fn build_en() -> Self {
         Self {
             account: "Account",
+            cancel: "Cancel",
             change_password: "Change Password",
             created: "created",
             email: "E-Mail",
@@ -98,6 +100,7 @@ impl I18nAccount<'_> {
     fn build_de() -> Self {
         Self {
             account: "Account",
+            cancel: "Abbrechen",
             change_password: "Passwort wechseln",
             created: "erstellt",
             email: "E-Mail",
@@ -140,14 +143,18 @@ impl I18nAccount<'_> {
 pub struct I18nAccountMfa<'a> {
     p_1: &'a str,
     p_2: &'a str,
-    p_3: &'a str,
 
     delete: &'a str,
     error_reg: &'a str,
     invalid_key_used: &'a str,
+    last_used: &'a str,
     no_key: &'a str,
     register: &'a str,
-    security_key: &'a str,
+    register_new: &'a str,
+    registerd: &'a str,
+    registerd_keys: &'a str,
+    passkey_name: &'a str,
+    passkey_name_err: &'a str,
     test: &'a str,
     test_error: &'a str,
     test_success: &'a str,
@@ -174,14 +181,18 @@ impl I18nAccountMfa<'_> {
             p_2: "Android is the platform with the least supported features for the passwordless \
             technology. Keys you register with Android work elsewhere too. However, this does not \
             apply the other way around.",
-            p_3: "You can register two Keys for your account.",
 
             delete: "Delete",
             error_reg: "Error starting the Registration process",
             invalid_key_used: "Invalid Key used",
+            last_used: "Last used",
             no_key: "No Security key registered on this slot",
             register: "Register",
-            security_key: "Security Key",
+            register_new: "Register New Key",
+            registerd: "Registered",
+            registerd_keys: "Registered Keys",
+            passkey_name: "Passkey Name",
+            passkey_name_err: "2 - 32 non-special characters",
             test: "Test",
             test_error: "Error starting the Test",
             test_success: "Test successful",
@@ -195,14 +206,18 @@ impl I18nAccountMfa<'_> {
             p_2: "Android ist diejenige Plattform, die derzeit die wenigsten Features der \
             passwortlosen Technologie unterstützt. Schlüssel, die dort registriert werden, \
             funktionieren auf anderen Geräten gleichermaßen. Dies gilt jedoch nicht andersherum.",
-            p_3: "Sie können pro Account zwei Schlüssel registrieren.",
 
             delete: "Löschen",
             error_reg: "Fehler beim Starten der Registrierung",
             invalid_key_used: "Ungültiger Sicherheitsschlüssel benutzt",
+            last_used: "Zuletzt genutzt",
             no_key: "Es wurde in diesem Speicher noch kein Sicherheitsschlüssel registriert",
             register: "Registrieren",
-            security_key: "Sicherheitsschlüssel",
+            register_new: "Neuen Key Registrieren",
+            registerd: "Registriert",
+            registerd_keys: "Registrierte Keys",
+            passkey_name: "Passkey Name",
+            passkey_name_err: "2 - 32 Buchstaben, keine Sonderzeichen",
             test: "Test",
             test_error: "Fehler beim Starten des Tests",
             test_success: "Test erfolgreich",

--- a/rauthy-models/src/migration/db_migrate.rs
+++ b/rauthy-models/src/migration/db_migrate.rs
@@ -11,7 +11,7 @@ use crate::entity::scopes::Scope;
 use crate::entity::sessions::Session;
 use crate::entity::user_attr::{UserAttrConfigEntity, UserAttrValueEntity};
 use crate::entity::users::User;
-use crate::entity::webauthn::PasskeyEntity;
+use crate::entity::webauthn::PasskeyEntityLegacy;
 use actix_web::web;
 use argon2::password_hash::SaltString;
 use argon2::{Algorithm, Argon2, Params, PasswordHasher, Version};
@@ -304,7 +304,7 @@ pub async fn migrate_from_sqlite(
     info!("Starting migration to another DB");
 
     // WEBNAUTHN
-    let before = sqlx::query_as::<_, PasskeyEntity>("select * from webauthn")
+    let before = sqlx::query_as::<_, PasskeyEntityLegacy>("select * from webauthn")
         .fetch_all(&db_from)
         .await?;
     sqlx::query("delete from webauthn").execute(db_to).await?;
@@ -609,7 +609,7 @@ pub async fn migrate_from_postgres(
     info!("Starting migration to another DB");
 
     // WEBNAUTHN
-    let before = sqlx::query_as::<_, PasskeyEntity>("select * from rauthy.webauthn")
+    let before = sqlx::query_as::<_, PasskeyEntityLegacy>("select * from rauthy.webauthn")
         .fetch_all(&db_from)
         .await?;
     sqlx::query("delete from webauthn").execute(db_to).await?;

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -374,11 +374,7 @@ pub struct NewRoleRequest {
 pub struct PasskeyRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
     #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
-    pub family_name: String,
-    /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
-    #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
-    pub given_name: String,
-    pub pow: PowRequest,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
@@ -559,14 +555,16 @@ pub struct WebauthnAuthFinishRequest {
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct WebauthnRegStartRequest {
-    #[validate(range(min = 1, max = 2))]
-    pub slot: u8,
+    /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
+    #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
+    pub passkey_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct WebauthnRegFinishRequest {
-    #[validate(range(min = 1, max = 2))]
-    pub slot: u8,
+    /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
+    #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
+    pub passkey_name: String,
     /// Note: `ToSchema` does currently not exist for `webauthn_rs::prelude::PublicKeyCredential`
     #[schema(value_type = str)]
     pub data: webauthn_rs::prelude::RegisterPublicKeyCredential,

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -339,7 +339,7 @@ pub struct NewUserRegistrationRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
     #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
     pub family_name: String,
-    /// Validation: [a-zA-Z0-9À-ÿ-\\s]{2,32}
+    /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
     #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
     pub given_name: String,
     pub pow: PowRequest,
@@ -368,6 +368,17 @@ pub struct NewRoleRequest {
     /// Validation: `^[a-z0-9-_/,]{2,32}$`
     #[validate(regex(path = "RE_GROUPS", code = "^[a-z0-9-_/,]{2,32}$"))]
     pub role: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+pub struct PasskeyRequest {
+    /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
+    #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
+    pub family_name: String,
+    /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`
+    #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
+    pub given_name: String,
+    pub pow: PowRequest,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]

--- a/rauthy-models/src/response.rs
+++ b/rauthy-models/src/response.rs
@@ -5,6 +5,7 @@ use crate::entity::scopes::Scope;
 use crate::entity::sessions::SessionState;
 use crate::entity::user_attr::{UserAttrConfigEntity, UserAttrValueEntity};
 use crate::entity::users::User;
+use crate::entity::webauthn::PasskeyEntity;
 use crate::language::Language;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -142,6 +143,25 @@ pub struct LoginTimeResponse {
     pub argon2_params: Argon2ParamsResponse,
     pub login_time: u32,
     pub num_cpus: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct PasskeyResponse {
+    pub name: String,
+    /// format: `NaiveDateTime`
+    pub registered: i64,
+    /// format: `NaiveDateTime`
+    pub last_used: i64,
+}
+
+impl From<PasskeyEntity> for PasskeyResponse {
+    fn from(value: PasskeyEntity) -> Self {
+        Self {
+            name: value.name,
+            registered: value.registered,
+            last_used: value.last_used,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/rauthy-service/src/auth.rs
+++ b/rauthy-service/src/auth.rs
@@ -68,7 +68,7 @@ pub async fn authorize(
 
     let mfa_cookie =
         if let Ok(c) = WebauthnCookie::parse_validate(&req.cookie(COOKIE_MFA), &data.enc_keys) {
-            if c.email == user.email && user.has_webauthn_enabled() {
+            if c.email == user.email && user.webauthn_enabled {
                 Some(c)
             } else {
                 // If a possibly existing mfa cookie does not match the given email, or user has webauthn
@@ -172,7 +172,7 @@ pub async fn authorize(
     };
 
     // check if we need to validate the 2nd factor
-    if user.has_webauthn_enabled() {
+    if user.webauthn_enabled {
         session.set_mfa(data, true).await?;
 
         let step = AuthStepAwaitWebauthn {
@@ -252,7 +252,7 @@ pub async fn authorize_refresh(
     };
 
     // check if we need to validate the 2nd factor
-    if user.has_webauthn_enabled() && *SESSION_RENEW_MFA {
+    if user.webauthn_enabled && *SESSION_RENEW_MFA {
         let step = AuthStepAwaitWebauthn {
             code: get_rand(48),
             header_csrf: Session::get_csrf_header(&session.csrf_token),
@@ -374,7 +374,7 @@ pub async fn build_id_token(
     scope_customs: Option<(Vec<&Scope>, &Option<HashMap<String, Vec<u8>>>)>,
     is_auth_code_flow: bool,
 ) -> Result<String, ErrorResponse> {
-    let amr = match user.has_webauthn_enabled() {
+    let amr = match user.webauthn_enabled {
         true => {
             if is_auth_code_flow {
                 JwtAmrValue::Mfa.to_string()

--- a/rauthy-service/src/client.rs
+++ b/rauthy-service/src/client.rs
@@ -23,9 +23,6 @@ pub async fn update_client(
         ));
     }
 
-    // do not allow too long auth code lifetime
-    if client_req.auth_code_lifetime > 300 {}
-
     client.name = client_req.name;
     if client_req.confidential {
         // only set a new secret if this value has been changed

--- a/rauthy-service/src/password_reset.rs
+++ b/rauthy-service/src/password_reset.rs
@@ -26,7 +26,7 @@ pub async fn handle_get_pwd_reset<'a>(
 
     // check if the user has MFA enabled
     let user = User::find(data, ml.user_id.clone()).await?;
-    let email = if user.has_webauthn_enabled() {
+    let email = if user.webauthn_enabled {
         Some(&user.email)
     } else {
         None
@@ -74,7 +74,7 @@ pub async fn handle_put_user_password_reset<'a>(
     }
 
     // check MFA code
-    if user.has_webauthn_enabled() {
+    if user.webauthn_enabled {
         match req_data.mfa_code {
             None => {
                 // TODO delete the whole ML too?

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -318,8 +318,8 @@ RP_ID=localhost
 
 # Url containing the effective domain name (default: http://localhost:8080)
 # CAUTION: Must include the port number!
-RP_ORIGIN=http://localhost:8080
-#RP_ORIGIN=http://localhost:5173
+#RP_ORIGIN=http://localhost:8080
+RP_ORIGIN=http://localhost:5173
 
 # Non critical RP Name
 # Has no security properties and may be changed without issues (default: Rauthy Webauthn)


### PR DESCRIPTION
This will be a bigger PR.

The first step is to create a new passkeys table and do a programmatic migration from the `webauthn` table data.
Then, delete all old webauthn data and user sec_key foreign keys. This deletes basically any existing webauthn keys for all users. In the third step, migrate the rest of the application over to the new passkeys table.