### PR TITLE
Fix access token sub claim

### DIFF
--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -153,7 +153,8 @@ pub struct JwtAccessClaims {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_origins: Option<Vec<String>>,
     // user part
-    pub uid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_username: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This fixes #263

The `sub` claim in the access token was mapped to the users email address, which was not correct. The `sub` from access and id token must be the same. The `sub` in both tokens contains the user ID, which is 100% stable, because the email might change over time.

The `uid` claim from the access token has been dropped, because the `sub` now contains this very value.

The access token has a new optional `email` claim, which will contain the users email, or the "old" `sub` value. This just makes a lot of sense to have it in the access token too, because it is needed in a lot of applications. The `email` however will only be present, if it has been requested by the scope and if the login flow is not `client_credentials`.