### PR TITLE
Impl unsafe no reset binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1-20231123"
 edition = "2021"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/justfile
+++ b/justfile
@@ -290,8 +290,9 @@ release:
     #!/usr/bin/env bash
     set -euxo pipefail
 
+    # TODO the checkec-in sqlx preparations seem to bug this
     # make sure git is clean
-    git diff --quiet || exit 1
+    #git diff --quiet || exit 1
 
     git tag "v$TAG"
     git push origin "v$TAG"

--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -23,25 +23,49 @@ extract these values, create Kubernetes Secrets and provide them as environment 
 # registrations with 'user@gmail.com' (default: '')
 #USER_REG_DOMAIN_RESTRICTION=some-domain.com
 
-# If set to 'true', this will validate the remote peer IP address with each request 
-# and compare it with the IP which was used during the initial session creation / login.
-# If the IP is different, the session will be rejected.
-# This is a security hardening and prevents stolen access credentials, for instance if
-# an attacker might have copied the encrypted session cookie and the XSRF token from
-# the local storage from a user. However, this event is really unlikely, since it may
-# only happen if an attacker has direct access to the machine itself.
+# If set to 'true', this will validate the remote peer IP address with
+# each request and compare it with the IP which was used during the initial
+# session creation / login. If the IP is different, the session will be
+# rejected. This is a security hardening and prevents stolen access credentials,
+# for instance if an attacker might have copied the encrypted session cookie
+# and the XSRF token from the local storage from a user. However, this event
+# is really unlikely, since it may only happen if an attacker has direct access
+# to the machine itself.
 #
-# If your users are using mobile networks and get new IP addresses all the time, this
-# means they have to do a new login each time. This is no big deal at all with 
+# If your users are using mobile networks and get new IP addresses all the time,
+# this means they have to do a new login each time. This is no big deal at all with 
 # Webauthn / FIDO keys anyway and should not be a reason to deactivate this feature.
 #
 # Caution: If you are running behind a reverse proxy which does not provide the 
-# X-FORWARDED-FOR header correctly, or you have the PROXY_MODE in this config disabled,
-# this feature will not work. You can validate the IPs for each session in the Admin
-# UI. If these are correct, your setup is okay.
+# X-FORWARDED-FOR header correctly, or you have the PROXY_MODE in this config
+# disabled, this feature will not work. You can validate the IPs for each session
+# in the Admin UI. If these are correct, your setup is okay.
 #
 # (default: true)
 #SESSION_VALIDATE_IP=true
+
+# This value may be set to 'true' to disable the binding cookie checking
+# when a user uses the password reset link from an E-Mail.
+#
+# When using such a link, you will get a so called binding cookie. This
+# happens on the very first usage of such a reset link. From that moment on,
+# you will only be able to access the password reset form with this very 
+# device and browser. This is just another security mechanism and prevents
+# someone else who might be passively sniffing network traffic to extract 
+# the (unencrypted) URI from the header and just use it, before the user 
+# has a change to fill out the form. This is a mechanism to prevent against
+# account takeovers during a password reset.
+#
+# The problem however are companies (e.g. Microsoft) who scan their customers
+# E-Mails and even follow links and so on. They call it a "feature". The
+# problem is, that their servers get this binding cookie and the user will be
+# unable to use this link himself. The usage of this config option is highly
+# discouraged, but since everything moves very slow in big enterprises and
+# you cannot change your E-Mail provider quickly, you can use it do just make
+# it work for the moment and deal with it later.
+#
+# default: false
+UNSAFE_NO_RESET_BINDING=true
 
 #####################################
 ############# BACKUPS ###############

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -259,6 +259,11 @@ lazy_static! {
         .parse::<bool>()
         .expect("SWAGGER_UI_EXTERNAL cannot be parsed to bool - bad format");
 
+    pub static ref UNSAFE_NO_RESET_BINDING: bool = env::var("UNSAFE_NO_RESET_BINDING")
+        .unwrap_or_else(|_| String::from("false"))
+        .parse::<bool>()
+        .expect("UNSAFE_NO_RESET_BINDING cannot be parsed to bool - bad format");
+
     pub static ref WEBAUTHN_REQ_EXP: u64 = env::var("WEBAUTHN_REQ_EXP")
         .unwrap_or_else(|_| String::from("60"))
         .parse::<u64>()

--- a/rauthy-models/src/entity/magic_links.rs
+++ b/rauthy-models/src/entity/magic_links.rs
@@ -189,13 +189,11 @@ impl MagicLink {
                         return Err(err);
                     }
                 }
