### PR TITLE
add `device_id` to `access_token` for `/userinfo` online verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,8 @@ The login form now contains a "Home" icon which will appear, if a `client_uri` i
 client. A user may click this and be redirected to the client, if a login is not desired for whatever reason.
 Additionally, if the user registration is configured to be open, a link to the user registration will be shown
 at the bottom as well.
-
-[]()
+[b03349c](https://github.com/sebadob/rauthy/commit/b03349c9d3f998aaecd3e4177c7b62bda067bf8b)
+[b03349c](https://github.com/sebadob/rauthy/commit/b03349c9d3f998aaecd3e4177c7b62bda067bf8b)
 
 #### Unlink Account from Provider
 
@@ -84,6 +84,18 @@ You can set environment variables either via `rauthy.cfg`, `.env` or as just an 
 initial setup in production. This makes it possible to create an admin account with the very first
 database setup with a custom E-Mail + Password, instead of the default `admin@localhost.de` with
 a random password, which you need to pull from the logs.
+
+[1a7d9e4](https://github.com/sebadob/rauthy/commit/1a7d9e40aad551a44648fe39e24c05d36a621fab)
+
+#### New config var `USERINFO_STRICT`
+
+You can now set a new config variable called `USERINFO_STRICT`. If set so true, Rauthy will do additional
+validations on the `/userinfo` endpoint and actually revoke (even otherwise still valid) access tokens,
+when any user / client / device it has been issued for has been deleted, expired or disabled. The non-strict
+mode will simply make sure the token is valid and that the user still exists. The additional validations
+will consume more resources because they need 1-2 additional database lookups but will provide more strict
+validation and possible earlier token revocation. If you don't need it that strict, and you are resource
+constrained, set it to `false`.
 
 ```
 #####################################
@@ -106,6 +118,8 @@ BOOTSTRAP_ADMIN_EMAIL="alfred@batcave.io"
 # will always be prioritized.
 BOOTSTRAP_ADMIN_PASSWORD_ARGON2ID='$argon2id$v=19$m=32768,t=3,p=2$mK+3taI5mnA+Gx8OjjKn5Q$XsOmyvt9fr0V7Dghhv3D0aTe/FjF36BfNS5QlxOPep0'
 ```
+
+[]()
 
 ### Bugfixes
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -4,10 +4,14 @@
 
 ## TODO before v0.23.0
 
-- `USERINFO_STRICT` config option -> strict session / device id checking against DB
-- handle `offline_access` properly again - either decide to fully remove or support it everywhere
+- Fully get rid of `offline_access` everywhere and just use the current `refresh_token` allow switch.
+  The naming seems to confuse a lot of people, while Rauthy's current approach is much more clear.
+  Make sure all `offline_access` leftovers are cleaned up and properly mention the behavior in the docs.
 - add `at_hash` claim to the ID token
+- fix button label misplacement on chrome + ugly tab bar
 - sessions view needs pagination
+- `refresh_token` handler in rauthy-client for `device_code` grant flow
+- check possibility of `no_std` for rauthy-client + device_code
 
 ## Stage 1 - essentials
 

--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -17,6 +17,19 @@ extract these values, create Kubernetes Secrets and provide them as environment 
 # If not, an admin must create each new user. (default: false)
 #OPEN_USER_REG=true
 
+# If set to true, the `/userinfo` endpoint will do additional validations.
+# The non-strict mode will fetch the user by id from the `sub` claim and make
+# sure it still exists and is enabled. The strict validation will do additional
+# database fetches and validates every possible value.
+# Additionally, it will look up a possibly linked user device from the `did` claim
+# and make sure it still exists. It will also extract the `client_id` the token
+# has been originally issued for from the `azp` claim, fetch it and make sure it
+# still exists and is enabled.
+# If you don't need the extra validations, you can set this to `false` to
+# save some resources, if your clients to a lot of `/userinfo` lookups.
+# default: true
+USERINFO_STRICT=true
+
 # Can be used when 'OPEN_USER_REG=true' to restrict the domains
 # for a registration. For instance, set it to
 # 'USER_REG_DOMAIN_RESTRICTION=gmail.com' to allow only

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -131,6 +131,11 @@ lazy_static! {
     pub static ref RE_TOKEN_68: Regex = Regex::new(r"^[a-zA-Z0-9-._~+/]+=*$").unwrap();
     pub static ref RE_TOKEN_ENDPOINT_AUTH_METHOD: Regex = Regex::new(r"^(client_secret_post|client_secret_basic|none)$").unwrap();
 
+    pub static ref USERINFO_STRICT: bool = env::var("USERINFO_STRICT")
+        .unwrap_or_else(|_| String::from("true"))
+        .parse::<bool>()
+        .expect("USERINFO_STRICT cannot be parsed to bool - bad format");
+
     pub static ref AUTH_HEADERS_ENABLE: bool = env::var("AUTH_HEADERS_ENABLE")
         .unwrap_or_else(|_| String::from("false"))
         .parse::<bool>()

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -78,6 +78,8 @@ pub struct JwtCommonClaims {
     pub azp: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
     pub cnf: Option<JktClaim>,
 }
 

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -152,6 +152,8 @@ pub struct JwtAccessClaims {
     pub allowed_origins: Option<Vec<String>>,
     // user part
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_username: Option<String>,

--- a/rauthy-service/src/token_set.rs
+++ b/rauthy-service/src/token_set.rs
@@ -19,7 +19,7 @@ pub enum AuthCodeFlow {
     No,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DeviceCodeFlow {
     Yes(String),
     No,
@@ -63,6 +63,7 @@ impl TokenSet {
             client.access_token_lifetime as i64,
             None,
             None,
+            DeviceCodeFlow::No,
         )
         .await?;
 
@@ -163,6 +164,10 @@ impl TokenSet {
                 diff
             }
         } else if scope.contains("offline_access") {
+            // TODO just fully remove the offline_access branch here. The term is way too confusing
+            // and not even used currently. It is impossible to end up in this if-branch right now.
+            // The mechanism that rauthy currently uses for refresh token handling is way better
+            // to understand for new users.
             *OFFLINE_TOKEN_LT
         } else {
             client.access_token_lifetime.unsigned_abs() as i64
@@ -193,6 +198,7 @@ impl TokenSet {
             lifetime,
             Some(TokenScopes(scope)),
             customs_access,
+            device_code_flow.clone(),
         )
         .await?;
         let refresh_token = if client.refresh_token {

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -38,6 +38,19 @@ DEV_DPOP_HTTP=true
 # (default: false)
 OPEN_USER_REG=true
 
+# If set to true, the `/userinfo` endpoint will do additional validations.
+# The non-strict mode will fetch the user by id from the `sub` claim and make
+# sure it still exists and is enabled. The strict validation will do additional
+# database fetches and validates every possible value.
+# Additionally, it will look up a possibly linked user device from the `did` claim
+# and make sure it still exists. It will also extract the `client_id` the token
+# has been originally issued for from the `azp` claim, fetch it and make sure it
+# still exists and is enabled.
+# If you don't need the extra validations, you can set this to `false` to
+# save some resources, if your clients to a lot of `/userinfo` lookups.
+# default: true
+USERINFO_STRICT=true
+
 # Can be used when 'OPEN_USER_REG=true' to restrict the domains for a registration. For instance, set it to
 # 'USER_REG_DOMAIN_RESTRICTION=gmail.com' to allow only registrations with 'user@gmail.com'.
 # default: ''


### PR DESCRIPTION
This PR will take care of adding the device_id from the `device_code` flow to the `access_token`.
This will make it possible to later do an online verification when such an access token is used on the `/userinfo` endpoint and actually check, that the device still exists even when the token is still valid.