### PR TITLE
Construct issuer correctly when https only serving is enabled

### DIFF
--- a/rauthy-models/src/app_state.rs
+++ b/rauthy-models/src/app_state.rs
@@ -136,7 +136,7 @@ impl AppState {
             panic!("ENC_KEY_ACTIVE not found in ENC_KEYS");
         }
 
-        let issuer_scheme = if listen_scheme == ListenScheme::HttpHttps || *PROXY_MODE {
+        let issuer_scheme = if matches!(listen_scheme, ListenScheme::HttpHttps | ListenScheme::Https) || *PROXY_MODE {
             "https"
         } else {
             "http"


### PR DESCRIPTION
When `LISTEN_SCHEME` is set to `https` the issuer URL is constructed using "http://" prefix, which doesn't seem right.