### PR TITLE
bug: wrong default path to DEV TLS certs inside container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG DB
 
 USER 10001:10001
 
-WORKDIR /app
+#WORKDIR /app
 
 COPY --chown=10001:10001 /out/rauthy-"$DB"-"$TARGETARCH" ./rauthy
 COPY --chown=10001:10001 --from=builderBackend /work/data ./data

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG DB
 
 USER 10001:10001
 
-#WORKDIR /app
+WORKDIR /app
 
 COPY --chown=10001:10001 /out/rauthy-"$DB"-"$TARGETARCH" ./rauthy
 COPY --chown=10001:10001 --from=builderBackend /work/data ./data

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -18,8 +18,7 @@
     -> may cause an extraction error in the UI, because no error body is being returned
 
 - BUG: wrong path in the default Dockerfile which points to the DEV TLS certificates
-  -> Should work fine when we just get rid of the `/app` path in the Dockerfile -> test!
-  -> Fix to `Dockerfile` has been done - check with next nightly release
+  -> Fix has been pushed - test and validate with next nightly or beta image build
 - make it possible to define a custom header to extract peer IP's (e.g. CDN headers)
 - BUG: when webauthn key in `../finish` is not accepted -> HTTP 401 -> no error message -> improve UX in UI
 - improve the book with all the new features

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -8,7 +8,7 @@
 
 ## Stage 2 - features - do before v1.0.0
 
-- BUG with Bitwarden Passkey implementation:
+- BUG with Bitwarden Passkey implementation - app bug and Rauthy cannot do anythign about it? -> investigate:
 
 ```
 2024-03-21T09:56:04.903993Z ERROR webauthn_rs_core::core: Credential indicates it is backed up, but has not declared valid backup elligibility
@@ -17,12 +17,9 @@
 
     -> may cause an extraction error in the UI, because no error body is being returned
 
-- UI: client cannot be saved multiple times after saving without reloading -> locked somewhere
-
-+ client name input can contain `undefined` after modifying when it was left empty
-
 - BUG: wrong path in the default Dockerfile which points to the DEV TLS certificates
   -> Should work fine when we just get rid of the `/app` path in the Dockerfile -> test!
+  -> Fix to `Dockerfile` has been done - check with next nightly release
 - make it possible to define a custom header to extract peer IP's (e.g. CDN headers)
 - BUG: when webauthn key in `../finish` is not accepted -> HTTP 401 -> no error message -> improve UX in UI
 - improve the book with all the new features

--- a/rauthy.deploy.cfg
+++ b/rauthy.deploy.cfg
@@ -256,3 +256,42 @@ WEBAUTHN_RENEW_EXP=2160
 # Be careful with this option, since Android and some special combinations of OS + browser to not support UV yet.
 # (default: false)
 #WEBAUTHN_FORCE_UV=false
+
+#####################################
+############### TLS #################
+#####################################
+
+## Rauthy TLS
+
+# Overwrite the path to the TLS certificate file in PEM format for rauthy (default: tls/tls.crt)
+TLS_CERT=/app/tls/cert-chain.pem
+# Overwrite the path to the TLS private key file in PEM format for rauthy.
+# If the path / filename ends with '.der', rauthy will parse it as DER, otherwise as PEM.
+# (default: tls/tls.key)
+TLS_KEY=/app/tls/key.pem
+
+## CACHE TLS
+
+# Enable / disable TLS for the cache communication (default: true)
+CACHE_TLS=true
+
+# The path to the server TLS certificate PEM file
+# default: tls/redhac.cert-chain.pem
+CACHE_TLS_SERVER_CERT=/app/tls/cert-chain.pem
+# The path to the server TLS key PEM file
+# default: tls/redhac.key.pem
+CACHE_TLS_SERVER_KEY=/app/tls/key.pem
+
+# The path to the client mTLS certificate PEM file. This is optional.
+CACHE_TLS_CLIENT_CERT=/app/tls/cert-chain.pem
+# The path to the client mTLS key PEM file. This is optional.
+CACHE_TLS_CLIENT_KEY=/app/tls/key.pem
+
+# If not empty, the PEM file from the specified location will be
+# added as the CA certificate chain for validating
+# the servers TLS certificate. This is optional.
+CACHE_TLS_CA_SERVER=/app/tls/ca-chain.pem
+# If not empty, the PEM file from the specified location will
+# be added as the CA certificate chain for validating
+# the clients mTLS certificate. This is optional.
+CACHE_TLS_CA_CLIENT=/app/tls/ca-chain.pem


### PR DESCRIPTION
This fixes a bug (will be tested and validated with the next nightly / beta build) with the default path to the DEV TLS certificates for testing inside the container image. This basically moves the `WORKDIR` to `/` to match the default testing config. With this in place, it should be able to start Rauthy for testing with DEV TLS certificates without specifying the path to them manually.