### PR TITLE
Fix password reset with old passkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy"
-version = "0.19.1-20231123"
+version = "0.19.2-20231123"
 dependencies = [
  "actix-service",
  "actix-web",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-common"
-version = "0.19.1-20231123"
+version = "0.19.2-20231123"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-handlers"
-version = "0.19.1-20231123"
+version = "0.19.2-20231123"
 dependencies = [
  "actix",
  "actix-multipart",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-models"
-version = "0.19.1-20231123"
+version = "0.19.2-20231123"
 dependencies = [
  "accept-language",
  "actix",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-notify"
-version = "0.19.1-20231123"
+version = "0.19.2-20231123"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-service"
-version = "0.19.1-20231123"
+version = "0.19.2-20231123"
 dependencies = [
  "actix-web",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 exclude = ["rauthy-client"]
 
 [workspace.package]
-version = "0.19.1-20231123"
+version = "0.19.2-20231123"
 edition = "2021"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/rauthy-handlers/src/middleware/principal.rs
+++ b/rauthy-handlers/src/middleware/principal.rs
@@ -71,7 +71,6 @@ where
                 principal.session = Some(s);
             }
 
-            // req.extensions_mut().insert(session);
             req.extensions_mut().insert(principal);
 
             service.call(req).await

--- a/rauthy-handlers/src/users.rs
+++ b/rauthy-handlers/src/users.rs
@@ -559,7 +559,7 @@ pub async fn post_webauthn_auth_start(
     id: web::Path<String>,
     // The principal here must be optional to make cases like user password reset in a
     // fully new / different browser which does not have any lefter data or cookies
-    principal: Option<ReqPrincipal>,
+    principal: ReqPrincipal,
     req: HttpRequest,
     req_data: Json<WebauthnAuthStartRequest>,
 ) -> Result<HttpResponse, ErrorResponse> {
@@ -567,12 +567,6 @@ pub async fn post_webauthn_auth_start(
     let id = match purpose {
         // only for a Login purpose, this can be accessed without authentication (yet)
         MfaPurpose::Login(_) => {
-            let principal = principal.ok_or_else(|| {
-                ErrorResponse::new(
-                    ErrorResponseType::Unauthorized,
-                    "Unauthorized Session".to_string(),
-                )
-            })?;
             // During Login, the session is allowed to be in init only state
             principal.validate_session_auth_or_init()?;
             id.into_inner()
@@ -604,12 +598,6 @@ pub async fn post_webauthn_auth_start(
         }
 
         _ => {
-            let principal = principal.ok_or_else(|| {
-                ErrorResponse::new(
-                    ErrorResponseType::Unauthorized,
-                    "Unauthorized Session".to_string(),
-                )
-            })?;
             // for all other purposes, we need an authenticated session
             principal.validate_session_auth()?;
 

--- a/rauthy-models/src/entity/users.rs
+++ b/rauthy-models/src/entity/users.rs
@@ -423,7 +423,6 @@ impl User {
         id: String,
         upd_user: UpdateUserRequest,
         user: Option<User>,
-        // OK((User, is_new_rauthy_admin))
     ) -> Result<(User, bool), ErrorResponse> {
         let mut user = match user {
             None => User::find(data, id).await?,

--- a/rauthy-models/src/entity/webauthn.rs
+++ b/rauthy-models/src/entity/webauthn.rs
@@ -728,11 +728,11 @@ pub async fn auth_finish(
     user_id: String,
     req: WebauthnAuthFinishRequest,
 ) -> Result<WebauthnAdditionalData, ErrorResponse> {
-    let mut user = User::find(data, user_id).await?;
-    let force_uv = user.account_type() == AccountType::Passkey || *WEBAUTHN_FORCE_UV;
-
     let auth_data = WebauthnData::find(data, req.code).await?;
     let auth_state = serde_json::from_str(&auth_data.auth_state_json).unwrap();
+
+    let mut user = User::find(data, user_id).await?;
+    let force_uv = user.account_type() == AccountType::Passkey || *WEBAUTHN_FORCE_UV;
 
     let pks = PasskeyEntity::find_for_user(data, &user.id).await?;
 

--- a/rauthy-service/src/password_reset.rs
+++ b/rauthy-service/src/password_reset.rs
@@ -7,6 +7,7 @@ use rauthy_models::app_state::AppState;
 use rauthy_models::entity::colors::ColorEntity;
 use rauthy_models::entity::magic_links::{MagicLink, MagicLinkUsage};
 use rauthy_models::entity::password::PasswordPolicy;
+use rauthy_models::entity::sessions::Session;
 use rauthy_models::entity::users::User;
 use rauthy_models::entity::webauthn;
 use rauthy_models::entity::webauthn::WebauthnServiceReq;
@@ -217,6 +218,9 @@ pub async fn handle_put_user_password_reset<'a>(
         ))
         .await
         .unwrap();
+
+    // delete all existing user sessions to have a clean flow
+    Session::invalidate_for_user(data, &user.id).await?;
 
     // delete the cookie
     let cookie = cookie::Cookie::build(PWD_RESET_COOKIE, "")


### PR DESCRIPTION
This is a bugfix for the case, when an already existing (old) user with registered passkeys wanted to perform a password reset, that was triggered by an admin. In this case, it would not be possible to do the request properly, if the user would use a fully cleaned up browser for the reset without any session cookies and stuff. The validation was basically too strict.