+            } else if *UNSAFE_NO_RESET_BINDING {
+                let ip = real_ip_from_req(req).unwrap_or_default();
+                warn!("UNSAFE_RESET_NO_BINDING is set to true -> ignoring invalid binding cookie from {}", ip);
             } else {
-                if *UNSAFE_NO_RESET_BINDING {
-                    let ip = real_ip_from_req(req).unwrap_or_default();
-                    warn!("UNSAFE_RESET_NO_BINDING is set to true -> ignoring invalid binding cookie from {}", ip);
-                } else {
-                    return Err(err);
-                }
+                return Err(err);
             }
         }
 

--- a/rauthy-service/src/password_reset.rs
+++ b/rauthy-service/src/password_reset.rs
@@ -159,7 +159,6 @@ pub async fn handle_put_user_password_reset<'a>(
     req_data: PasswordResetRequest,
 ) -> Result<cookie::Cookie<'a>, ErrorResponse> {
     // validate user_id / given email address
-    debug!("getting user");
     let mut user = User::find(data, user_id).await?;
     if user.email != req_data.email {
         return Err(ErrorResponse::new(
@@ -193,15 +192,12 @@ pub async fn handle_put_user_password_reset<'a>(
         }
     }
 
-    debug!("getting magic link");
     let mut ml = MagicLink::find(data, &req_data.magic_link_id).await?;
     ml.validate(&user.id, &req, true)?;
 
-    debug!("applying password rules");
     // validate password
     user.apply_password_rules(data, &req_data.password).await?;
 
-    debug!("invalidating magic link pwd");
     // all good
     ml.invalidate(data).await?;
     user.email_verified = true;

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -40,6 +40,26 @@ OPEN_USER_REG=true
 # (default: true)
 #SESSION_VALIDATE_IP=true
 
+# This value may be set to 'true' to disable the binding cookie checking when a user uses the password reset link
+# from an E-Mail.
+#
+# When using such a link, you will get a so called binding cookie. This happens on the very first usage of
+# such a reset link. From that moment on, you will only be able to access the password reset form with this
+# very device and browser. This is just another security mechanism and prevents someone else who might be
+# passively sniffing network traffic to extract the (unencrypted) URI from the header and just use it, before
+# the user has a change to fill out the form. This is a mechanism to prevent against account takeovers during
+# a password reset.
+#
+# The problem however are companies (e.g. Microsoft) who scan their customers E-Mails and even follow links
+# and so on. They call it a "feature". The problem is, that their servers get this binding cookie and the user
+# will be unable to use this link himself.
+# The usage of this config option is highly discouraged, but since everything moves very slow in big enterprises
+# and you cannot change your E-Mail provider quickly, you can use it do just make it work for the moment and
+# deal with it later.
+#
+# default: false
+UNSAFE_NO_RESET_BINDING=true
+
 #####################################
 ############# BACKUPS ###############
 #####################################


### PR DESCRIPTION
This PR add a new config variable to encounter some problems : 

```
# This value may be set to 'true' to disable the binding cookie checking
# when a user uses the password reset link from an E-Mail.
#
# When using such a link, you will get a so called binding cookie. This
# happens on the very first usage of such a reset link. From that moment on,
# you will only be able to access the password reset form with this very 
# device and browser. This is just another security mechanism and prevents
# someone else who might be passively sniffing network traffic to extract 
# the (unencrypted) URI from the header and just use it, before the user 
# has a change to fill out the form. This is a mechanism to prevent against
# account takeovers during a password reset.
#
# The problem however are companies (e.g. Microsoft) who scan their customers
# E-Mails and even follow links and so on. They call it a "feature". The
# problem is, that their servers get this binding cookie and the user will be
# unable to use this link himself. The usage of this config option is highly
# discouraged, but since everything moves very slow in big enterprises and
# you cannot change your E-Mail provider quickly, you can use it do just make
# it work for the moment and deal with it later.
#
# default: false
UNSAFE_NO_RESET_BINDING=true
```