### PR TITLE
Adjust validation for `roles`, `groups` and `scopes` names

### DIFF
--- a/frontend/src/components/admin/groups/GroupConfig.svelte
+++ b/frontend/src/components/admin/groups/GroupConfig.svelte
@@ -28,7 +28,7 @@
 
     let formErrors = {};
     const schema = yup.object().shape({
-        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/', length: 2-128"),
+        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:', length: 2-64"),
     });
 
     function handleKeyPress(event) {

--- a/frontend/src/components/admin/roles/RoleConfig.svelte
+++ b/frontend/src/components/admin/roles/RoleConfig.svelte
@@ -28,7 +28,7 @@
 
     let formErrors = {};
     const schema = yup.object().shape({
-        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/', length: 2-128"),
+        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:', length: 2-64"),
     });
 
     function handleKeyPress(event) {

--- a/frontend/src/components/admin/scopes/ScopeConfig.svelte
+++ b/frontend/src/components/admin/scopes/ScopeConfig.svelte
@@ -37,7 +37,7 @@
 
     let formErrors = {};
     const schema = yup.object().shape({
-        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/', length: 2-128"),
+        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:', length: 2-64"),
     });
 
     function handleKeyPress(event) {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -27,7 +27,7 @@ export const REGEX_CONTACT = /^[a-zA-Z0-9+.@/:]{0,48}$/gm;
 export const REGEX_LOWERCASE_SPACE = /^[a-z0-9-_\/\s]{2,128}$/gm;
 export const REGEX_PROVIDER_SCOPE = /^[a-z0-9-_\/:\s]{0,128}$/gm;
 export const REGEX_PEM = /^(-----BEGIN CERTIFICATE-----)[a-zA-Z0-9+/=\n]+(-----END CERTIFICATE-----)$/gm;
-export const REGEX_ROLES = /^[a-z0-9\-_/]{2,128}$/gm;
+export const REGEX_ROLES = /^[a-z0-9\-_/:]{2,64}$/gm;
 export const REGEX_URI = /^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]*$/gm;
 export const REGEX_URI_SPACE = /^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%\s]+$/m;
 export const REGEX_IP_V4 = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/gm;

--- a/migrations/postgres/24_roles_groups_scopes_limit.sql
+++ b/migrations/postgres/24_roles_groups_scopes_limit.sql
@@ -1,0 +1,4 @@
+-- remove the limit checks on id and name fields for roles, groups, scopes
+-- to allow longer scope names like i.e. 'urn:ietf:params:oauth:grant-type:device_code'
+
+-- noop on postgres -> has been done with past migrations already

--- a/migrations/sqlite/24_roles_groups_scopes_limit.sql
+++ b/migrations/sqlite/24_roles_groups_scopes_limit.sql
@@ -1,0 +1,55 @@
+-- remove the limit checks on id and name fields for roles, groups, scopes
+-- to allow longer scope names like i.e. 'urn:ietf:params:oauth:grant-type:device_code'
+
+create table scopes_dg_tmp
+(
+    id                  varchar(36) not null
+        constraint scopes_pk
+            primary key,
+    name                varchar     not null,
+    attr_include_access varchar,
+    attr_include_id     varchar
+);
+
+insert into scopes_dg_tmp(id, name, attr_include_access, attr_include_id)
+select id, name, attr_include_access, attr_include_id
+from scopes;
+
+drop table scopes;
+
+alter table scopes_dg_tmp
+    rename to scopes;
+
+create table groups_dg_tmp
+(
+    id   varchar not null
+        constraint groups_pk
+            primary key,
+    name varchar not null
+);
+
+insert into groups_dg_tmp(id, name)
+select id, name
+from groups;
+
+drop table groups;
+
+alter table groups_dg_tmp
+    rename to groups;
+
+create table roles_dg_tmp
+(
+    id   varchar not null
+        constraint roles_pk
+            primary key,
+    name varchar not null
+);
+
+insert into roles_dg_tmp(id, name)
+select id, name
+from roles;
+
+drop table roles;
+
+alter table roles_dg_tmp
+    rename to roles;

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -99,7 +99,6 @@ lazy_static! {
 
     pub static ref RE_ATTR: Regex = Regex::new(r"^[a-zA-Z0-9-_/]{2,32}$").unwrap();
     pub static ref RE_ATTR_DESC: Regex = Regex::new(r"^[a-zA-Z0-9-_/\s]{0,128}$").unwrap();
-    pub static ref RE_SCOPE: Regex = Regex::new(r"^[a-z0-9-_/:\s]{0,128}$").unwrap();
     pub static ref RE_ALNUM: Regex = Regex::new(r"^[a-zA-Z0-9]+$").unwrap();
     pub static ref RE_ALNUM_24: Regex = Regex::new(r"^[a-zA-Z0-9]{24}$").unwrap();
     pub static ref RE_ALNUM_48: Regex = Regex::new(r"^[a-zA-Z0-9]{48}$").unwrap();
@@ -118,14 +117,17 @@ lazy_static! {
     pub static ref RE_DATE_STR: Regex = Regex::new(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$").unwrap();
     pub static ref RE_GRANT_TYPES: Regex = Regex::new(r"^(authorization_code|client_credentials|urn:ietf:params:oauth:grant-type:device_code|password|refresh_token)$").unwrap();
     pub static ref RE_GRANT_TYPES_EPHEMERAL: Regex = Regex::new(r"^(authorization_code|client_credentials|password|refresh_token)$").unwrap();
+    pub static ref RE_GROUPS: Regex = Regex::new(r"^[a-z0-9-_/,:]{2,64}$").unwrap();
     pub static ref RE_LOWERCASE: Regex = Regex::new(r"^[a-z0-9-_/]{2,128}$").unwrap();
     pub static ref RE_LOWERCASE_SPACE: Regex = Regex::new(r"^[a-z0-9-_/\s]{2,128}$").unwrap();
-    pub static ref RE_GROUPS: Regex = Regex::new(r"^[a-z0-9-_/,]{2,32}$").unwrap();
     pub static ref RE_MFA_CODE: Regex = Regex::new(r"^[a-zA-Z0-9]{48}$").unwrap();
     pub static ref RE_PEM: Regex = Regex::new(r"^(-----BEGIN CERTIFICATE-----)[a-zA-Z0-9+/=\n]+(-----END CERTIFICATE-----)$").unwrap();
     pub static ref RE_PHONE: Regex = Regex::new(r"^\+[0-9]{0,32}$").unwrap();
-    pub static ref RE_STREET: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-.\s]{0,48}$").unwrap();
+    // we have a pretty high upper limit for characters here just to be sure that even if
+    // multiple values like 'urn:ietf:params:oauth:grant-type:device_code' would not fail
+    pub static ref RE_SCOPE_SPACE: Regex = Regex::new(r"^[a-z0-9-_/:\s]{0,512}$").unwrap();
     pub static ref RE_SEARCH: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%@]+$").unwrap();
+    pub static ref RE_STREET: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-.\s]{0,48}$").unwrap();
     pub static ref RE_URI: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]+$").unwrap();
     pub static ref RE_USER_NAME: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-\s]{2,32}$").unwrap();
     pub static ref RE_TOKEN_68: Regex = Regex::new(r"^[a-zA-Z0-9-._~+/]+=*$").unwrap();


### PR DESCRIPTION
This will take care of a few things:

- remove the length limitations in the database for roles, groups and scopes (the API does full validation already)
- allow 64 instead of 32 long names on the api for these
- allow `:` to be contained in the names as well
- fix / adopt all other places where these changes cause issues

The reason behind this is to allow roles and groups names with a `:`, which can give you a bit nicer names, so you can have a better separation between different apps. For instance you could have roles like `app1:admin`, `app1:user`, `app2:admin`, ... .  

The fix for the scope especially makes it possible to allow longer scope names as well like `urn:ietf:params:oauth:grant-type:device_code` or `urn:matrix:client:api:guest`.