### PR TITLE
Make sure to strip binary when doing a release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ panic = "abort"
 [profile.release]
 codegen-units = 1
 lto = true
+strip = true
 panic = "abort"
 
 [workspace.dependencies]


### PR DESCRIPTION
That saves around 20% of the binary size in my case (55MiB → 44MiB)