### PR TITLE
Fix typos in openapi spec /clients/{id}}/colors -> /clients/{id}/colors

### DIFF
--- a/rauthy-handlers/src/clients.rs
+++ b/rauthy-handlers/src/clients.rs
@@ -294,7 +294,7 @@ pub async fn put_clients(
 /// - rauthy_admin
 #[utoipa::path(
     get,
-    path = "/clients/{id}}/colors",
+    path = "/clients/{id}/colors",
     tag = "clients",
     responses(
         (status = 200, description = "Ok", body = Colors),
@@ -321,7 +321,7 @@ pub async fn get_client_colors(
 /// - rauthy_admin
 #[utoipa::path(
     put,
-    path = "/clients/{id}}/colors",
+    path = "/clients/{id}/colors",
     tag = "clients",
     request_body = ColorsRequest,
     responses(
@@ -353,7 +353,7 @@ pub async fn put_client_colors(
 /// - rauthy_admin
 #[utoipa::path(
     delete,
-    path = "/clients/{id}}/colors",
+    path = "/clients/{id}/colors",
     tag = "clients",
     responses(
         (status = 200, description = "Ok"),


### PR DESCRIPTION
Another typo in the spec. Seems utoipa does not check syntax in these bits either.

I also noticed that the openapi spec does not mention authentication so the swagger-ui does not offer a field for the API key to use for testing and that the calls do not mention which API key permission they need (though that should be fairly obvious) in the generated docs.

I am not far enough yet to know if the missing authentication part will become a problem for generating the Terraform provider but if it does I can patch it locally for now and let you know.