### PR TITLE
Expand default scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,15 +51,30 @@ You can now set the upper limit and the lifespan for cached user's. This is one 
 optimizations, since Rauthy gets closer to the first v1.0.0 release:
 
 ```
-# The max cache size for users. If you can afford it memory-wise,
-# make it possible to fit all active users inside the cache.
+# The max cache size for users. If you can afford it memory-wise, make it possible to fit
+# all active users inside the cache.
+# The cache size you provide here should roughly match the amount of users you want to be able
+# to cache actively. Depending on your setup (WebIDs, custom attributes, ...), this number
+# will be multiplied internally  by 3 or 4 to create multiple cache entries for each user.
 # default: 100
 CACHE_USERS_SIZE=100
-# The lifespan of the users cache in seconds. Cache eviction on
-# updates will be handled automatically.
+
+# The lifespan of the users cache in seconds. Cache eviction on updates will be handled automatically.
 # default: 28800
 CACHE_USERS_LIFESPAN=28800
 ```
+
+### Additional claims available in ID tokens
+
+The scope `profile` now additionally adds the following claims to the ID token (if they exist for the user):
+- `locale`
+- `birthdate`
+
+The new scope `address` adds:
+- `address` in JSON format
+
+  The new scope `phone` adds:
+- `phone`
 
 ### Changes
 
