### PR TITLE
feat: `DeviceCode` verification uri -> qrcode

### DIFF
--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -24,6 +24,7 @@ axum = [
     "dep:elliptic-curve",
 ]
 device-code = []
+qrcode = ["device-code", "dep:qrcode"]
 
 [dependencies]
 # common
@@ -53,6 +54,7 @@ axum = { version = "0.7", optional = true, features = [] }
 axum-extra = { version = "0.9", optional = true, features = ["cookie", "typed-header"] }
 
 # device-code
+qrcode = { version = "0.14.0", optional = true }
 
 # make minimal versions happy
 elliptic-curve = { version = "0.13.8", optional = true }

--- a/rauthy-client/examples/device-code/Cargo.toml
+++ b/rauthy-client/examples/device-code/Cargo.toml
@@ -6,12 +6,5 @@ authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"
 
 [dependencies]
-#anyhow = "1.0.75"
-#axum = { version = "0.7.1", features = ["http2"] }
-#axum-extra = { version = "0.9.0", features = ["cookie"] }
-dotenvy = "0.15.7"
 tokio = { version = "1.34.0", features = ["full"] }
-#tracing = "0.1.40"
-#tracing-subscriber = { version = "0.3.18", features = ["tracing"] }
-
-rauthy-client = { path = "../..", features = ["device-code"] }
+rauthy-client = { path = "../..", features = ["device-code", "qrcode"] }

--- a/rauthy-client/examples/device-code/src/main.rs
+++ b/rauthy-client/examples/device-code/src/main.rs
@@ -23,6 +23,14 @@ async fn main() -> Result<(), RauthyError> {
         device_code.verification_uri_complete.as_ref().unwrap()
     );
 
+    // with the `qrcode` feature endabled, we can render the
+    // verification_uri_complete into one
+    let qr = device_code.qr_string()?;
+    println!("\n{}", qr);
+
+    // we can get a QR as SVG as well, but this example can't display it.
+    // let qr = device_code.qr_svg()?;
+
     let ts = device_code.wait_for_token().await?;
     println!("\nTokenSet on accept:\n{:?}", ts);
 

--- a/rauthy-client/src/device_code.rs
+++ b/rauthy-client/src/device_code.rs
@@ -256,4 +256,42 @@ impl DeviceCode {
             }
         }
     }
+
+    #[cfg(feature = "qrcode")]
+    fn qr(&self) -> Result<qrcode::QrCode, RauthyError> {
+        if let Some(uri) = &self.verification_uri_complete {
+            Ok(qrcode::QrCode::new(uri)?)
+        } else {
+            Err(RauthyError::Provider(Cow::from(
+                "did not receive a `verification_uri_complete`",
+            )))
+        }
+    }
+
+    #[cfg(feature = "qrcode")]
+    pub fn qr_string(&self) -> Result<String, RauthyError> {
+        use qrcode::render::unicode;
+
+        let code = self.qr()?;
+        let image = code
+            .render::<unicode::Dense1x2>()
+            .dark_color(unicode::Dense1x2::Light)
+            .light_color(unicode::Dense1x2::Dark)
+            .build();
+        Ok(image)
+    }
+
+    #[cfg(feature = "qrcode")]
+    pub fn qr_svg(&self) -> Result<String, RauthyError> {
+        use qrcode::render::svg;
+
+        let code = self.qr()?;
+        let image = code
+            .render()
+            .min_dimensions(200, 200)
+            .dark_color(svg::Color("#000000"))
+            .light_color(svg::Color("#ffffff"))
+            .build();
+        Ok(image)
+    }
 }

--- a/rauthy-client/src/rauthy_error.rs
+++ b/rauthy-client/src/rauthy_error.rs
@@ -69,3 +69,10 @@ impl From<serde_json::Error> for RauthyError {
         Self::Serde(value.to_string())
     }
 }
+
+#[cfg(feature = "qrcode")]
+impl From<qrcode::types::QrError> for RauthyError {
+    fn from(value: qrcode::types::QrError) -> Self {
+        Self::Internal(Cow::from(value.to_string()))
+    }
+}


### PR DESCRIPTION
Makes it possible to generate a qrcode from a `verification_uri_full` returned during the Device Authorization Grant flow.
#369  