### PR TITLE
fix: take turtle as input for custom triples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2211,12 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -4087,6 +4099,7 @@ dependencies = [
  "rio_api",
  "rio_turtle",
  "rsa 0.9.3",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -4270,6 +4283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+
+[[package]]
 name = "reqwest"
 version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4415,6 +4434,35 @@ dependencies = [
  "spki 0.7.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.38",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -14,7 +14,7 @@ import sjcl from "sjcl";
 import { decode, encode } from "base64-arraybuffer";
 
 export function buidlWebIdUri(userId) {
-	return `${window.location.origin}/auth/webid/${userId}/profile`
+	return `${window.location.origin}/auth/webid/${userId}/profile#me`
 }
 
 export function extractFormErrors(err) {

--- a/rauthy-models/Cargo.toml
+++ b/rauthy-models/Cargo.toml
@@ -72,4 +72,5 @@ webauthn-rs-proto = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1"
+rstest = "0.18.2"
 tokio-test = "*"

--- a/rauthy-models/src/i18n/account.rs
+++ b/rauthy-models/src/i18n/account.rs
@@ -134,8 +134,7 @@ confirmed, your new address will be updated."#,
             web_id_desc: r#"You can configure the fields that should be exposed with your WebID.
 This is a feature used by some networks for decentralized logins. If you do not know what it is,
 you most probably do not need it."#,
-            web_id_desc_data:
-                "You can add custom data fields to your WebID in valid FOAF vocabulary",
+            web_id_desc_data: "You can add custom data fields to your WebID in valid turtle",
             web_id_expert_mode: "Enable Expert Mode",
         }
     }

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -1,6 +1,6 @@
 # if 'true', the data store will be initialized with DEV values (default: false)
 # !!! DO NOT USE IN PRODUCTION !!!
-DEV_MODE=true
+DEV_MODE=false
 
 # Can be set to 'true' during local development to allow an HTTP scheme for the DPoP 'htu' claim
 # Will only be applied if `DEV_MODE == true` as well.


### PR DESCRIPTION
It now parses and formats data in turtle, translating to and from n-triples when required.
