### PR TITLE
Fix typo in openapi spec ErrorRresponse -> ErrorResponse

### DIFF
--- a/rauthy-handlers/src/auth_providers.rs
+++ b/rauthy-handlers/src/auth_providers.rs
@@ -217,7 +217,7 @@ pub async fn post_provider_callback(
     tag = "providers",
     responses(
         (status = 200, description = "OK"),
-        (status = 400, description = "BadRequest", body = ErrorRresponse),
+        (status = 400, description = "BadRequest", body = ErrorResponse),
     ),
 )]
 #[delete("/providers/link")]


### PR DESCRIPTION
I noticed this small typo in part of the openapi spec when trying to create a terraform provider based on it.