### PR TITLE
rauthy-client: drop `anyhow` in favor of `RauthyError` + `thiserror`

### DIFF
--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rauthy-client"
-version = "0.3.0"
+version = "0.4.0-20240427"
 edition = "2021"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -23,13 +23,13 @@ axum = [
     # minimal versions
     "dep:elliptic-curve",
 ]
+device-code = []
 
 [dependencies]
 # common
-anyhow = "1.0.75"
 base64 = "0.22.0"
 bincode = "1.3.3"
-cached = { version = "0.49", features = [] }
+cached = { version = "0.50.0", features = [] }
 chacha20poly1305 = { version = "0.10.1", features = ["std"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std"] }
 jwt-simple = { version = "0.12.6", default-features = false, features = ["pure-rust"] }
@@ -40,6 +40,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 ring = "0.17.5"
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.100"
+thiserror = { version = "1.0" }
 tokio = "1.34"
 tracing = "0.1.40"
 
@@ -50,6 +51,8 @@ http = { version = "1.0.0", optional = true }
 # axum
 axum = { version = "0.7", optional = true, features = [] }
 axum-extra = { version = "0.9", optional = true, features = ["cookie", "typed-header"] }
+
+# device-code
 
 # make minimal versions happy
 elliptic-curve = { version = "0.13.8", optional = true }

--- a/rauthy-client/README.md
+++ b/rauthy-client/README.md
@@ -8,3 +8,4 @@ overhead and secure default values, if you only use [Rauthy](https://github.com/
 
 You can find examples for `actix-web`, `axum` or a fully generic framework / application in the
 [Examples](https://github.com/sebadob/rauthy/tree/main/rauthy-client/examples) directory.
+ 

--- a/rauthy-client/examples/actix-web/Cargo.lock
+++ b/rauthy-client/examples/actix-web/Cargo.lock
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.49.3"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
+checksum = "10a7d38ed2761b8a13ce42bc44b09d5a052b88da2f9fead624c779f31ac0729a"
 dependencies = [
  "ahash",
  "cached_proc_macro",
@@ -506,14 +506,14 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9f16c0d84de31a2ab7fdf5f7783c14631f7075cf464eb3bb43119f61c9cb2a"
+checksum = "771aa57f3b17da6c8bcacb187bb9ec9bc81c8160e72342e67c329e0e1651a669"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -681,9 +681,9 @@ checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -691,27 +691,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1662,7 +1662,6 @@ name = "rauthy-client"
 version = "0.3.0"
 dependencies = [
  "actix-web",
- "anyhow",
  "base64 0.22.0",
  "bincode",
  "cached",
@@ -1675,6 +1674,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
 ]

--- a/rauthy-client/examples/axum/Cargo.lock
+++ b/rauthy-client/examples/axum/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -337,9 +337,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cached"
-version = "0.49.3"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
+checksum = "10a7d38ed2761b8a13ce42bc44b09d5a052b88da2f9fead624c779f31ac0729a"
 dependencies = [
  "ahash",
  "cached_proc_macro",
@@ -352,14 +352,14 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9f16c0d84de31a2ab7fdf5f7783c14631f7075cf464eb3bb43119f61c9cb2a"
+checksum = "771aa57f3b17da6c8bcacb187bb9ec9bc81c8160e72342e67c329e0e1651a669"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -508,9 +508,9 @@ checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -518,27 +518,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1322,7 +1322,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -1442,7 +1442,6 @@ dependencies = [
 name = "rauthy-client"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "axum",
  "axum-extra",
  "base64 0.22.0",
@@ -1457,6 +1456,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -1655,7 +1655,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -1815,17 +1815,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
@@ -1864,7 +1853,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -1950,7 +1939,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -2026,7 +2015,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -2182,7 +2171,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2216,7 +2205,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2443,7 +2432,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]

--- a/rauthy-client/src/device_code.rs
+++ b/rauthy-client/src/device_code.rs
@@ -1,0 +1,12 @@
+use crate::rauthy_error::RauthyError;
+
+#[derive(Debug)]
+pub struct DeviceCode {
+    pub issuer: String,
+}
+
+impl DeviceCode {
+    pub async fn request() -> Result<Self, RauthyError> {
+        todo!()
+    }
+}

--- a/rauthy-client/src/handler/actix_web.rs
+++ b/rauthy-client/src/handler/actix_web.rs
@@ -3,6 +3,7 @@ use crate::cookie_state::{OidcCookieState, OIDC_STATE_COOKIE};
 use crate::handler::{OidcCallbackParams, OidcCookieInsecure, OidcSetRedirectStatus};
 use crate::principal::PrincipalOidc;
 use crate::provider::OidcProvider;
+use crate::rauthy_error::RauthyError;
 use crate::token_set::{JwtIdClaims, OidcTokenSet};
 use actix_web::{
     http::header::{LOCATION, SET_COOKIE},
@@ -46,11 +47,7 @@ pub async fn validate_redirect_principal(
         };
 
         let value = cookie_state.to_encrypted_cookie_value(enc_key);
-        let cookie = build_lax_cookie_300(
-            OIDC_STATE_COOKIE,
-            &value,
-            insecure,
-        );
+        let cookie = build_lax_cookie_300(OIDC_STATE_COOKIE, &value, insecure);
 
         if set_redirect_status == OidcSetRedirectStatus::Yes {
             HttpResponse::TemporaryRedirect()
@@ -72,7 +69,7 @@ pub async fn oidc_callback(
     params: web::Query<OidcCallbackParams>,
     enc_key: &[u8],
     insecure: OidcCookieInsecure,
-) -> anyhow::Result<(String, OidcTokenSet, JwtIdClaims)> {
+) -> Result<(String, OidcTokenSet, JwtIdClaims), RauthyError> {
     let cookie_state = OidcCookieState::from_req_cookie_value(req, enc_key)?;
     crate::handler::oidc_callback(cookie_state, params.into_inner(), insecure).await
 }

--- a/rauthy-client/src/handler/axum.rs
+++ b/rauthy-client/src/handler/axum.rs
@@ -3,6 +3,7 @@ use crate::cookie_state::{OidcCookieState, OIDC_STATE_COOKIE};
 use crate::handler::{OidcCallbackParams, OidcCookieInsecure, OidcSetRedirectStatus};
 use crate::principal::PrincipalOidc;
 use crate::provider::OidcProvider;
+use crate::rauthy_error::RauthyError;
 use crate::token_set::{JwtIdClaims, OidcTokenSet};
 use axum::{
     body::Body,
@@ -54,11 +55,7 @@ pub async fn validate_redirect_principal(
         };
 
         let value = cookie_state.to_encrypted_cookie_value(enc_key);
-        let cookie = build_lax_cookie_300(
-            OIDC_STATE_COOKIE,
-            &value,
-            insecure,
-        );
+        let cookie = build_lax_cookie_300(OIDC_STATE_COOKIE, &value, insecure);
 
         if set_redirect_status == OidcSetRedirectStatus::Yes {
             Response::builder().status(302)
@@ -81,7 +78,7 @@ pub async fn oidc_callback(
     params: Query<OidcCallbackParams>,
     enc_key: &[u8],
     insecure: OidcCookieInsecure,
-) -> anyhow::Result<(String, OidcTokenSet, JwtIdClaims)> {
+) -> Result<(String, OidcTokenSet, JwtIdClaims), RauthyError> {
     let cookie_state = OidcCookieState::from_jar_cookie_value(jar, enc_key)?;
     crate::handler::oidc_callback(cookie_state, params.0, insecure).await
 }

--- a/rauthy-client/src/oidc_config.rs
+++ b/rauthy-client/src/oidc_config.rs
@@ -76,10 +76,11 @@ pub enum JwtClaimTyp {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rauthy_error::RauthyError;
     use std::ops::Deref;
 
     #[test]
-    fn test_claim_mapping() -> anyhow::Result<()> {
+    fn test_claim_mapping() -> Result<(), RauthyError> {
         let mapping = ClaimMapping::None;
         // no matter which roles / groupe we have - None should always deny access
         assert!(!mapping.matches(&vec!["".to_string()], &vec!["".to_string()]));

--- a/rauthy-client/src/principal/mod.rs
+++ b/rauthy-client/src/principal/mod.rs
@@ -1,4 +1,5 @@
 use crate::provider::OidcProvider;
+use crate::rauthy_error::RauthyError;
 use crate::token_set::JwtAccessClaims;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -36,14 +37,14 @@ pub struct PrincipalOidc {
 impl PrincipalOidc {
     /// Creates a Principal from a raw Base64 encoded JWT token.
     /// This will also validate the token against the JWK fetched from the issuer.
-    pub async fn from_token_validated(token: &str) -> anyhow::Result<Self> {
+    pub async fn from_token_validated(token: &str) -> Result<Self, RauthyError> {
         let claims = JwtAccessClaims::from_token_validated(token).await?;
 
         let config = OidcProvider::config()?;
 
         let id = claims
             .sub
-            .ok_or_else(|| anyhow::Error::msg("'sub' claim is mandatory"))?;
+            .ok_or_else(|| RauthyError::InvalidClaims("'sub' claim is mandatory"))?;
         let roles = claims.roles.unwrap_or_default();
         let groups = claims.groups.unwrap_or_default();
 

--- a/rauthy-client/src/rauthy_error.rs
+++ b/rauthy-client/src/rauthy_error.rs
@@ -1,0 +1,65 @@
+use base64::DecodeError;
+use bincode::ErrorKind;
+use chacha20poly1305::Error;
+use std::borrow::Cow;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RauthyError {
+    #[error("BadRequest: {0}")]
+    BadRequest(&'static str),
+    #[error("Base64: {0}")]
+    Base64(String),
+    #[error("Encryption: {0}")]
+    Encryption(Cow<'static, str>),
+    #[error("Internal: {0}")]
+    Internal(Cow<'static, str>),
+    #[error("Init: {0}")]
+    Init(&'static str),
+    #[error("InvalidClaims: {0}")]
+    InvalidClaims(&'static str),
+    #[error("InvalidJwt: {0}")]
+    InvalidJwt(&'static str),
+    #[error("JWK: {0}")]
+    JWK(Cow<'static, str>),
+    #[error("MalformedJwt: {0}")]
+    MalformedJwt(&'static str),
+    #[error("Provider: {0}")]
+    Provider(Cow<'static, str>),
+    #[error("Request Error: {0}")]
+    Request(Cow<'static, str>),
+    #[error("Serde: {0}")]
+    Serde(String),
+    #[error("Token: {0}")]
+    Token(Cow<'static, str>),
+}
+
+impl From<base64::DecodeError> for RauthyError {
+    fn from(value: DecodeError) -> Self {
+        Self::Base64(value.to_string())
+    }
+}
+
+impl From<chacha20poly1305::Error> for RauthyError {
+    fn from(value: Error) -> Self {
+        Self::Encryption(Cow::from(value.to_string()))
+    }
+}
+
+impl From<Box<bincode::ErrorKind>> for RauthyError {
+    fn from(value: Box<ErrorKind>) -> Self {
+        Self::Serde(value.to_string())
+    }
+}
+
+impl From<reqwest::Error> for RauthyError {
+    fn from(value: reqwest::Error) -> Self {
+        Self::Request(Cow::from(value.to_string()))
+    }
+}
+
+impl From<jwt_simple::Error> for RauthyError {
+    fn from(value: jwt_simple::Error) -> Self {
+        Self::Token(Cow::from(value.to_string()))
+    }
+}


### PR DESCRIPTION
This PR drops `anyhow` from `rauthy-client`. It should not be used in a crate. Instead we get a new `RauthyError` error type which converts easily into anything else.