@@ -88,12 +103,16 @@ but also even encryption algorithm encryptions really easy in the future.
 [38a2a52](https://github.com/sebadob/rauthy/commit/38a2a52fe6530cf4efdedfe96d2b3041959fcd3d)
 - push users into their own, separate, configurable cache
 [3137927](https://github.com/sebadob/rauthy/commit/31379278440ec6ddaf1a2288ba3950ab60994963)
+- add additional user values matching OIDC default claims
+[fca0c13](https://github.com/sebadob/rauthy/commit/fca0c1306624bdffa112ad8239e381064cb0b843)
 
 ### Bugfixes
 
 - A visual bugfix appeared on Apple systems because of the slightly bigger font size. This made
 the live events look a bit ugly and characters jumping in a line where they should never end up.
 [3b56b50](https://github.com/sebadob/rauthy/commit/3b56b50f4f24b7707c522934f9c03714703c64ad)
+- An incorrect URL has been returned for the `end_session_endpoint` in the OIDC metadata
+[]()
 
 ## v0.19.2
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -2,22 +2,8 @@
 
 ## CURRENT WORK
 
-Add new user claims:
-- profile:
-    - birthdate
-    - locale
-- address
-- phone
-    - phone_number
-    - TODO can we implement a generic interface for custom phone number verification here?
-
 ## Leftover TODO's for v0.20.0
 
-- add additional user values for self-modify in the accounts view
-- add more default claims for users https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
-- add DB migration for the new user values
-- simplify the "GET all users response" to only include necessary values to decrease the payload
-for big deployments
 - UI: fix ItemTiles component flex-wrap
 - UI: new version event shows `NewRauthyAdmin` instead of `NewRauthyVersion`
 - UI: event `UserPasswordReset` could additionally show the corresponding E-Mail
@@ -30,6 +16,8 @@ for big deployments
 
 ## Stage 2 - features - do before v1.0.0
 
+- impl oidc metadata `check_session_iframe`
+- impl leftovers on `/userinfo` endpoint
 - admin ui: template button for client branding: default-light + default-dark ?
 - double check against https://openid.net/specs/openid-connect-core-1_0.html that everything is implemented correctly one more time
 - benchmarks and performance tuning

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -23,7 +23,8 @@ export function extractFormErrors(err) {
 }
 
 export function isDefaultScope(name) {
-	return name === 'openid' || name === 'profile' || name === 'email' || name === 'groups';
+	return name === 'openid' || name === 'profile' || name === 'email' || name === 'groups'
+		|| name === 'address' || name === 'phone';
 }
 
 export const redirectToLogin = (state) => {

--- a/migrations/postgres/16_additional_scopes.sql
+++ b/migrations/postgres/16_additional_scopes.sql
@@ -1,0 +1,4 @@
+insert into scopes (id, name, attr_include_access, attr_include_id)
+values  ('awyOUa5rjFkowidSw03otjXU', 'address', null, null),
+        ('ImGlzlvfeOrJ9iY394AVeJgJ', 'phone', null, null)
+on conflict do nothing;

--- a/migrations/sqlite/16_additional_scopes.sql
+++ b/migrations/sqlite/16_additional_scopes.sql
@@ -1,0 +1,3 @@
+insert or ignore into scopes (id, name, attr_include_access, attr_include_id)
+values  ('awyOUa5rjFkowidSw03otjXU', 'address', null, null),
+        ('ImGlzlvfeOrJ9iY394AVeJgJ', 'phone', null, null);

--- a/rauthy-handlers/src/openapi.rs
+++ b/rauthy-handlers/src/openapi.rs
@@ -211,6 +211,7 @@ use utoipa::{openapi, OpenApi};
             response::WebauthnLoginResponse,
             response::WebIdResponse,
 
+            rauthy_models::AddressClaim,
             rauthy_models::JktClaim,
             token_set::TokenSet,
         ),

--- a/rauthy-models/src/entity/well_known.rs
+++ b/rauthy-models/src/entity/well_known.rs
@@ -94,7 +94,7 @@ impl WellKnown {
         let token_endpoint = format!("{}/oidc/token", issuer);
         let introspection_endpoint = format!("{}/oidc/tokenInfo", issuer);
         let userinfo_endpoint = format!("{}/oidc/userinfo", issuer);
-        let end_session_endpoint = format!("{}/oidc/userinfo", issuer);
+        let end_session_endpoint = format!("{}/oidc/logout", issuer);
         let jwks_uri = format!("{}/oidc/certs", issuer);
         let grant_types_supported = vec![
             "authorization_code".to_string(),

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -105,7 +105,7 @@ pub struct AddressClaim {
 impl AddressClaim {
     pub fn try_build(user: &User, values: &UserValues) -> Option<Self> {
         let mut slf = Self {
-            formatted: format!("{} {}", user.given_name, user.family_name),
+            formatted: format!("{} {}\n", user.given_name, user.family_name),
             street_address: None,
             locality: None,
             postal_code: None,

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -3,12 +3,15 @@
 #![forbid(unsafe_code)]
 
 use crate::entity::sessions::Session;
+use crate::entity::users::User;
+use crate::entity::users_values::UserValues;
 use actix_web::http::header::{HeaderName, HeaderValue};
 use actix_web::HttpRequest;
 use rauthy_common::constants::PROXY_MODE;
 use rauthy_common::error_response::{ErrorResponse, ErrorResponseType};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use utoipa::ToSchema;
@@ -85,6 +88,63 @@ pub struct JktClaim {
     pub jkt: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AddressClaim {
+    pub formatted: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub street_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locality: Option<String>,
+    // pub region: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub postal_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+}
+
+impl AddressClaim {
+    pub fn try_build(user: &User, values: &UserValues) -> Option<Self> {
+        let mut slf = Self {
+            formatted: format!("{} {}", user.given_name, user.family_name),
+            street_address: None,
+            locality: None,
+            postal_code: None,
+            country: None,
+        };
+
+        if let Some(street) = &values.street {
+            writeln!(slf.formatted, "{}", street).expect("AddressClaim to build");
+            slf.street_address = Some(street.clone());
+        }
+
+        if let Some(zip) = values.zip {
+            slf.postal_code = Some(zip);
+
+            if let Some(city) = &values.city {
+                writeln!(slf.formatted, "{}, {}", zip, city).expect("AddressClaim to build");
+                slf.locality = Some(city.clone());
+            } else {
+                writeln!(slf.formatted, "{}", zip).expect("AddressClaim to build");
+            }
+        }
+
+        if let Some(country) = &values.country {
+            writeln!(slf.formatted, "{}", country).expect("AddressClaim to build");
+            slf.country = Some(country.clone());
+        }
+
+        if slf.street_address.is_some()
+            || slf.locality.is_some()
+            || slf.postal_code.is_some()
+            || slf.country.is_some()
+        {
+            Some(slf)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JwtAccessClaims {
     pub typ: JwtTokenType,
@@ -120,6 +180,14 @@ pub struct JwtIdClaims {
     pub given_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub family_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<AddressClaim>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub birthdate: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
     pub roles: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<String>>,

--- a/rauthy-service/src/auth.rs
+++ b/rauthy-service/src/auth.rs
@@ -677,7 +677,6 @@ fn get_bearer_token_from_header(headers: &HeaderMap) -> Result<String, ErrorResp
 }
 
 /// Returns the 'userInfo' for the [/oidc/userinfo endpoint](crate::handlers::get_userinfo)<br>
-/// **Important: This function does NOT validate the token again!**
 pub async fn get_userinfo(
     data: &web::Data<AppState>,
     req: HttpRequest,
@@ -685,7 +684,6 @@ pub async fn get_userinfo(
     // get bearer token
     let bearer = get_bearer_token_from_header(req.headers())?;
 
-    // token should already be validated in the permission extractor
     let claims = validate_token::<JwtCommonClaims>(data, &bearer).await?;
 
     let email = claims.subject.ok_or_else(|| {


### PR DESCRIPTION
This will add addtitional OIDC default claims and / or expand the current ones.
The newly available user values may be added to the ID token if requested via scope.