### PR TITLE
Feat: Add `ClaimMapping`

### DIFF
--- a/rauthy-client/examples/axum/src/main.rs
+++ b/rauthy-client/examples/axum/src/main.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use axum::routing::get;
 use axum::Router;
-use rauthy_client::oidc_config::{JwtClaim, JwtClaimTyp, RauthyConfig};
+use rauthy_client::oidc_config::{ClaimMapping, JwtClaim, JwtClaimTyp, RauthyConfig};
 use rauthy_client::provider::OidcProvider;
 use rauthy_client::{DangerAcceptInvalidCerts, RauthyHttpsOnly};
 use std::collections::HashSet;
@@ -28,19 +28,19 @@ async fn main() -> anyhow::Result<()> {
     rauthy_client::init(None, RauthyHttpsOnly::No, DangerAcceptInvalidCerts::Yes).await?;
 
     let config = RauthyConfig {
-        // If this is Some(_), the principal will have a .is_admin field being set correctly, if
-        // this claim matches.
-        admin_claim: Some(JwtClaim {
+        // Sets the .is_admin field for the principal based on the `ClaimMapping`.
+        admin_claim: ClaimMapping::Or(vec![JwtClaim {
             typ: JwtClaimTyp::Roles,
             value: "admin".to_string(),
-        }),
-        // This claim must always exist for every single user. Without this claim, a user would
-        // not have access to this app. This is used, because usually you never want to just have
-        // all your OIDC users to have access to a certain application.
-        user_claim: JwtClaim {
+        }]),
+        // Sets the .is_user field for the principal based on the `ClaimMapping`.
+        // Without this claim, a user would not have access to this app. This is
+        // used, because usually you never want to just have all your OIDC users to
+        // have access to a certain application.
+        user_claim: ClaimMapping::Or(vec![JwtClaim {
             typ: JwtClaimTyp::Groups,
             value: "user".to_string(),
-        },
+        }]),
         // In almost all cases, this should just match the `client_id`
         allowed_audiences: HashSet::from(["dev-test".to_string()]),
         client_id: "dev-test".to_string(),

--- a/rauthy-client/examples/generic/src/main.rs
+++ b/rauthy-client/examples/generic/src/main.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use actix_web::{web::Data, App, HttpServer};
-use rauthy_client::oidc_config::{JwtClaim, JwtClaimTyp, RauthyConfig};
+use rauthy_client::oidc_config::{ClaimMapping, JwtClaim, JwtClaimTyp, RauthyConfig};
 use rauthy_client::provider::OidcProvider;
 use rauthy_client::{DangerAcceptInvalidCerts, RauthyHttpsOnly};
 use std::collections::HashSet;
@@ -27,19 +27,19 @@ async fn main() -> anyhow::Result<()> {
     rauthy_client::init(None, RauthyHttpsOnly::No, DangerAcceptInvalidCerts::Yes).await?;
 
     let config = RauthyConfig {
-        // If this is Some(_), the principal will have a .is_admin field being set correctly, if
-        // this claim matches.
-        admin_claim: Some(JwtClaim {
+        // Sets the .is_admin field for the principal based on the `ClaimMapping`.
+        admin_claim: ClaimMapping::Or(vec![JwtClaim {
             typ: JwtClaimTyp::Roles,
             value: "admin".to_string(),
-        }),
-        // This claim must always exist for every single user. Without this claim, a user would
-        // not have access to this app. This is used, because usually you never want to just have
-        // all your OIDC users to have access to a certain application.
-        user_claim: JwtClaim {
+        }]),
+        // Sets the .is_user field for the principal based on the `ClaimMapping`.
+        // Without this claim, a user would not have access to this app. This is
+        // used, because usually you never want to just have all your OIDC users to
+        // have access to a certain application.
+        user_claim: ClaimMapping::Or(vec![JwtClaim {
             typ: JwtClaimTyp::Groups,
             value: "user".to_string(),
-        },
+        }]),
         // In almost all cases, this should just match the `client_id`
         allowed_audiences: HashSet::from(["dev-test".to_string()]),
         client_id: "dev-test".to_string(),

--- a/rauthy-client/src/oidc_config.rs
+++ b/rauthy-client/src/oidc_config.rs
@@ -4,13 +4,13 @@ use std::collections::HashSet;
 /// The configuration for the Rauthy setup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RauthyConfig {
-    /// If this is Some(_), the principal will have a .is_admin field being set correctly, if
-    /// this claim matches.
-    pub admin_claim: Option<JwtClaim>,
-    /// This claim must always exist for every single user. Without this claim, a user would
-    /// not have access to this app. This is used, because usually you never want to just have
-    /// all your OIDC users to have access to a certain application.
-    pub user_claim: JwtClaim,
+    /// Sets the .is_admin field for the principal based on the `ClaimMapping`.
+    pub admin_claim: ClaimMapping,
+    /// Sets the .is_user field for the principal based on the `ClaimMapping`.
+    /// Without this claim, a user would not have access to this app. This is
+    /// used, because usually you never want to just have all your OIDC users to
+    /// have access to a certain application.
+    pub user_claim: ClaimMapping,
     /// In almost all cases, this should just match the `client_id`
     pub allowed_audiences: HashSet<String>,
     /// the `client_id` from Rauthy
@@ -27,10 +27,47 @@ pub struct RauthyConfig {
     pub secret: Option<String>,
 }
 
+/// The claim selector which decides how a claim should be evaluated, based on the roles and groups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ClaimMapping {
+    /// It doesn't matter which role or group a user have, it returns always `true`.
+    Any,
+    /// Return true if one of the `JwtClaim` is in the role or group, based on the `JwtClaimTyp`.
+    Or(Vec<JwtClaim>),
+    /// Return true if all of the `JwtClaim` is in the role or group, based on the `JwtClaimTyp`.
+    And(Vec<JwtClaim>),
+    /// It doesn't matter which role or group a user have, it returns always `false`.
+    None,
+}
+
+impl ClaimMapping {
+    pub fn matches(&self, roles: &Vec<String>, groups: &Vec<String>) -> bool {
+        match self {
+            ClaimMapping::Any => true,
+            ClaimMapping::Or(claims) => {
+                claims.into_iter().any(|claim| claim.matches(roles, groups))
+            }
+            ClaimMapping::And(claims) => {
+                claims.into_iter().all(|claim| claim.matches(roles, groups))
+            }
+            ClaimMapping::None => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JwtClaim {
     pub typ: JwtClaimTyp,
     pub value: String,
+}
+
+impl JwtClaim {
+    pub fn matches(&self, roles: &Vec<String>, groups: &Vec<String>) -> bool {
+        match &self.typ {
+            JwtClaimTyp::Roles => roles.contains(&self.value),
+            JwtClaimTyp::Groups => groups.contains(&self.value),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rauthy-client/src/principal/mod.rs
+++ b/rauthy-client/src/principal/mod.rs
@@ -1,4 +1,3 @@
-use crate::oidc_config::JwtClaimTyp;
 use crate::provider::OidcProvider;
 use crate::token_set::JwtAccessClaims;
 use std::collections::HashMap;
@@ -47,18 +46,8 @@ impl PrincipalOidc {
         let roles = claims.roles.unwrap_or_default();
         let groups = claims.groups.unwrap_or_default();
 
-        let is_admin = if let Some(claim) = &config.admin_claim {
-            match claim.typ {
-                JwtClaimTyp::Roles => roles.contains(&claim.value),
-                JwtClaimTyp::Groups => groups.contains(&claim.value),
-            }
-        } else {
-            false
-        };
-        let is_user = match config.user_claim.typ {
-            JwtClaimTyp::Roles => roles.contains(&config.user_claim.value),
-            JwtClaimTyp::Groups => groups.contains(&config.user_claim.value),
-        };
+        let is_admin = config.admin_claim.matches(&roles, &groups);
+        let is_user = config.user_claim.matches(&roles, &groups);
 
         Ok(Self {
             id,

--- a/rauthy-client/src/provider.rs
+++ b/rauthy-client/src/provider.rs
@@ -1,5 +1,5 @@
 use crate::jwks::JwksMsg;
-use crate::oidc_config::{JwtClaim, RauthyConfig};
+use crate::oidc_config::{ClaimMapping, RauthyConfig};
 use crate::{DangerAcceptInvalidCerts, RauthyHttpsOnly, VERSION};
 use jwt_simple::common::VerificationOptions;
 use serde::{Deserialize, Serialize};
@@ -18,8 +18,8 @@ pub(crate) struct OidcProviderConfig {
     pub provider: OidcProvider,
     pub redirect_uri: String,
     pub secret: Option<String>,
-    pub admin_claim: Option<JwtClaim>,
-    pub user_claim: JwtClaim,
+    pub admin_claim: ClaimMapping,
+    pub user_claim: ClaimMapping,
     pub verification_options: VerificationOptions,
 }
 
@@ -33,8 +33,8 @@ impl OidcProviderConfig {
         allowed_audiences: HashSet<String>,
         email_verified: bool,
         secret: Option<String>,
-        admin_claim: Option<JwtClaim>,
-        user_claim: JwtClaim,
+        admin_claim: ClaimMapping,
+        user_claim: ClaimMapping,
     ) -> anyhow::Result<Self> {
         let append = if iss.ends_with('/') {
             ".well-known/openid-configuration"


### PR DESCRIPTION
This adds the ability to choose between `any`, `or`, `and` and `none` `JwtClaims`. This is helpful to set the `.is_admin` and `.is_user` field more flexibly.