### PR TITLE
catch flase impl of passkeys

### DIFF
--- a/frontend/src/utils/webauthn.js
+++ b/frontend/src/utils/webauthn.js
@@ -1,61 +1,66 @@
-import { webauthnAuthFinish, webauthnAuthStart } from "./dataFetching.js";
+import {webauthnAuthFinish, webauthnAuthStart} from "./dataFetching.js";
 import {arrBufToBase64UrlSafe, base64UrlSafeToArrBuf} from "./helpers.js";
 
 export async function webauthnAuth(uid, data, errorMsg) {
-	let res = await webauthnAuthStart(uid, data);
-	if (res.status === 200) {
-		let resp = await res.json();
-		let challenge = resp.rcr;
+    let res = await webauthnAuthStart(uid, data);
+    if (res.status === 200) {
+        let resp = await res.json();
+        let challenge = resp.rcr;
 
-		// the navigator credentials engine needs some values as array buffers
-		challenge.publicKey.challenge = base64UrlSafeToArrBuf(challenge.publicKey.challenge);
-		for (let cred of challenge.publicKey.allowCredentials) {
-			cred.id = base64UrlSafeToArrBuf(cred.id);
-		}
+        // the navigator credentials engine needs some values as array buffers
+        challenge.publicKey.challenge = base64UrlSafeToArrBuf(challenge.publicKey.challenge);
+        for (let cred of challenge.publicKey.allowCredentials) {
+            cred.id = base64UrlSafeToArrBuf(cred.id);
+        }
 
-		// prompt for the user security key and get its public key
-		let challengePk
-		try {
-			challengePk = await navigator.credentials.get(challenge);
-		} catch (e) {
-			console.error(e);
-			return {
-				err: true,
-				msg: errorMsg || 'Invalid Key',
-			};
-		}
+        // prompt for the user security key and get its public key
+        let challengePk
+        try {
+            challengePk = await navigator.credentials.get(challenge);
+        } catch (e) {
+            console.error(e);
+            return {
+                err: true,
+                msg: errorMsg || 'Invalid Key',
+            };
+        }
 
-		// the backend expects base64 url safe string instead of array buffers
-		let data = {
-			code: resp.code,
-			data: {
-				id: challengePk.id,
-				rawId: arrBufToBase64UrlSafe(challengePk.rawId),
-				response: {
-					authenticatorData: arrBufToBase64UrlSafe(challengePk.response.authenticatorData),
-					clientDataJSON: arrBufToBase64UrlSafe(challengePk.response.clientDataJSON),
-					signature: arrBufToBase64UrlSafe(challengePk.response.signature),
-				},
-				type: challengePk.type,
-			}
-		}
+        // the backend expects base64 url safe string instead of array buffers
+        let data = {
+            code: resp.code,
+            data: {
+                id: challengePk.id,
+                rawId: arrBufToBase64UrlSafe(challengePk.rawId),
+                response: {
+                    authenticatorData: arrBufToBase64UrlSafe(challengePk.response.authenticatorData),
+                    clientDataJSON: arrBufToBase64UrlSafe(challengePk.response.clientDataJSON),
+                    signature: arrBufToBase64UrlSafe(challengePk.response.signature),
+                },
+                type: challengePk.type,
+            }
+        }
 
-		// send the data to the backend
-		res = await webauthnAuthFinish(uid, data);
-		if (res.status === 202) {
-			let body = await res.json();
-			return {
-				err: false,
-				msg: 'Authentication successful',
-				body,
-			};
-		} else {
-			console.error(res);
-		}
-	} else {
-		return {
-			err: true,
-			msg: 'Error starting the Authentication'
-		};
-	}
+        // send the data to the backend
+        res = await webauthnAuthFinish(uid, data);
+        if (res.status === 202) {
+            let body = await res.json();
+            return {
+                err: false,
+                msg: 'Authentication successful',
+                body,
+            };
+        } else {
+            console.error(res);
+            return {
+                err: true,
+                msg: 'Authentication Error',
+            };
+        }
+    } else {
+        console.error(res);
+        return {
+            err: true,
+            msg: 'Error starting the Authentication'
+        };
+    }
 }


### PR DESCRIPTION
An earlier version of the Bitwarden passkey implementation seems to have had an error and not populate values correctly.
This could lead to Rauthy complaining and returning an error, because the implementation was not correctly done.
This never seen before case could lead the UI to get stuck and not show an error because of a missing error body.

I cannot reproduce the error, but I added additional catches in the UI which should cases like this in the future and return to the default view showing an error.