### PR TITLE
switch log level for failed custom peer ip header extraction

### DIFF
--- a/rauthy-common/src/utils.rs
+++ b/rauthy-common/src/utils.rs
@@ -7,7 +7,7 @@ use base64::{engine, engine::general_purpose, Engine as _};
 use gethostname::gethostname;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
-use tracing::error;
+use tracing::{debug, error};
 
 const B64_URL_SAFE: engine::GeneralPurpose = general_purpose::URL_SAFE;
 const B64_URL_SAFE_NO_PAD: engine::GeneralPurpose = general_purpose::URL_SAFE_NO_PAD;
@@ -194,10 +194,7 @@ fn ip_from_cust_header(headers: &HeaderMap) -> Option<String> {
         if let Some(Ok(value)) = headers.get(header_name).map(|s| s.to_str()) {
             return Some(value.to_string());
         }
-        error!(
-            "Was unable to extract the PEER IP from PEER_IP_HEADER_NAME: {} - using fallback",
-            header_name
-        );
+        debug!("no PEER IP from PEER_IP_HEADER_NAME: '{}'", header_name);
     }
 
     None


### PR DESCRIPTION
Switches the log level for failed peer ip extraction from the custom header from `error` to `debug`.  
The current setup will spam the logs if you have for instance a ready check inside kubernetes which of course does not have this custom header.