### PR TITLE
feat: dynamic server side pagination + search for users

### DIFF
--- a/dev_notes.md
+++ b/dev_notes.md
@@ -2,6 +2,8 @@
 
 ## CURRENT WORK
 
+- dynamic server side pagination for users in admin ui
+
 ## Stage 1 - essentials
 
 [x] finished
@@ -17,12 +19,13 @@
 
 ### Notes for performance optimizations
 
-- all the `get_`s on the `Client` will probably be good with returning slices instead of real Strings -> less memory
-  allocations
+- all the `get_`s on the `Client` will probably be good with returning slices instead of real Strings
+  -> less memory allocations
 
 ## Stage 3 - Possible nice to haves
 
 - respect `display=popup` and / or `display=touch` on `/authorize`
 - impl experimental `dilithium` alg for token signing to become quantum safe
-- 'rauthy-migrate' project to help migrating to rauthy?
+- 'rauthy-migrate' project to help migrating to rauthy? probably when doing benchmarks anyway and use it
+  for dummy data?
 - custom event listener template to build own implementation? -> only if NATS will be implemented maybe?

--- a/migrations/postgres/22_users_created_at_index.sql
+++ b/migrations/postgres/22_users_created_at_index.sql
@@ -1,0 +1,2 @@
+create index users_created_at_index
+    on users (created_at);

--- a/migrations/sqlite/22_users_created_at_index.sql
+++ b/migrations/sqlite/22_users_created_at_index.sql
@@ -1,0 +1,2 @@
+create index users_created_at_index
+    on users (created_at);

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -68,6 +68,7 @@ pub const IDX_SCOPES: &str = "scopes_";
 pub const IDX_SESSION: &str = "session_";
 pub const IDX_SESSIONS: &str = "sessions";
 pub const IDX_USERS: &str = "users_";
+pub const USER_COUNT_IDX: &str = "users_count_total";
 pub const IDX_USERS_VALUES: &str = "users_values_";
 pub const IDX_USER_ATTR_CONFIG: &str = "user_attrs_";
 pub const IDX_WEBAUTHN: &str = "webauthn_";
