### PR TITLE
Implement `max_age`  + `auth_time` during the auth flow

### DIFF
--- a/frontend/src/components/account/AccInfo.svelte
+++ b/frontend/src/components/account/AccInfo.svelte
@@ -1,6 +1,6 @@
 <script>
     import CheckIcon from "$lib/CheckIcon.svelte";
-    import {buidlWebIdUri, formatDateFromTs} from "../../utils/helpers.js";
+    import {buildWebIdUri, formatDateFromTs} from "../../utils/helpers.js";
 
     export let t;
     export let user = {};
@@ -90,8 +90,8 @@
         <div class={classRow}>
             <div class={classLabel}><b>WebID:</b></div>
             <span class="value">
-                <a href={buidlWebIdUri(user.id)} target="_blank">
-                    {@html buidlWebIdUri(user.id).replace('/auth/', '/auth/<wbr/>')}
+                <a href={buildWebIdUri(user.id)} target="_blank">
+                    {@html buildWebIdUri(user.id).replace('/auth/', '/auth/<wbr/>')}
                 </a>
             </span>
         </div>

--- a/frontend/src/components/account/AccWebId.svelte
+++ b/frontend/src/components/account/AccWebId.svelte
@@ -3,7 +3,7 @@
     import {fade, slide} from 'svelte/transition';
     import {putUserWebIdData} from "../../utils/dataFetching.js";
     import Switch from "$lib/Switch.svelte";
-    import {buidlWebIdUri} from "../../utils/helpers.js";
+    import {buildWebIdUri} from "../../utils/helpers.js";
 
     export let t;
     export let webIdData;
@@ -13,7 +13,7 @@
     let err = '';
     let success = false;
     let expertMode = !!webIdData.custom_triples;
-    let webIdLink = buidlWebIdUri(webIdData.user_id);
+    let webIdLink = buildWebIdUri(webIdData.user_id);
 
     // do not set any value here - will be bound to validate function in <AccWebIdEntries/>
     let getData;

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -12,7 +12,7 @@ import {
 } from "./constants.js";
 import { decode, encode } from "base64-arraybuffer";
 
-export function buidlWebIdUri(userId) {
+export function buildWebIdUri(userId) {
 	return `${window.location.origin}/auth/${userId}/profile#me`
 }
 

--- a/rauthy-handlers/src/oidc.rs
+++ b/rauthy-handlers/src/oidc.rs
@@ -1,13 +1,9 @@
-use std::ops::Add;
-use std::time::{SystemTime, UNIX_EPOCH};
-
+use crate::{map_auth_step, real_ip_from_req, ReqPrincipal};
 use actix_web::cookie::time::OffsetDateTime;
 use actix_web::http::header::{HeaderValue, CONTENT_TYPE};
 use actix_web::http::{header, StatusCode};
 use actix_web::{get, post, web, HttpRequest, HttpResponse, HttpResponseBuilder, ResponseError};
 use chrono::Utc;
-use tracing::debug;
-
 use rauthy_common::constants::{APPLICATION_JSON, COOKIE_MFA, HEADER_HTML, SESSION_LIFETIME};
 use rauthy_common::error_response::ErrorResponse;
 use rauthy_models::app_state::AppState;
@@ -29,8 +25,9 @@ use rauthy_models::templates::{
 };
 use rauthy_models::JwtCommonClaims;
 use rauthy_service::auth;
-
-use crate::{map_auth_step, real_ip_from_req, ReqPrincipal};
+use std::ops::Add;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::debug;
 
 /// OIDC Authorization HTML
 ///

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -171,6 +171,7 @@ pub struct JwtIdClaims {
     pub azp: String,
     pub typ: JwtTokenType,
     pub amr: Vec<String>,
+    pub auth_time: i64,
     pub preferred_username: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -87,7 +87,8 @@ pub struct AuthRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "RE_ALNUM", code = "[a-zA-Z0-9]"))]
     pub code_challenge_method: Option<String>,
-    pub max_age: Option<u64>,
+    #[validate(range(min = 0))]
+    pub max_age: Option<i64>,
 }
 
 #[derive(Debug, Deserialize, Validate, ToSchema)]

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -87,6 +87,7 @@ pub struct AuthRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "RE_ALNUM", code = "[a-zA-Z0-9]"))]
     pub code_challenge_method: Option<String>,
+    pub max_age: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Validate, ToSchema)]


### PR DESCRIPTION
This PR will make Rauthy respect `max_age` during the GET `/authorize` and it will add `auth_time` to the ID token.

The `auth_time` might be slightly off in certainc cases at this moment. To get it 100% right, Rauthy would need another DB migration. This will however not be implemented now, because I would be forced to release a new minor version just because of this small thing.  
Everything is there and working and the accuracy of the `auth_time` will be improved with a future PR.