### PR TITLE
DX: try to improve LSP freak out in clean environments

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,10 +1,8 @@
 set shell := ["bash", "-uc"]
 
 export TAG := `cat Cargo.toml | grep '^version =' | cut -d " " -f3 | xargs`
-
-db_url_sqlite := "sqlite:data/rauthy.db"
-db_url_sqlite_mem := "sqlite::memory"
-db_url_postgres := "postgresql://rauthy:123SuperSafe@localhost:5432/rauthy"
+export DB_URL_SQLITE := `cat rauthy.cfg | grep ^DATABASE_URL= | cut -d'=' -f2`
+export DB_URL_POSTGRES := `cat rauthy.cfg | grep ^DATABASE_URL_POSTGRES= | cut -d'=' -f2`
 
 test_pid_file := ".test_pid"
 
@@ -95,44 +93,57 @@ pull-latest-cross:
 
 # clippy with sqlite features
 clippy:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
     clear
-    DATABASE_URL={{db_url_sqlite}} cargo clippy --features sqlite
+    cargo clippy --features sqlite
 
 
 # clippy with postgres features
 clippy-postgres:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
     clear
-    DATABASE_URL={{db_url_postgres}} cargo clippy
+    DATABASE_URL=$DB_URL_POSTGRES cargo clippy
 
 
 # re-create and migrate the sqlite database with sqlx
 migrate:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
     mkdir -p data/
     rm -f data/rauthy.db*
-    DATABASE_URL={{db_url_sqlite}} sqlx database create
-    DATABASE_URL={{db_url_sqlite}} sqlx migrate run --source migrations/sqlite
+    DATABASE_URL=$DB_URL_SQLITE sqlx database create
+    DATABASE_URL=$DB_URL_SQLITE sqlx migrate run --source migrations/sqlite
 
 
 # migrate the postgres database with sqlx
 migrate-postgres:
-    DATABASE_URL={{db_url_postgres}} sqlx migrate run --source migrations/postgres
-
-
-# runs the application with sqlite feature
-run:
-    DATABASE_URL={{db_url_sqlite}} cargo run --features sqlite
-
-
-# runs the application with postgres feature
-run-postgres:
-    DATABASE_URL={{db_url_postgres}} cargo run
-
-
-# runs the UI in development mode
-run-ui:
     #!/usr/bin/env bash
-    cd frontend
-    npm run dev -- --host
+    set -euxo pipefail
+
+    DATABASE_URL=$DB_URL_POSTGRES sqlx migrate run --source migrations/postgres
+
+
+# runs any of: none (sqlite), postgres, ui
+run ty="sqlite":
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    clear
+
+    if [[ {{ty}} == "postgres" ]]; then
+      DATABASE_URL=$DB_URL_POSTGRES cargo run
+    elif [[ {{ty}} == "ui" ]]; then
+      cd frontend
+      npm run dev -- --host
+    elif [[ {{ty}} == "sqlite" ]]; then
+      cargo run --features sqlite
+    else
+      echo "specifiy either nothing (sqlite), ui, por postgres"
+    fi
 
 
 # prints out the currently set version
@@ -143,12 +154,12 @@ version:
 
 # prepare DB migrations for SQLite for compile-time checked queries
 prepare: migrate
-    DATABASE_URL={{db_url_sqlite}} cargo sqlx prepare --workspace -- --features sqlite
+    cargo sqlx prepare --workspace -- --features sqlite
 
 
 # prepare DB migrations for Postgres for compile-time checked queries
 prepare-postgres: migrate-postgres
-    DATABASE_URL={{db_url_postgres}} cargo sqlx prepare --workspace
+    DATABASE_URL=$DB_URL_POSTGRES cargo sqlx prepare --workspace
 
 
 # only starts the backend in test mode with sqlite database for easier test debugging
@@ -157,8 +168,8 @@ test-backend: migrate prepare
     set -euxo pipefail
     clear
 