@@ -343,6 +344,11 @@ lazy_static! {
         .unwrap_or_else(|_| String::from("false"))
         .parse::<bool>()
         .expect("SWAGGER_UI_EXTERNAL cannot be parsed to bool - bad format");
+
+     pub static ref SSP_THRESHOLD: u16 = env::var("SSP_THRESHOLD")
+        .unwrap_or_else(|_| String::from("1000"))
+        .parse::<u16>()
+        .expect("SSP_THRESHOLD cannot be parsed to u16 - bad format");
 
     pub static ref UNSAFE_NO_RESET_BINDING: bool = env::var("UNSAFE_NO_RESET_BINDING")
         .unwrap_or_else(|_| String::from("false"))

--- a/rauthy-handlers/src/generic.rs
+++ b/rauthy-handlers/src/generic.rs
@@ -543,9 +543,10 @@ pub async fn get_search(
 ) -> Result<HttpResponse, ErrorResponse> {
     principal.validate_admin_session()?;
 
+    let limit = params.limit.unwrap_or(100) as i64;
     match params.ty {
         SearchParamsType::User => {
-            let res = User::search(&data, &params.idx, &params.q).await?;
+            let res = User::search(&data, &params.idx, &params.q, limit).await?;
             Ok(HttpResponse::Ok().json(res))
         }
     }

--- a/rauthy-handlers/src/users.rs
+++ b/rauthy-handlers/src/users.rs
@@ -94,12 +94,6 @@ pub async fn get_users(
         }
     } else {
         let users = User::find_all_simple(&data).await?;
-        // let mut res = Vec::new();
-        // users
-        //     .into_iter()
-        //     // return a simplified version to decrease payload for big deployments
-        //     .for_each(|u| res.push(UserResponseSimple::from(u)));
-
         Ok(HttpResponse::Ok()
             .insert_header(("x-user-count", user_count))
             .json(users))

--- a/rauthy-models/src/entity/continuation_token.rs
+++ b/rauthy-models/src/entity/continuation_token.rs
@@ -1,0 +1,55 @@
+use actix_web::http::header::{HeaderName, HeaderValue};
+use rauthy_common::error_response::{ErrorResponse, ErrorResponseType};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContinuationToken {
+    pub id: String,
+    pub ts: i64,
+}
+
+impl ToString for ContinuationToken {
+    fn to_string(&self) -> String {
+        format!("{}{}", self.ts, self.id)
+    }
+}
+
+impl TryFrom<&str> for ContinuationToken {
+    type Error = ErrorResponse;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.len() < 16 {
+            return Err(ErrorResponse::new(
+                ErrorResponseType::BadRequest,
+                "Invalid continuation_token".to_string(),
+            ));
+        }
+
+        let (ts, id) = value.split_at(10);
+        let ts = i64::from_str(ts).map_err(|err| {
+            ErrorResponse::new(
+                ErrorResponseType::BadRequest,
+                format!("timestamp str cannot be parsed into i64: {:?}", err),
+            )
+        })?;
+
+        Ok(Self {
+            id: id.to_string(),
+            ts,
+        })
+    }
+}
+
+impl ContinuationToken {
+    pub fn new(id: String, ts: i64) -> Self {
+        Self { id, ts }
+    }
+
+    pub fn into_header_pair(self) -> (HeaderName, HeaderValue) {
+        // these header values will always be valid
+        let name = HeaderName::from_str("x-continuation-token").unwrap();
+        let value = HeaderValue::from_str(&self.to_string()).unwrap();
+        (name, value)
+    }
+}

--- a/rauthy-models/src/entity/mod.rs
+++ b/rauthy-models/src/entity/mod.rs
@@ -9,6 +9,7 @@ pub mod clients;
 pub mod clients_dyn;
 pub mod colors;
 pub mod config;
+pub mod continuation_token;
 pub mod db_version;
 pub mod dpop_proof;
 pub mod groups;

--- a/rauthy-models/src/entity/users.rs
+++ b/rauthy-models/src/entity/users.rs
@@ -587,6 +587,7 @@ impl User {
         data: &web::Data<AppState>,
         idx: &SearchParamsIdx,
         q: &str,
+        limit: i64,
     ) -> Result<Vec<UserResponseSimple>, ErrorResponse> {
         let q = format!("%{}%", q);
 
@@ -594,18 +595,20 @@ impl User {
             SearchParamsIdx::Id => {
                 query_as!(
                     UserResponseSimple,
-                    "SELECT id, email FROM users WHERE id LIKE $1 ORDER BY created_at ASC",
-                    q
+                    "SELECT id, email FROM users WHERE id LIKE $1 ORDER BY created_at ASC LIMIT $2",
+                    q,
+                    limit
                 )
                 .fetch_all(&data.db)
                 .await?
             }
             SearchParamsIdx::Email => {
                 query_as!(
-                    UserResponseSimple,
-                    "SELECT id, email FROM users WHERE email LIKE $1 ORDER BY created_at ASC",
-                    q
-                )
+                UserResponseSimple,
+                "SELECT id, email FROM users WHERE email LIKE $1 ORDER BY created_at ASC LIMIT $2",
+                q,
+                limit
+            )
                 .fetch_all(&data.db)
                 .await?
             }

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -647,6 +647,17 @@ pub struct NewRoleRequest {
     pub role: String,
 }
 
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+pub struct PaginationParams {
+    pub page: Option<u32>,
+    pub page_size: Option<u16>,
+    pub offset: Option<u16>,
+    pub backwards: Option<bool>,
+    /// Validation: `[a-zA-Z0-9]`
+    #[validate(regex(path = "RE_ALNUM", code = "[a-zA-Z0-9]"))]
+    pub continuation_token: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
 pub struct PasskeyRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,32}`

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -687,6 +687,7 @@ pub struct SearchParams {
     /// The actual search query - validation: `[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%@]+`
     #[validate(regex(path = "RE_SEARCH", code = "[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%@]+"))]
     pub q: String,
+    pub limit: Option<u16>,
 }
 
 #[derive(Debug, PartialEq, Deserialize, ToSchema)]

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -786,6 +786,13 @@ SWAGGER_UI_EXTERNAL=true
 # default: 30
 #SSE_KEEP_ALIVE=30
 
+# Dynamic server side pagination threshold
+# If the total users count exceeds this value, Rauthy will dynamically
+# change search and pagination for users in the Admin UI from client
+# side to server side to not have a degradation in performance.
+# default: 1000
+SSP_THRESHOLD=1000
+
 #####################################
 ############ TEMPLATES ##############
 #####################################


### PR DESCRIPTION
This will add dynamic server side pagination and search functionality for the users page in the Admin UI.  
For bigger instances with many thousands of users, this will become more important, so the UI does not need to fetch all the users each time.

All the other "fetch all" endpoints will stay pretty small anyway, so there is no need to do this server side, since client side is usually more responsive and provides a better UX.