### PR TITLE
respect `login_hint` during authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,13 @@ There is a whole new section in the config:
 #DYN_CLIENT_RATE_LIMIT_SEC=60
 ```
 
+#### Better UX with respecting `login_hint`
+
+This is a small UX improvement in some situations. If a downstream client needs a user to log in, and it knows
+the users E-Mail address somehow, maybe because of an external initial registration, It may append the correct
+value with appending the `login_hint` to the login redirect. If this is present, the login UI will pre-fill the
+E-Mail input field with the given value, which make it one less step for the user to log in.
+
 ### Changes
 
 - The `/userinfo` endpoint now correctly respects the `scope` claim from withing the given `Bearer` token
@@ -132,6 +139,8 @@ introduced with v0.20
 - Implement OpenID Connect Dynamic Client Registration
 [b48552e](https://github.com/sebadob/rauthy/commit/b48552e79f2a3aca0c5cefcc25ef7d9f7c21c6d4)
 [12179c9](https://github.com/sebadob/rauthy/commit/12179c9898126e5e78a80a3b49df6ca5a501ff81)
+- respect `login_hint` during GET `/authorize`
+[]()
 
 ### Bugfixes
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -4,10 +4,6 @@
 
 ## TODO next
 
-- respect `login_hint` in the authorize ui
-- add `at_hash` claim to the ID token
-- respect `request_uri` during auth
-- fix broken link build in Admin UI if a new version is available
 
 ## Stage 1 - essentials
 
@@ -15,6 +11,7 @@
 
 ## Stage 2 - features - do before v1.0.0
 
+- add `at_hash` claim to the ID token
 - impl oidc metadata `check_session_iframe` ?
 - remove `offline_access` everywhere, because its overhead to manage and not really beneficial with webauthn?
 - admin ui: template button for client branding: default-light + default-dark ?

--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -39,7 +39,6 @@
 
     let isLoading = false;
     let err = '';
-    let isReady = false;
     let needsPassword = false;
     let clientMfaForce = false;
     let showReset = false;
@@ -116,7 +115,9 @@
         challenge = params.code_challenge;
         challengeMethod = params.code_challenge_method;
 
-        isReady = true
+        if (params.login_hint) {
+            formValues.email = params.login_hint;
+        }
     })
 
     async function fetchClientLogo(id) {


### PR DESCRIPTION
If the user does not already have a valid session, a downstream client can improve the login flow, if it knows the username / email from some other source.  
In this case, it may append `login_hint` to the params. This will be respected by the Rauthy UI and the given value will pre-fill the E-Mail input field. This way, the user needs to do one less step for the login.