### PR TITLE
Move WellKnown into entity

### DIFF
--- a/rauthy-handlers/src/openapi.rs
+++ b/rauthy-handlers/src/openapi.rs
@@ -4,7 +4,7 @@ use crate::{
 use actix_web::web;
 use rauthy_common::constants::{PROXY_MODE, RAUTHY_VERSION};
 use rauthy_common::error_response::{ErrorResponse, ErrorResponseType};
-use rauthy_models::app_state::{AppState, WellKnown};
+use rauthy_models::app_state::AppState;
 use rauthy_models::events::event;
 use rauthy_models::language;
 use rauthy_models::ListenScheme;
@@ -137,6 +137,7 @@ use utoipa::{openapi, OpenApi};
             entity::webauthn::WebauthnAdditionalData,
             entity::webauthn::WebauthnLoginReq,
             entity::webauthn::WebauthnServiceReq,
+            entity::well_known::WellKnown,
 
             event::EventLevel,
             ErrorResponse,
@@ -205,8 +206,6 @@ use utoipa::{openapi, OpenApi};
 
             rauthy_models::JktClaim,
             token_set::TokenSet,
-
-            WellKnown,
         ),
     ),
     tags(

--- a/rauthy-main/tests/handler_generic.rs
+++ b/rauthy-main/tests/handler_generic.rs
@@ -1,6 +1,6 @@
 use crate::common::{get_backend_url, get_issuer};
 use pretty_assertions::assert_eq;
-use rauthy_models::app_state::WellKnown;
+use rauthy_models::entity::well_known::WellKnown;
 use std::error::Error;
 
 mod common;

--- a/rauthy-models/src/entity/mod.rs
+++ b/rauthy-models/src/entity/mod.rs
@@ -23,6 +23,7 @@ pub mod sessions;
 pub mod user_attr;
 pub mod users;
 pub mod webauthn;
+pub mod well_known;
 
 pub async fn is_db_alive(db: &DbPool) -> bool {
     query("SELECT 1").execute(db).await.is_ok()

--- a/rauthy-models/src/entity/well_known.rs
+++ b/rauthy-models/src/entity/well_known.rs
@@ -1,0 +1,154 @@
+use crate::app_state::AppState;
+use crate::entity::scopes::Scope;
+use actix_web::web;
+use rauthy_common::constants::CACHE_NAME_12HR;
+use rauthy_common::error_response::ErrorResponse;
+use redhac::{cache_get, cache_get_from, cache_get_value, cache_put};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// The struct for the `.well-known` endpoint for automatic OIDC discovery
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+pub struct WellKnown {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub introspection_endpoint: String,
+    pub userinfo_endpoint: String,
+    pub end_session_endpoint: String,
+    pub jwks_uri: String,
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub registration_endpoint: Option<String>,
+    // pub check_session_iframe: String,
+    pub grant_types_supported: Vec<String>,
+    pub response_types_supported: Vec<String>,
+    pub id_token_signing_alg_values_supported: Vec<String>,
+    pub token_endpoint_auth_signing_alg_values_supported: Vec<String>,
+    pub claims_supported: Vec<String>,
+    pub scopes_supported: Vec<String>,
+    pub code_challenge_methods_supported: Vec<String>,
+    pub dpop_signing_alg_values_supported: Vec<String>,
+}
+
+const IDX: &str = ".well-known";
+
+impl WellKnown {
+    pub async fn json(data: &web::Data<AppState>) -> Result<String, ErrorResponse> {
+        if let Some(wk) = cache_get!(
+            String,
+            CACHE_NAME_12HR.to_string(),
+            IDX.to_string(),
+            &data.caches.ha_cache_config,
+            false
+        )
+        .await?
+        {
+            Ok(wk)
+        } else {
+            let scopes = Scope::find_all(data)
+                .await?
+                .into_iter()
+                .map(|s| s.name)
+                .collect::<Vec<String>>();
+            let slf = Self::new(&data.issuer, scopes);
+            let json = serde_json::to_string(&slf).unwrap();
+
+            cache_put(
+                CACHE_NAME_12HR.to_string(),
+                IDX.to_string(),
+                &data.caches.ha_cache_config,
+                &json,
+            )
+            .await?;
+
+            Ok(json)
+        }
+    }
+
+    /// Rebuilds the WellKnown, serializes it as json and updates it inside the cache.
+    /// Should be called after any update on the Scopes.
+    pub async fn rebuild(data: &web::Data<AppState>) -> Result<(), ErrorResponse> {
+        let scopes = Scope::find_all(data)
+            .await?
+            .into_iter()
+            .map(|s| s.name)
+            .collect::<Vec<String>>();
+        let slf = Self::new(&data.issuer, scopes);
+        let json = serde_json::to_string(&slf).unwrap();
+
+        cache_put(
+            CACHE_NAME_12HR.to_string(),
+            IDX.to_string(),
+            &data.caches.ha_cache_config,
+            &json,
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+impl WellKnown {
+    pub fn new(issuer: &str, scopes_supported: Vec<String>) -> Self {
+        let authorization_endpoint = format!("{}/oidc/authorize", issuer);
+        let token_endpoint = format!("{}/oidc/token", issuer);
+        let introspection_endpoint = format!("{}/oidc/tokenInfo", issuer);
+        let userinfo_endpoint = format!("{}/oidc/userinfo", issuer);
+        let end_session_endpoint = format!("{}/oidc/userinfo", issuer);
+        let jwks_uri = format!("{}/oidc/certs", issuer);
+        let grant_types_supported = vec![
+            "authorization_code".to_string(),
+            "client_credentials".to_string(),
+            "password".to_string(),
+            "refresh_token".to_string(),
+        ];
+        let response_types_supported = vec!["code".to_string()];
+        let id_token_signing_alg_values_supported = vec![
+            "RS256".to_string(),
+            "RS384".to_string(),
+            "RS512".to_string(),
+            "EdDSA".to_string(),
+        ];
+        let token_endpoint_auth_signing_alg_values_supported = vec![
+            "RS256".to_string(),
+            "RS384".to_string(),
+            "RS512".to_string(),
+            "EdDSA".to_string(),
+        ];
+        let claims_supported = vec![
+            "aud".to_string(),
+            "sub".to_string(),
+            "iss".to_string(),
+            "name".to_string(),
+            "given_name".to_string(),
+            "family_name".to_string(),
+            "preferred_username".to_string(),
+            "email".to_string(),
+        ];
+        let code_challenge_methods_supported = vec!["plain".to_string(), "S256".to_string()];
+        let dpop_signing_alg_values_supported = vec![
+            "RS256".to_string(),
+            "RS384".to_string(),
+            "RS512".to_string(),
+            "EdDSA".to_string(),
+        ];
+
+        WellKnown {
+            issuer: String::from(issuer),
+            authorization_endpoint,
+            token_endpoint,
+            introspection_endpoint,
+            userinfo_endpoint,
+            end_session_endpoint,
+            jwks_uri,
+            grant_types_supported,
+            response_types_supported,
+            id_token_signing_alg_values_supported,
+            token_endpoint_auth_signing_alg_values_supported,
+            claims_supported,
+            scopes_supported,
+            code_challenge_methods_supported,
+            dpop_signing_alg_values_supported,
+        }
+    }
+}


### PR DESCRIPTION
This is a preparation for the `webid` coming in the future.

This moves the `WellKnown` struct out of the `AppState` into its own entity.
The `supported_scopes` can and will be dynamically rebuilt depending on Scope updates.
This is a preparation step for the `webid` claim for Solid-OIDC which will come in the future.