### PR TITLE
Host `.well-known` additionally on root `/`

### DIFF
--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -428,6 +428,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                     .add(("pragma", "no-cache")),
             )
             .wrap(pub_metrics.clone())
+            .service(oidc::get_well_known)
             .service(generic::redirect)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first


### PR DESCRIPTION
This hosts the `.well-known/openid-configuration` on the root path additionally.  
Actually, this is the "wrong" spot, because this should always exists at `<issuer_url>/.well-known/openid-configuration`.
But this is an additional host, which then redirects to all the correct locations.  
This should make it possible, that even when someone is not providing the correct issuer for downstream client auto-configurations, that it should still work and basically fix the users issue.