### PR TITLE
Internal Improvements

### DIFF
--- a/rauthy-main/tests/handler_api_keys.rs
+++ b/rauthy-main/tests/handler_api_keys.rs
@@ -18,7 +18,7 @@ async fn test_api_keys() -> Result<(), Box<dyn Error>> {
 
     let url = format!("{}/api_keys", get_backend_url());
     let res = client.get(&url).send().await?;
-    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
 
     // create a new api key
     let mut payload = ApiKeyRequest {


### PR DESCRIPTION
Adds some additional docs on internal session validation fn's, simplifies some of them to make them more readable and mainatainable and return `HTTP 401` in some places where it makes more sense than an `HTTP 403`.