### PR TITLE
Encrypted backups to S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,6 +4210,7 @@ dependencies = [
  "rio_turtle",
  "rsa",
  "rstest",
+ "rusty-s3",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "rus
 ring = "0.17"
 rio_api = "0.8.4"
 rio_turtle = "0.8.4"
+rusty-s3 = "0.5.0"
 semver = { version = "1.0.19", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -183,6 +183,20 @@ extract these values, create Kubernetes Secrets and provide them as environment 
 # Disables the housekeeping schedulers (default: false)
 #SCHED_DISABLE=true
 
+# The following section will only be taken into account, when
+# SQLite is used as the main database. If you use Postgres, you
+# should use Postgres native tooling like for instance `pgbackrest`
+# to manage your backups.
+# If S3 access is configured, your SQLite backups will be encrypted
+# and pushed into the configured bucket.
+#S3_URL=
+#S3_REGION=
+#S3_PATH_STYLE=false
+#S3_BUCKET=my_s3_bucket_name
+#S3_ACCESS_KEY=
+#S3_ACCESS_SECRET=
+#S3_DANGER_ACCEPT_INVALID_CERTS=false
+
 #####################################
 ############# E-MAIL ################
 #####################################

--- a/rauthy-main/src/logging.rs
+++ b/rauthy-main/src/logging.rs
@@ -20,7 +20,7 @@ pub fn setup_logging() -> tracing::Level {
         _ => panic!("Log Level must be one of the following: error, warn, info, debug, trace"),
     };
     let filter = format!(
-        "{},hyper=info,matrix_sdk_crypto=error,matrix_sdk_base=error,matrix_sdk::encryption=error",
+        "{},cryptr=info,hyper=info,matrix_sdk_crypto=error,matrix_sdk_base=error,matrix_sdk::encryption=error",
         log_level.as_str()
     );
     env::set_var("RUST_LOG", &filter);

--- a/rauthy-models/Cargo.toml
+++ b/rauthy-models/Cargo.toml
@@ -57,6 +57,7 @@ ring = { workspace = true }
 rio_api = { workspace = true }
 rio_turtle = { workspace = true }
 rsa = { version = "0.9.3", features = ["serde", "sha2"] }
+rusty-s3 = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -66,7 +66,8 @@ UNSAFE_NO_RESET_BINDING=true
 
 # Cron job for automatic data store backups (default: "0 0 4 * * * *")
 # sec min hour day_of_month month day_of_week year
-BACKUP_TASK="0 0 4 * * * *"
+#BACKUP_TASK="0 0 4 * * * *"
+BACKUP_TASK="0 4 12 * * * *"
 
 # The name for the data store backups. The current timestamp will always be appended automatically. (default: rauthy-backup-)
 BACKUP_NAME="rauthy-backup-"
@@ -167,6 +168,18 @@ CACHE_RECONNECT_TIMEOUT_UPPER=5000
 # default: disabled / not set
 #SCHED_USER_EXP_DELETE_MINS=7200
 
+# The following section will only be taken into account, when SQLite is used as the main database.
+# If you use Postgres, you should use Postgres native tooling like for instance `pgbackrest` to manage
+# your backups.
+# If S3 access is configured, your SQLite backups will be encrypted and pushed into the configured bucket.
+#S3_URL=
+#S3_REGION=
+#S3_PATH_STYLE=true
+#S3_BUCKET=
+#S3_ACCESS_KEY=
+#S3_ACCESS_SECRET=
+#S3_DANGER_ACCEPT_INVALID_CERTS=true
+
 #####################################
 ############# DEPOP #################
 #####################################
@@ -202,7 +215,11 @@ EMAIL_SUB_PREFIX="Rauthy IAM"
 # Format: "key_id/enc_key another_key_id/another_enc_key" - the enc_key itself must be exactly 32 characters long and
 # and should not contain special characters.
 # The ID must match '[a-zA-Z0-9]{2,20}'
-ENC_KEYS="bVCyTsGaggVy5yqQ/S9n7oCen53xSJLzcsmfdnBDvNrqQ63r4 q6u26onRvXVG4427/3CEC8RJWBcMkrBMkRXgx65AmJsNTghSA"
+#ENC_KEYS="bVCyTsGaggVy5yqQ/S9n7oCen53xSJLzcsmfdnBDvNrqQ63r4 q6u26onRvXVG4427/3CEC8RJWBcMkrBMkRXgx65AmJsNTghSA"
+ENC_KEYS="
+q6u26onRvXVG4427/M0NFQzhSSldCY01rckJNa1JYZ3g2NUFtSnNOVGdoU0E=
+bVCyTsGaggVy5yqQ/UzluN29DZW41M3hTSkx6Y3NtZmRuQkR2TnJxUTYzcjQ=
+"
 ENC_KEY_ACTIVE=bVCyTsGaggVy5yqQ
 
 # M_COST should never be below 32768 in production


### PR DESCRIPTION
This implements SQLite backups automatically being pushed to a configured S3 bucket.
The backups will always be encrypted and plain SQLite files are neither an option nor allowed.

It well append the file ending `.cryptr` to make it directly visible, that these files are encrypted.

Restoring from an encrypted S3 backup will come with another PR.