### PR TITLE
Impl opt panic on matrix error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4002,6 +4002,7 @@ dependencies = [
  "gethostname",
  "lazy_static",
  "once_cell",
+ "oxiri",
  "pretty_assertions",
  "rand",
  "rand_core",

--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -283,6 +283,17 @@ ENABLE_WEB_ID=true
 # May be set to disable the TLS validation for the Matrix client.
 # default: false
 #EVENT_MATRIX_DANGER_DISABLE_TLS_VALIDATION=false
+# The default behavior is, that Rauthy will panic at startup if it cannot connect
+# to a configured Matrix server. The reason is that event notifications cannot be
+# dropped silently.
+# However, if you use a self-hosted Matrix server which uses Rauthy as its OIDC
+# provider and both instances went offline, you will have a chicken and egg problem:
+# - Rauthy cannot connect to Matrix and will panic
+# - Your Matrix server cannot connect to Rauthy and will panic
+# To solve this issue, you can temporarily set this value to 'true' and revert
+# back, after the system is online again.
+# default: false
+#EVENT_MATRIX_ERROR_NO_PANIC=false
 
 # The Webhook for Slack Notifications.
 # If left empty, no messages will be sent to Slack.

--- a/rauthy-models/src/response.rs
+++ b/rauthy-models/src/response.rs
@@ -592,6 +592,7 @@ pub struct AppVersionResponse {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use std::env;
 
     use crate::{entity::webids::WebId, response::WebIdResponse};
 
@@ -602,9 +603,11 @@ mod tests {
 <http://www.w3.org/ns/solid/terms#oidcIssuer>
 <http://localhost:8080/auth/v1> .
 "#),
-  "<http://localhost:8080/auth/webid/SomeId123/profile> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/PersonalProfileDocument> ;\n\t<http://xmlns.com/foaf/0.1/primaryTopic> <http://localhost:8080/auth/webid/SomeId123/profile#me> .\n<http://localhost:8080/auth/webid/SomeId123/profile#me> <http://www.w3.org/ns/solid/terms#oidcIssuer> <http://localhost:8080/auth/v1> ;\n\t<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;\n\t<http://xmlns.com/foaf/0.1/givenname> \"Given\" ;\n\t<http://xmlns.com/foaf/0.1/family_name> \"Family\" ;\n\t<http://xmlns.com/foaf/0.1/mbox> <mailto:mail@example.com> .\n<http://localhost:8080/auth/webid/za9UxpH7XVxqrtpEbThoqvn2/profile#me> <http://www.w3.org/ns/solid/terms#oidcIssuer> <http://localhost:8080/auth/v1> .\n"
+  "<http://localhost:8081/auth/SomeId123/profile> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/PersonalProfileDocument> ;\n\t<http://xmlns.com/foaf/0.1/primaryTopic> <http://localhost:8081/auth/SomeId123/profile#me> .\n<http://localhost:8081/auth/SomeId123/profile#me> <http://www.w3.org/ns/solid/terms#oidcIssuer> <http://localhost:8080/auth/v1> ;\n\t<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> ;\n\t<http://xmlns.com/foaf/0.1/givenname> \"Given\" ;\n\t<http://xmlns.com/foaf/0.1/family_name> \"Family\" ;\n\t<http://xmlns.com/foaf/0.1/mbox> <mailto:mail@example.com> .\n<http://localhost:8080/auth/webid/za9UxpH7XVxqrtpEbThoqvn2/profile#me> <http://www.w3.org/ns/solid/terms#oidcIssuer> <http://localhost:8080/auth/v1> .\n"
     )]
     fn test_web_id_response(#[case] custom_triples: Option<&str>, #[case] expected_resp: &str) {
+        env::set_var("PUB_URL", "localhost:8081".to_string());
+
         let resp = WebIdResponse {
             webid: WebId::try_new("SomeId123".to_string(), custom_triples, true)
                 .expect("Invalid cusyom triples in test case"),

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -1,6 +1,6 @@
 # if 'true', the data store will be initialized with DEV values (default: false)
 # !!! DO NOT USE IN PRODUCTION !!!
-DEV_MODE=false
+DEV_MODE=true
 
 # Can be set to 'true' during local development to allow an HTTP scheme for the DPoP 'htu' claim
 # Will only be applied if `DEV_MODE == true` as well.
@@ -278,6 +278,17 @@ EPHEMERAL_CLIENTS_CACHE_LIFETIME=3600
 # May be set to disable the TLS validation for the Matrix client.
 # default: false
 #EVENT_MATRIX_DANGER_DISABLE_TLS_VALIDATION=false
+# The default behavior is, that Rauthy will panic at startup if it cannot connect
+# to a configured Matrix server. The reason is that event notifications cannot be
+# dropped silently.
+# However, if you use a self-hosted Matrix server which uses Rauthy as its OIDC
+# provider and both instances went offline, you will have a chicken and egg problem:
+# - Rauthy cannot connect to Matrix and will panic
+# - Your Matrix server cannot connect to Rauthy and will panic
+# To solve this issue, you can temporarily set this value to 'true' and revert
+# back, after the system is online again.
+# default: false
+EVENT_MATRIX_ERROR_NO_PANIC=true
 
 # The Webhook for Slack Notifications.
 # If left empty, no messages will be sent to Slack.


### PR DESCRIPTION
This PR introduces the new config variable `EVENT_MATRIX_ERROR_NO_PANIC`.
If set to `true`, Rauthy will not panic at startup, if it cannot connect to a configured Matrix server.

This solves a possible chicken and egg problem if you self-host Matrix and Rauthy is your OIDC provider at the same time.