### PR TITLE
Fix scopes migration

### DIFF
--- a/rauthy-client/src/lib.rs
+++ b/rauthy-client/src/lib.rs
@@ -6,12 +6,13 @@
 //! with the least amount of overhead and secure default values, if you only use
 //! [Rauthy](https://github.com/sebadob/rauthy) anyway.
 //!
-//! This client should work without any issues with other OIDC providers as well, as long as they
-//! support the S256 PKCE flow. However, this was only tested against
-//! [Rauthy](https://github.com/sebadob/rauthy).
-//!
 //! You can find examples for `actix-web`, `axum` or a fully generic framework / application in the
 //! [Examples](https://github.com/sebadob/rauthy/tree/main/rauthy-client/examples) directory.
+//!
+//! # Features
+//!
+//! - `actix-web` will enable actix-web specific extractors and handlers
+//! - `axum` will enable axum specific extractors and handlers
 
 use crate::provider::OidcProvider;
 use base64::{engine, engine::general_purpose, Engine as _};

--- a/rauthy-models/src/migration/db_migrate.rs
+++ b/rauthy-models/src/migration/db_migrate.rs
@@ -533,11 +533,14 @@ pub async fn migrate_from_sqlite(
         .await?;
     sqlx::query("delete from scopes").execute(db_to).await?;
     for b in before {
-        sqlx::query("insert into scopes (id, name) values ($1, $2)")
-            .bind(b.id)
-            .bind(b.name)
-            .execute(db_to)
-            .await?;
+        sqlx::query(
+            r#"insert into scopes (id, name, attr_include_access, attr_include_id)
+            values ($1, $2, $3, $4)"#,
+        )
+        .bind(b.id)
+        .bind(b.name)
+        .execute(db_to)
+        .await?;
     }
 
     // USER ATTR CONFIG
@@ -907,11 +910,14 @@ pub async fn migrate_from_postgres(
         .await?;
     sqlx::query("delete from scopes").execute(db_to).await?;
     for b in before {
-        sqlx::query("insert into scopes (id, name) values ($1, $2)")
-            .bind(b.id)
-            .bind(b.name)
-            .execute(db_to)
-            .await?;
+        sqlx::query(
+            r#"insert into scopes (id, name, attr_include_access, attr_include_id)
+            values ($1, $2, $3, $4)"#,
+        )
+        .bind(b.id)
+        .bind(b.name)
+        .execute(db_to)
+        .await?;
     }
 
     // USER ATTR CONFIG


### PR DESCRIPTION
This fixes a bug with the internal `DB_MIGRATE_FROM` feature.
The `scopes` migration has not been updated to the "new" version with the custom attribute mapping.
This means, that during a migration, the custom mappings would get lost.