-    DATABASE_URL={{db_url_sqlite}} cargo build --features sqlite
-    DATABASE_URL={{db_url_sqlite}} ./target/debug/rauthy test
+    cargo build --features sqlite
+    ./target/debug/rauthy test
 
 
 # stops a possibly running test backend that may have spawned in the background for integration tests
@@ -181,7 +192,7 @@ test test="":
     set -euxo pipefail
     clear
 
-    DATABASE_URL={{db_url_sqlite}} cargo test --features sqlite {{test}}
+    cargo test --features sqlite {{test}}
 
 
 # runs the full set of tests with in-memory sqlite
@@ -190,8 +201,8 @@ test-full test="": test-backend-stop migrate prepare
     set -euxo pipefail
     clear
 
-    DATABASE_URL={{db_url_sqlite}} cargo build --features sqlite
-    DATABASE_URL={{db_url_sqlite}} ./target/debug/rauthy test &
+    cargo build --features sqlite
+    ./target/debug/rauthy test &
     #just migrate-sqlite && DATABASE_URL=sqlite:data/rauthy.db cargo run --features sqlite test
     #cargo test --features sqlite test_userinfo
     sleep 1
@@ -199,7 +210,7 @@ test-full test="": test-backend-stop migrate prepare
     echo $PID > {{test_pid_file}}
     echo "PID: $PID"
 
-    DATABASE_URL={{db_url_sqlite}} cargo test --features sqlite {{test}}
+    cargo test --features sqlite {{test}}
     kill "$PID"
     echo All tests successful
 
@@ -210,14 +221,14 @@ test-postgres test="": test-backend-stop migrate-postgres prepare-postgres
     set -euxo pipefail
     clear
 
-    DATABASE_URL={{db_url_postgres}} cargo build
-    DATABASE_URL={{db_url_postgres}} ./target/debug/rauthy test &
+    DATABASE_URL=$DB_URL_POSTGRES cargo build
+    DATABASE_URL=$DB_URL_POSTGRES ./target/debug/rauthy test &
     sleep 1
     PID=$(echo "$!")
     echo $PID > {{test_pid_file}}
     echo "PID: $PID"
 
-    DATABASE_URL={{db_url_postgres}} cargo test
+    DATABASE_URL=$DB_URL_POSTGRES cargo test
     kill "$PID"
     echo All tests successful
 

--- a/rauthy-main/Cargo.toml
+++ b/rauthy-main/Cargo.toml
@@ -6,7 +6,8 @@ authors.workspace = true
 license.workspace = true
 
 [features]
-sqlite = []
+default = []
+postgres = []
 
 [dependencies]
 actix-web = { workspace = true }

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -11,10 +11,10 @@ use rauthy_common::constants::{
     CACHE_NAME_12HR, CACHE_NAME_AUTH_CODES, CACHE_NAME_AUTH_PROVIDER_CALLBACK,
     CACHE_NAME_CLIENTS_DYN, CACHE_NAME_DPOP_NONCES, CACHE_NAME_EPHEMERAL_CLIENTS,
     CACHE_NAME_LOGIN_DELAY, CACHE_NAME_POW, CACHE_NAME_SESSIONS, CACHE_NAME_USERS,
-    CACHE_NAME_WEBAUTHN, CACHE_NAME_WEBAUTHN_DATA, DEV_MODE, DPOP_NONCE_EXP,
-    DYN_CLIENT_RATE_LIMIT_SEC, DYN_CLIENT_REG_TOKEN, ENABLE_DYN_CLIENT_REG, ENABLE_WEB_ID,
-    EPHEMERAL_CLIENTS_CACHE_LIFETIME, POW_EXP, RAUTHY_VERSION, SWAGGER_UI_EXTERNAL,
-    SWAGGER_UI_INTERNAL, UPSTREAM_AUTH_CALLBACK_TIMEOUT_SECS, WEBAUTHN_DATA_EXP, WEBAUTHN_REQ_EXP,
+    CACHE_NAME_WEBAUTHN, CACHE_NAME_WEBAUTHN_DATA, DPOP_NONCE_EXP, DYN_CLIENT_RATE_LIMIT_SEC,
+    DYN_CLIENT_REG_TOKEN, ENABLE_DYN_CLIENT_REG, ENABLE_WEB_ID, EPHEMERAL_CLIENTS_CACHE_LIFETIME,
+    POW_EXP, RAUTHY_VERSION, SWAGGER_UI_EXTERNAL, SWAGGER_UI_INTERNAL,
+    UPSTREAM_AUTH_CALLBACK_TIMEOUT_SECS, WEBAUTHN_DATA_EXP, WEBAUTHN_REQ_EXP,
 };
 use rauthy_common::password_hasher;
 use rauthy_handlers::middleware::ip_blacklist::RauthyIpBlacklistMiddleware;
