### PR TITLE
feat: trusted authn / authz headers

### DIFF
--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -76,6 +76,35 @@ extract these values, create Kubernetes Secrets and provide them as environment 
 # set `CF-Connecting-IP`.
 PEER_IP_HEADER_NAME="CF-Connecting-IP"
 
+# You can enable authn/authz headers which would be added to the response
+# of the `/auth/v1/forward_auth` endpoint. With  `AUTH_HEADERS_ENABLE=true`,
+# the headers below will be added to authenticated requests. These could
+# be used on legacy downstream applications, that don't support OIDC on
+# their own.
+# However, be careful when using this, since this kind of authn/authz has
+# a lot of pitfalls out of the scope of Rauthy.
+AUTH_HEADERS_ENABLE=true
+
+# Configure the header names being used for the different values.
+# You can change them to your needs, if you cannot easily change your
+# downstream apps.
+# default: x-forwarded-user
+AUTH_HEADER_USER=x-forwarded-user
+# default: x-forwarded-user-roles
+AUTH_HEADER_ROLES=x-forwarded-user-roles
+# default: x-forwarded-user-groups
+AUTH_HEADER_GROUPS=x-forwarded-user-groups
+# default: x-forwarded-user-email
+AUTH_HEADER_EMAIL=x-forwarded-user-email
+# default: x-forwarded-user-email-verified
+AUTH_HEADER_EMAIL_VERIFIED=x-forwarded-user-email-verified
+# default: x-forwarded-user-family-name
+AUTH_HEADER_FAMILY_NAME=x-forwarded-user-family-name
+# default: x-forwarded-user-given-name
+AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
+# default: x-forwarded-user-mfa
+AUTH_HEADER_MFA=x-forwarded-user-mfa
+
 #####################################
 ############# BACKUPS ###############
 #####################################

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -120,6 +120,27 @@ lazy_static! {
     pub static ref RE_TOKEN_68: Regex = Regex::new(r"^[a-zA-Z0-9-._~+/]+=*$").unwrap();
     pub static ref RE_TOKEN_ENDPOINT_AUTH_METHOD: Regex = Regex::new(r"^(client_secret_post|client_secret_basic|none)$").unwrap();
 
+    pub static ref AUTH_HEADERS_ENABLE: bool = env::var("AUTH_HEADERS_ENABLE")
+        .unwrap_or_else(|_| String::from("false"))
+        .parse::<bool>()
+        .expect("Cannot parse AUTH_HEADERS_ENABLE to bool");
+    pub static ref AUTH_HEADER_USER: String = env::var("AUTH_HEADER_USER")
+        .unwrap_or_else(|_| String::from("x-forwarded-user"));
+    pub static ref AUTH_HEADER_ROLES: String = env::var("AUTH_HEADER_ROLES")
+        .unwrap_or_else(|_| String::from("x-forwarded-user-roles"));
+    pub static ref AUTH_HEADER_GROUPS: String = env::var("AUTH_HEADER_GROUPS")
+        .unwrap_or_else(|_| String::from("x-forwarded-user-groups"));
+    pub static ref AUTH_HEADER_EMAIL: String = env::var("AUTH_HEADER_EMAIL")
+        .unwrap_or_else(|_| String::from("x-forwarded-user-email"));
+    pub static ref AUTH_HEADER_EMAIL_VERIFIED: String = env::var("AUTH_HEADER_EMAIL_VERIFIED")
+        .unwrap_or_else(|_| String::from("x-forwarded-user-email-verified"));
+    pub static ref AUTH_HEADER_FAMILY_NAME: String = env::var("AUTH_HEADER_FAMILY_NAME")
+        .unwrap_or_else(|_| String::from("x-forwarded-user-family-name"));
+    pub static ref AUTH_HEADER_GIVEN_NAME: String = env::var("AUTH_HEADER_GIVEN_NAME")
+        .unwrap_or_else(|_| String::from("x-forwarded-user-given-name"));
+    pub static ref AUTH_HEADER_MFA: String = env::var("AUTH_HEADER_MFA")
+        .unwrap_or_else(|_| String::from("x-forwarded-user-mfa"));
+
     pub static ref PUB_URL: String = env::var("PUB_URL").expect("PUB_URL env var is not set");
     pub static ref PUB_URL_WITH_SCHEME: String = {
         let scheme = if env::var("LISTEN_SCHEME").as_deref() == Ok("http") && !*PROXY_MODE {
@@ -153,7 +174,7 @@ lazy_static! {
     pub static ref DPOP_FORCE_NONCE: bool = env::var("DPOP_NONCE_FORCE")
         .unwrap_or_else(|_| String::from("true"))
         .parse::<bool>()
-        .unwrap_or(true);
+        .expect("Cannot parse DPOP_FORCE_NONCE to bool");
 
     pub static ref ENABLE_DYN_CLIENT_REG: bool = env::var("ENABLE_DYN_CLIENT_REG")
         .unwrap_or_else(|_| String::from("false"))

--- a/rauthy-common/src/error_response.rs
+++ b/rauthy-common/src/error_response.rs
@@ -2,9 +2,10 @@ use crate::constants::{APPLICATION_JSON, HEADER_DPOP_NONCE, HEADER_HTML, HEADER_
 use actix_multipart::MultipartError;
 use actix_web::error::BlockingError;
 use actix_web::http::header::{
-    ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, WWW_AUTHENTICATE,
+    InvalidHeaderValue, ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS,
+    WWW_AUTHENTICATE,
 };
-use actix_web::http::StatusCode;
+use actix_web::http::{header, StatusCode};
 use actix_web::{HttpResponse, HttpResponseBuilder, ResponseError};
 use cryptr::CryptrError;
 use css_color::ParseColorError;
@@ -419,6 +420,15 @@ impl From<actix_web::http::header::ToStrError> for ErrorResponse {
                 "Request headers contained non ASCII characters: {:?}",
                 value
             ),
+        )
+    }
+}
+
+impl From<header::InvalidHeaderValue> for ErrorResponse {
+    fn from(value: InvalidHeaderValue) -> Self {
+        ErrorResponse::new(
+            ErrorResponseType::Internal,
+            format!("Cannot convert to HeaderValue: {:?}", value),
         )
     }
 }

--- a/rauthy-handlers/src/openapi.rs
+++ b/rauthy-handlers/src/openapi.rs
@@ -90,6 +90,7 @@ use utoipa::{openapi, OpenApi};
         oidc::post_token_info,
         oidc::post_validate_token,
         oidc::get_userinfo,
+        oidc::get_forward_auth,
         oidc::get_well_known,
 
         roles::get_roles,

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -584,6 +584,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                             .service(oidc::post_token)
                             .service(oidc::post_token_info)
                             .service(oidc::get_userinfo)
+                            .service(oidc::get_forward_auth)
                             .service(generic::get_enc_keys)
                             .service(generic::post_migrate_enc_key)
                             .service(generic::ping)

--- a/rauthy-models/src/response.rs
+++ b/rauthy-models/src/response.rs
@@ -524,6 +524,7 @@ pub struct Userinfo {
     pub sub: String,
     pub name: String,
     pub roles: Vec<String>,
+    pub mfa_enabled: bool,
 
     // scope: address
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rauthy-service/src/auth.rs
+++ b/rauthy-service/src/auth.rs
@@ -726,6 +726,7 @@ pub async fn get_userinfo(
         sub: user.id.clone(),
         name: format!("{} {}", &user.given_name, &user.family_name),
         roles,
+        mfa_enabled: user.has_webauthn_enabled(),
 
         // scope: address
         address: None,

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -84,6 +84,35 @@ OPEN_USER_REG=true
 # set `CF-Connecting-IP`.
 #PEER_IP_HEADER_NAME="CF-Connecting-IP"
 
+# You can enable authn/authz headers which would be added to the response
+# of the `/auth/v1/forward_auth` endpoint. With  `AUTH_HEADERS_ENABLE=true`,
+# the headers below will be added to authenticated requests. These could
+# be used on legacy downstream applications, that don't support OIDC on
+# their own.
+# However, be careful when using this, since this kind of authn/authz has
+# a lot of pitfalls out of the scope of Rauthy.
+AUTH_HEADERS_ENABLE=true
+
+# Configure the header names being used for the different values.
+# You can change them to your needs, if you cannot easily change your
+# downstream apps.
+# default: x-forwarded-user
+AUTH_HEADER_USER=x-forwarded-user
+# default: x-forwarded-user-roles
+AUTH_HEADER_ROLES=x-forwarded-user-roles
+# default: x-forwarded-user-groups
+AUTH_HEADER_GROUPS=x-forwarded-user-groups
+# default: x-forwarded-user-email
+AUTH_HEADER_EMAIL=x-forwarded-user-email
+# default: x-forwarded-user-email-verified
+AUTH_HEADER_EMAIL_VERIFIED=x-forwarded-user-email-verified
+# default: x-forwarded-user-family-name
+AUTH_HEADER_FAMILY_NAME=x-forwarded-user-family-name
+# default: x-forwarded-user-given-name
+AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
+# default: x-forwarded-user-mfa
+AUTH_HEADER_MFA=x-forwarded-user-mfa
+
 #####################################
 ############# BACKUPS ###############
 #####################################

--- a/rauthy.test.cfg
+++ b/rauthy.test.cfg
@@ -6,6 +6,8 @@
 # !!! DO NOT USE IN PRODUCTION !!!
 DEV_MODE=true
 
+AUTH_HEADERS_ENABLE=true
+
 RAUTHY_ADMIN_EMAIL="admin@localhost.de"
 
 # Limits the maximum amount of parallel password hashes at the exact same time to never exceed system memory while


### PR DESCRIPTION
This is an implementation of a dedicated `/auth/v1/oidc/forward_auth` endpoint with support for optional trusted authn / authz headers (mentioned in #337 ).

This makes it possible to have a more feature rich integration with things like Traefik's ForwardAuth middleware and push trusted headers about the logged in user to downstream applications (if proxy is configured properly of course).

The following config values do exist now:

```
# You can enable authn/authz headers which would be added to the response
# of the `/auth/v1/forward_auth` endpoint. With  `AUTH_HEADERS_ENABLE=true`,
# the headers below will be added to authenticated requests. These could
# be used on legacy downstream applications, that don't support OIDC on
# their own.
# However, be careful when using this, since this kind of authn/authz has
# a lot of pitfalls out of the scope of Rauthy.
AUTH_HEADERS_ENABLE=true

# Configure the header names being used for the different values.
# You can change them to your needs, if you cannot easily change your
# downstream apps.
# default: x-forwarded-user
AUTH_HEADER_USER=x-forwarded-user
# default: x-forwarded-user-roles
AUTH_HEADER_ROLES=x-forwarded-user-roles
# default: x-forwarded-user-groups
AUTH_HEADER_GROUPS=x-forwarded-user-groups
# default: x-forwarded-user-email
AUTH_HEADER_EMAIL=x-forwarded-user-email
# default: x-forwarded-user-email-verified
AUTH_HEADER_EMAIL_VERIFIED=x-forwarded-user-email-verified
# default: x-forwarded-user-family-name
AUTH_HEADER_FAMILY_NAME=x-forwarded-user-family-name
# default: x-forwarded-user-given-name
AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
# default: x-forwarded-user-mfa
AUTH_HEADER_MFA=x-forwarded-user-mfa
```

With these config variables, you can name the headers to your liking to match your environment.