### PR TITLE
Skip 2nd, unnecessary `redirect_uri` check 

### DIFF
--- a/dev_notes.md
+++ b/dev_notes.md
@@ -2,13 +2,6 @@
 
 ## CURRENT WORK
 
-## TODO leftover mandatory to implement features for OIDC compliance
-
-https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation -> 15.1
-These are mandatory and will come with the next PR's.
-
-- double check `redirect_uri` during final token request with auth code
-
 ## TODO next features
 
 - respect `login_hint` in the authorize ui


### PR DESCRIPTION
This PR completes the leftover mandatory implementations to be compliant with the OIDC core spec.  
There are only two notes:

1. Not all `prompt` params are implemented. `none` and `login` work like expected. I am unsure, if I want to implement `consent` later on at all, because it does not make too much sense to me in case of Rauthy.  
Rauthys only purpose is to identify and authorize users. If you don't want a downstream application to have any additional information about you, then just don't fill out the optional fields.  
If for instance Github is your auth provider, then this is a whole different story. You provide a lot more information to Github than you would ever want a 3rd party client to get. In this case, a (selective) consent makes sense, so you know which data will be shared.  
Usually, these consent windows are just annoying, because everyone just accepts it, otherwise access would be rejected. One of the best examples are cookie consents. They are just annoying and provide a horrible UX. 99% of users just accept them and the 1% that cares, is blocking tracking cookies and stuff via browser extensions anyway.  
The only mandatory consent is `none`, the others are optional. `login` makes sense, the others not really in this case imho.
2. By RFC, you must check, request and re-validate the `redirect_uri` a 2nd time during `code` flow when the Ressource Owner requests the code on the final `/token` endpoint. The reason is, that the spec allows the `redirect_uri` to be optional in some cases when the client application makes the initial GET `/authorize`. If an attacker would be able to simply trick a user into being redirected to a URI under his control, this would be a security leak. Technically, the attacker would know the original parameter as well and could obtain a token anyway in that scenario.  
With Rauthy, this is impossible in the first place. The `redirect_uri` parameter is mandatory in the client config, no matter if it is confidential or public. The URI is carefully validated and checked before the user would even see the login form. It is therefore not possible to redirect to a malicious URI because of an optional value. This additional check is skipped, because all other parameters are already safely validated during the final token request.