### PR TITLE
Release `rauthy-client` v0.1.0

### DIFF
--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rauthy-client"
-version = "0.1.0-20231127"
+version = "0.1.0"
 edition = "2021"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/rauthy-client/README.md
+++ b/rauthy-client/README.md
@@ -1,9 +1,13 @@
 # rauthy-client
 
-Minimal and safe by default client library for the Rauthy project.
+Minimal and safe by default client library for the [Rauthy](https://github.com/sebadob/rauthy) project.
 
-This has not been released and should only be used for testing until the first release.
+You can of course use any generic OIDC client with [Rauthy](https://github.com/sebadob/rauthy).
+However, the idea of this crate is to provide the simplest possible production ready setup, with the least amount of
+overhead and secure default values, if you only use [Rauthy](https://github.com/sebadob/rauthy) anyway.
 
-It is working with the `axum` framework for now and a first example for axum exists.  
-However, at least `actix` will be added as a feature before the first release and the
-API might change with the introduction with this feature as the next step.
+This client should work without any issues with other OIDC providers as well, as long as they support the S256 PKCE
+flow. However, this was only tested against [Rauthy](https://github.com/sebadob/rauthy).
+
+You can find examples for `actix-web`, `axum` or a fully generic framework / application in the
+[Examples](https://github.com/sebadob/rauthy/tree/main/rauthy-client/examples) directory.


### PR DESCRIPTION
This is the preparation to release the `rauthy-client` on crates.io