### PR TITLE
feat: add `at_hash` to the `id_token`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The "new" mechanism Rauthy uses with the switch in the Admin UI to issue / allow
 is much more clear, since the `offline_access` scope produces a lot of confusion for people new to OIDC.
 From the name, it simply makes no sense that you need to activate `offline_access` to get a refresh token.
 Having an option named "allow refresh tokens" is just so much better.
+[71db7fe](https://github.com/sebadob/rauthy/commit/71db7fef18568a599f30cae6e494bba40cb33e7d)
 
 ### Features
 
@@ -132,6 +133,13 @@ validation and possible earlier token revocation. If you don't need it that stri
 constrained, set it to `false`.
 
 [198e7f9](https://github.com/sebadob/rauthy/commit/198e7f957c32fef5f0f786b145408f7d625f20ce)
+
+#### `at_hash` in `id_token`
+
+The Rauthy `id_token` now contains the access token hash `at_hash` claim. This is needed for additional
+downstream validation, if a client provides both tokens and they are not coming from Rauthy directly.
+With the additional validation of the `at_hash` claim, clients can be 100% sure, that a given `id_token`
+belongs to a specific `access_token` and has not been swapped out.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ The Rauthy `id_token` now contains the access token hash `at_hash` claim. This i
 downstream validation, if a client provides both tokens and they are not coming from Rauthy directly.
 With the additional validation of the `at_hash` claim, clients can be 100% sure, that a given `id_token`
 belongs to a specific `access_token` and has not been swapped out.
+[]()
 
 ### Bugfixes
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -6,9 +6,7 @@
 
 - fix button label misplacement on chrome + ugly tab bar
 - sessions view needs pagination
-- `refresh_token` handler in rauthy-client for `device_code` grant flow
-- check possibility of `no_std` for rauthy-client + device_code
-- when implementing userinfo lookup into the rauthy-client, add an fn to validate the `at_hash` as well
+- check out the possibility to include SCIM
 
 ## Stage 1 - essentials
 
@@ -16,6 +14,7 @@
 
 ## Stage 2 - features - do before v1.0.0
 
+- prettify the UI
 - update the book with all the new features
 - benchmarks and performance tuning
 - maybe get a nicer logo
@@ -24,6 +23,12 @@
 
 - all the `get_`s on the `Client` will probably be good with returning slices instead of real Strings
   -> less memory allocations
+
+### `rauthy-client` TODO's
+
+- check possibility of `no_std` with `device_code` flow -> embedded devices
+- automatic `refresh_token` handler for `device_code` grant flow
+- when implementing userinfo lookup, add an fn to validate the `at_hash` as well
 
 ## Stage 3 - Possible nice to haves
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -4,11 +4,11 @@
 
 ## TODO before v0.23.0
 
-- add `at_hash` claim to the ID token
 - fix button label misplacement on chrome + ugly tab bar
 - sessions view needs pagination
 - `refresh_token` handler in rauthy-client for `device_code` grant flow
 - check possibility of `no_std` for rauthy-client + device_code
+- when implementing userinfo lookup into the rauthy-client, add an fn to validate the `at_hash` as well
 
 ## Stage 1 - essentials
 

--- a/rauthy-client/src/token_set.rs
+++ b/rauthy-client/src/token_set.rs
@@ -104,6 +104,7 @@ pub struct JwtIdClaims {
     pub typ: JwtTokenType,
     pub amr: Vec<String>,
     pub auth_time: i64,
+    pub at_hash: Option<String>,
     pub preferred_username: String,
     pub email: Option<String>,
     pub email_verified: Option<bool>,

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -175,6 +175,7 @@ pub struct JwtIdClaims {
     pub typ: JwtTokenType,
     pub amr: Vec<String>,
     pub auth_time: i64,
+    pub at_hash: String,
     pub preferred_username: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,

--- a/rauthy-service/src/auth.rs
+++ b/rauthy-service/src/auth.rs
@@ -1,5 +1,5 @@
 use crate::token_set::{
-    AuthCodeFlow, DeviceCodeFlow, DpopFingerprint, TokenNonce, TokenScopes, TokenSet,
+    AtHash, AuthCodeFlow, DeviceCodeFlow, DpopFingerprint, TokenNonce, TokenScopes, TokenSet,
 };
 use actix_web::http::header;
 use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
@@ -330,7 +330,8 @@ pub async fn authorize_refresh(
 }
 
 /// Builds the access token for a user after all validation has been successful
-#[allow(clippy::type_complexity)]
+// too many arguments is not an issue - params cannot be mistaken because of enum wrappers
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub async fn build_access_token(
     user: Option<&User>,
     data: &web::Data<AppState>,
@@ -420,6 +421,7 @@ pub async fn build_id_token(
     data: &web::Data<AppState>,
     client: &Client,
     dpop_fingerprint: Option<DpopFingerprint>,
+    at_hash: AtHash,
     lifetime: i64,
     nonce: Option<TokenNonce>,
     scope: &str,
@@ -463,6 +465,7 @@ pub async fn build_id_token(
         typ: JwtTokenType::Id,
         amr: vec![amr],
         auth_time,
+        at_hash: at_hash.0,
         preferred_username: user.email.clone(),
         email: None,
         email_verified: None,


### PR DESCRIPTION
This will add the `at_hash` claim to the `id_token` for additional downstream validation, that a received `id_token` actually belongs to a specific `access_token`.