@@ -82,9 +82,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     } else {
         dotenvy::from_filename("rauthy.cfg").expect("'rauthy.cfg' error");
         dotenvy::dotenv().ok();
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         {
-            if *DEV_MODE {
+            if *rauthy_common::constants::DEV_MODE {
                 // In this case, we want to set the `DATABASE_URL` programmatically.
                 // It seems a bit silly at first, but it makes it possible to have a
                 // default for SQLite in the config to not make the LSP freak out, while

--- a/rauthy-models/Cargo.toml
+++ b/rauthy-models/Cargo.toml
@@ -10,7 +10,8 @@ license.workspace = true
 doctest = false
 
 [features]
-sqlite = []
+default = []
+postgres = []
 
 [dependencies]
 accept-language = { workspace = true }

--- a/rauthy-models/src/app_state.rs
+++ b/rauthy-models/src/app_state.rs
@@ -24,14 +24,14 @@ use tracing::{debug, error, info, warn};
 use webauthn_rs::prelude::Url;
 use webauthn_rs::Webauthn;
 
-#[cfg(not(feature = "sqlite"))]
+#[cfg(feature = "postgres")]
 pub type DbPool = sqlx::PgPool;
-#[cfg(feature = "sqlite")]
+#[cfg(not(feature = "postgres"))]
 pub type DbPool = sqlx::SqlitePool;
 
-#[cfg(not(feature = "sqlite"))]
+#[cfg(feature = "postgres")]
 pub type DbTxn<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
-#[cfg(feature = "sqlite")]
+#[cfg(not(feature = "postgres"))]
 pub type DbTxn<'a> = sqlx::Transaction<'a, sqlx::Sqlite>;
 
 #[derive(Debug, Clone)]
@@ -196,7 +196,7 @@ impl AppState {
             .parse::<u32>()
             .expect("Error parsing DATABASE_MAX_CONN to u32");
 
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let pool = {
             if *DB_TYPE == DbType::Sqlite {
                 let msg = r#"
@@ -216,7 +216,7 @@ impl AppState {
             pool
         };
 
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let pool = {
             if *DB_TYPE == DbType::Postgres {
                 let msg = r#"

--- a/rauthy-models/src/entity/app_version.rs
+++ b/rauthy-models/src/entity/app_version.rs
@@ -76,12 +76,12 @@ impl LatestAppVersion {
         };
         let data = bincode::serialize(&slf)?;
 
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = query!(
             "insert or replace into config (id, data) values ('latest_version', $1)",
             data,
         );
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = query!(
             r#"insert into config (id, data) values ('latest_version', $1)
             on conflict(id) do update set data = $1"#,

--- a/rauthy-models/src/entity/colors.rs
+++ b/rauthy-models/src/entity/colors.rs
@@ -79,13 +79,13 @@ impl ColorEntity {
         let cols = Colors::from(req);
         let col_bytes = cols.as_bytes();
 
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = sqlx::query!(
             "insert or replace into colors (client_id, data) values ($1, $2)",
             client_id,
             col_bytes,
         );
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = sqlx::query!(
             r#"insert into colors (client_id, data) values ($1, $2)
                 on conflict(client_id) do update set data = $2"#,

--- a/rauthy-models/src/entity/db_version.rs
+++ b/rauthy-models/src/entity/db_version.rs
@@ -37,12 +37,12 @@ impl DbVersion {
             };
             let data = bincode::serialize(&slf)?;
 
-            #[cfg(feature = "sqlite")]
+            #[cfg(not(feature = "postgres"))]
             let q = query!(
                 "insert or replace into config (id, data) values ('db_version', $1)",
                 data,
             );
-            #[cfg(not(feature = "sqlite"))]
+            #[cfg(feature = "postgres")]
             let q = query!(
                 r#"insert into config (id, data) values ('db_version', $1)
                 on conflict(id) do update set data = $1"#,
@@ -132,12 +132,12 @@ impl DbVersion {
         // which is already checked above
 
         // the passkeys table was introduced with v0.15.0
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let is_db_v0_15_0 = query!("select * from pg_tables where tablename = 'passkeys' limit 1")
             .fetch_one(db)
             .await
             .is_err();
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let is_db_v0_15_0 = query!(
             "select * from sqlite_master where type = 'table' and name = 'passkeys' limit 1"
         )
@@ -153,13 +153,13 @@ impl DbVersion {
 
         // To check for any DB older than 0.15.0, we check for the existence of the 'clients' table
         // which is there since the very beginning.
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let is_db_pre_v0_15_0 =
             query!("select * from pg_tables where tablename = 'clients' limit 1")
                 .fetch_one(db)
                 .await
                 .is_err();
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let is_db_pre_v0_15_0 =
             query!("select * from sqlite_master where type = 'table' and name = 'clients' limit 1")
                 .fetch_one(db)

--- a/rauthy-models/src/entity/logos.rs
+++ b/rauthy-models/src/entity/logos.rs
@@ -289,7 +289,7 @@ impl Logo {
         let res = self.res.as_str();
 
         // SVGs don't have a resolution -> just save one version
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         match typ {
             LogoType::Client => {
                 query!(
@@ -317,7 +317,7 @@ impl Logo {
         .execute(&data.db)
         .await?;
 
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         match typ {
             LogoType::Client => {
                 query!(

--- a/rauthy-models/src/entity/refresh_tokens.rs
+++ b/rauthy-models/src/entity/refresh_tokens.rs
@@ -101,7 +101,7 @@ impl RefreshToken {
     }
 
     pub async fn save(&self, data: &web::Data<AppState>) -> Result<(), ErrorResponse> {
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = sqlx::query!(
             r#"insert or replace into refresh_tokens (id, user_id, nbf, exp, scope, is_mfa)
                 values ($1, $2, $3, $4, $5, $6)"#,
@@ -112,7 +112,7 @@ impl RefreshToken {
             self.scope,
             self.is_mfa,
         );
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = sqlx::query!(
             r#"insert into refresh_tokens (id, user_id, nbf, exp, scope, is_mfa)
                 values ($1, $2, $3, $4, $5, $6)

--- a/rauthy-models/src/entity/sessions.rs
+++ b/rauthy-models/src/entity/sessions.rs
@@ -242,7 +242,7 @@ impl Session {
     pub async fn save(&self, data: &web::Data<AppState>) -> Result<(), ErrorResponse> {
         let state_str = self.state.as_str();
 
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = sqlx::query!(
             r#"insert or replace into
             sessions (id, csrf_token, user_id, roles, groups, is_mfa, state, exp, last_seen, remote_ip)
@@ -259,7 +259,7 @@ impl Session {
             self.remote_ip,
         );
 
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = sqlx::query!(
             r#"insert into
             sessions (id, csrf_token, user_id, roles, groups, is_mfa, state, exp, last_seen, remote_ip)

--- a/rauthy-models/src/entity/user_attr.rs
+++ b/rauthy-models/src/entity/user_attr.rs
@@ -35,14 +35,14 @@ impl UserAttrConfigEntity {
             ));
         }
 
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = sqlx::query!(
             "insert into user_attr_config (name, desc) values ($1, $2)",
             new_attr.name,
             new_attr.desc,
         );
 
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = sqlx::query!(
             "insert into user_attr_config (name, \"desc\") values ($1, $2)",
             new_attr.name,
@@ -243,7 +243,7 @@ impl UserAttrConfigEntity {
 
         let mut txn = data.db.begin().await?;
 
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = sqlx::query!(
             "update user_attr_config set name  = $1, desc = $2 where name = $3",
             slf.name,
@@ -251,7 +251,7 @@ impl UserAttrConfigEntity {
             name,
         );
 
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = sqlx::query!(
             "update user_attr_config set name  = $1, \"desc\" = $2 where name = $3",
             slf.name,
@@ -470,7 +470,7 @@ impl UserAttrValueEntity {
             } else {
                 let v = serde_json::to_vec(&value.value).unwrap();
 
-                #[cfg(feature = "sqlite")]
+                #[cfg(not(feature = "postgres"))]
                 let q = sqlx::query!(
                     r#"insert or replace into user_attr_values (user_id, key, value)
                     values ($1, $2, $3)"#,
@@ -479,7 +479,7 @@ impl UserAttrValueEntity {
                     v,
                 );
 
-                #[cfg(not(feature = "sqlite"))]
+                #[cfg(feature = "postgres")]
                 let q = sqlx::query!(
                     r#"insert into user_attr_values (user_id, key, value)
                     values ($1, $2, $3)

--- a/rauthy-models/src/entity/users_values.rs
+++ b/rauthy-models/src/entity/users_values.rs
@@ -58,7 +58,7 @@ impl UserValues {
         user_id: String,
         values: UserValuesRequest,
     ) -> Result<Option<Self>, ErrorResponse> {
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = sqlx::query!(
             r#"INSERT OR REPLACE INTO
                 users_values (id, birthdate, phone, street, zip, city, country)
@@ -71,7 +71,7 @@ impl UserValues {
             values.city,
             values.country,
         );
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = sqlx::query!(
             r#"INSERT INTO
                 users_values (id, birthdate, phone, street, zip, city, country)

--- a/rauthy-models/src/entity/webids.rs
+++ b/rauthy-models/src/entity/webids.rs
@@ -71,14 +71,14 @@ impl WebId {
     }
 
     pub async fn upsert(data: &web::Data<AppState>, web_id: WebId) -> Result<(), ErrorResponse> {
-        #[cfg(feature = "sqlite")]
+        #[cfg(not(feature = "postgres"))]
         let q = query!(
             "INSERT OR REPLACE INTO webids (user_id, custom_triples, expose_email) VALUES ($1, $2, $3)",
             web_id.user_id,
             web_id.custom_triples,
             web_id.expose_email,
         );
-        #[cfg(not(feature = "sqlite"))]
+        #[cfg(feature = "postgres")]
         let q = query!(
             r#"INSERT INTO webids (user_id, custom_triples, expose_email) VALUES ($1, $2, $3)
             ON CONFLICT(user_id) DO UPDATE SET custom_triples = $2, expose_email = $3"#,

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -214,8 +214,8 @@ CACHE_RECONNECT_TIMEOUT_UPPER=5000
 # schema: rauthy with owner rauthy
 #
 #DATABASE_URL=sqlite::memory:
-#DATABASE_URL=sqlite:data/rauthy.db
-#DATABASE_URL=postgresql://postgres:123SuperSafe@localhost:5432/rauthy
+DATABASE_URL=sqlite:data/rauthy.db
+DATABASE_URL_POSTGRES=postgresql://postgres:123SuperSafe@localhost:5432/rauthy
 
 # Max DB connections - irrelevant for SQLite (default: 5)
 #DATABASE_MAX_CONN=5


### PR DESCRIPTION
This PR is about trying to not make the LSP freak out in clean environments.
This should make it easier for new contributors to get into the project.

We cannot simply set `DATABASE_URL` for instance for sqlx compile time checked queries, because we cannot use the `Any` driver. However, to be able to easily switch between databases in dev without the need to modify the config each time, `just` has been providing this information until now.  
This works fine, but it makes the rust LSP freak out each time in environments, where you cannot set vars without interfering with the default setup.

This PR is about exploring solutions to make getting into the project smoother for new contributors.