### PR TITLE
Expand scope groups roles validation - additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,14 @@ With the additional validation of the `at_hash` claim, clients can be 100% sure,
 belongs to a specific `access_token` and has not been swapped out.  
 [d506865](https://github.com/sebadob/rauthy/commit/d506865898e61fce45e5cf4c754ad4300bd37161)
 
+#### Better roles, groups and scopes names
+
+The allowed names for roles, groups and scopes have been adjusted. Rauthy allows names of up to 64 characters
+now and containing `:` or `*`. This will make it possible to define custom scopes with names like
+`urn:matrix:client:api:guest` or `urn:matrix:client:api:*`.
+
+[]()
+
 ### Bugfixes
 
 - The button for requesting a password reset from inside a federated account view has been

--- a/frontend/src/components/admin/groups/GroupConfig.svelte
+++ b/frontend/src/components/admin/groups/GroupConfig.svelte
@@ -28,7 +28,7 @@
 
     let formErrors = {};
     const schema = yup.object().shape({
-        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:', length: 2-64"),
+        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:*', length: 2-64"),
     });
 
     function handleKeyPress(event) {
@@ -48,7 +48,7 @@
         }
 
         let req = {
-            group: group.name
+            group: group.name.trim(),
         }
 
         let res = await putGroup(group.id, req);

--- a/frontend/src/components/admin/groups/GroupTileAddNew.svelte
+++ b/frontend/src/components/admin/groups/GroupTileAddNew.svelte
@@ -12,7 +12,7 @@
     export let onSave;
     let expandContainer;
 
-    let group = { group: '' };
+    let group = {group: ''};
 
     let err = '';
     let isLoading = false;
@@ -21,14 +21,14 @@
     let formErrors = {};
 
     const schema = yup.object().shape({
-        group: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/', length: 2-128"),
+        group: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:*', length: 2-64"),
     });
 
     $: if (success) {
         timer = setTimeout(() => {
             onSave();
             success = false;
-            group = { group: '' };
+            group = {group: ''};
             expandContainer = false;
         }, 1500);
     }
@@ -47,6 +47,7 @@
             return;
         }
 
+        group.group = group.group.trim();
         let res = await postGroup(group);
         if (res.ok) {
             success = true;

--- a/frontend/src/components/admin/roles/RoleConfig.svelte
+++ b/frontend/src/components/admin/roles/RoleConfig.svelte
@@ -28,7 +28,7 @@
 
     let formErrors = {};
     const schema = yup.object().shape({
-        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:', length: 2-64"),
+        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:*', length: 2-64"),
     });
 
     function handleKeyPress(event) {
@@ -48,7 +48,7 @@
         }
 
         let req = {
-            role: role.name
+            role: role.name.trim(),
         }
 
         let res = await putRole(role.id, req);

--- a/frontend/src/components/admin/roles/RoleTileAddNew.svelte
+++ b/frontend/src/components/admin/roles/RoleTileAddNew.svelte
@@ -12,7 +12,7 @@
     export let onSave;
     let expandContainer;
 
-    let role = { role: '' };
+    let role = {role: ''};
 
     let err = '';
     let isLoading = false;
@@ -21,13 +21,13 @@
     let formErrors = {};
 
     const schema = yup.object().shape({
-        role: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/', length: 2-128"),
+        role: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:*', length: 2-64"),
     });
 
     $: if (success) {
         timer = setTimeout(() => {
             success = false;
-            role = { role: '' };
+            role = {role: ''};
             expandContainer = false;
             onSave();
         }, 1500);
@@ -47,6 +47,7 @@
             return;
         }
 
+        role.role = role.role.trim();
         let res = await postRole(role);
         if (res.ok) {
             success = true;

--- a/frontend/src/components/admin/scopes/ScopeConfig.svelte
+++ b/frontend/src/components/admin/scopes/ScopeConfig.svelte
@@ -37,7 +37,7 @@
 
     let formErrors = {};
     const schema = yup.object().shape({
-        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:', length: 2-64"),
+        name: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:*', length: 2-64"),
     });
 
     function handleKeyPress(event) {
@@ -57,7 +57,7 @@
         }
 
         let req = {
-            scope: scope.name
+            scope: scope.name.trim(),
         }
         if (scope.attr_include_access.length > 0) {
             req.attr_include_access = scope.attr_include_access;

--- a/frontend/src/components/admin/scopes/ScopeTileAddNew.svelte
+++ b/frontend/src/components/admin/scopes/ScopeTileAddNew.svelte
@@ -12,7 +12,7 @@
     export let onSave;
     let expandContainer;
 
-    let scope = { scope: '' };
+    let scope = {scope: ''};
 
     let err = '';
     let isLoading = false;
@@ -21,14 +21,14 @@
     let formErrors = {};
 
     const schema = yup.object().shape({
-        scope: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/', length: 2-128"),
+        scope: yup.string().trim().matches(REGEX_ROLES, "Can only contain: 'a-z0-9-_/:*', length: 2-64"),
     });
 
     $: if (success) {
         timer = setTimeout(() => {
             onSave();
             success = false;
-            scope = { scope: '' };
+            scope = {scope: ''};
             expandContainer = false;
         }, 1500);
     }
@@ -47,6 +47,7 @@
             return;
         }
 
+        scope.scope = scope.scope.trim();
         let res = await postScope(scope);
         if (res.ok) {
             success = true;

--- a/frontend/src/lib/itemTiles/ItemTiles.svelte
+++ b/frontend/src/lib/itemTiles/ItemTiles.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <div class="container">
-    {#if items.length > 0}
+    {#if items?.length > 0}
         {#each items as item}
             <DeleteItemTile bind:label={item} onDelete={deleteItem}/>
         {/each}

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -27,7 +27,7 @@ export const REGEX_CONTACT = /^[a-zA-Z0-9+.@/:]{0,48}$/gm;
 export const REGEX_LOWERCASE_SPACE = /^[a-z0-9-_\/\s]{2,128}$/gm;
 export const REGEX_PROVIDER_SCOPE = /^[a-z0-9-_\/:\s]{0,128}$/gm;
 export const REGEX_PEM = /^(-----BEGIN CERTIFICATE-----)[a-zA-Z0-9+/=\n]+(-----END CERTIFICATE-----)$/gm;
-export const REGEX_ROLES = /^[a-z0-9\-_/:]{2,64}$/gm;
+export const REGEX_ROLES = /^[a-z0-9\-_/:*]{2,64}$/gm;
 export const REGEX_URI = /^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]*$/gm;
 export const REGEX_URI_SPACE = /^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%\s]+$/m;
 export const REGEX_IP_V4 = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/gm;

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -117,7 +117,7 @@ lazy_static! {
     pub static ref RE_DATE_STR: Regex = Regex::new(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$").unwrap();
     pub static ref RE_GRANT_TYPES: Regex = Regex::new(r"^(authorization_code|client_credentials|urn:ietf:params:oauth:grant-type:device_code|password|refresh_token)$").unwrap();
     pub static ref RE_GRANT_TYPES_EPHEMERAL: Regex = Regex::new(r"^(authorization_code|client_credentials|password|refresh_token)$").unwrap();
-    pub static ref RE_GROUPS: Regex = Regex::new(r"^[a-z0-9-_/,:]{2,64}$").unwrap();
+    pub static ref RE_GROUPS: Regex = Regex::new(r"^[a-z0-9-_/,:*]{2,64}$").unwrap();
     pub static ref RE_LOWERCASE: Regex = Regex::new(r"^[a-z0-9-_/]{2,128}$").unwrap();
     pub static ref RE_LOWERCASE_SPACE: Regex = Regex::new(r"^[a-z0-9-_/\s]{2,128}$").unwrap();
     pub static ref RE_MFA_CODE: Regex = Regex::new(r"^[a-zA-Z0-9]{48}$").unwrap();
@@ -125,7 +125,7 @@ lazy_static! {
     pub static ref RE_PHONE: Regex = Regex::new(r"^\+[0-9]{0,32}$").unwrap();
     // we have a pretty high upper limit for characters here just to be sure that even if
     // multiple values like 'urn:ietf:params:oauth:grant-type:device_code' would not fail
-    pub static ref RE_SCOPE_SPACE: Regex = Regex::new(r"^[a-z0-9-_/:\s]{0,512}$").unwrap();
+    pub static ref RE_SCOPE_SPACE: Regex = Regex::new(r"^[a-z0-9-_/:\s*]{0,512}$").unwrap();
     pub static ref RE_SEARCH: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%@]+$").unwrap();
     pub static ref RE_STREET: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-.\s]{0,48}$").unwrap();
     pub static ref RE_URI: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]+$").unwrap();

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -76,8 +76,8 @@ pub struct AuthRequest {
     /// Validation: `[a-z0-9-_/]{2,128}`
     #[validate(regex(path = "RE_LOWERCASE", code = "[a-z0-9-_/]{2,128}"))]
     pub response_type: String,
-    /// Validation: `[a-z0-9-_/:\s]{0,512}`
-    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s]{0,512}"))]
+    /// Validation: `[a-z0-9-_/:\s*]{0,512}`
+    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s*]{0,512}"))]
     #[serde(default = "default_scope")]
     pub scope: String,
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
@@ -163,8 +163,8 @@ pub struct DeviceGrantRequest {
     /// Validation: max length is 256
     #[validate(length(max = 256))]
     pub client_secret: Option<String>,
-    /// Validation: `[a-z0-9-_/:\s]{0,512}`
-    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s]{0,512}"))]
+    /// Validation: `[a-z0-9-_/:\s*]{0,512}`
+    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s*]{0,512}"))]
     pub scope: Option<String>,
 }
 
@@ -225,8 +225,8 @@ pub struct EphemeralClientRequest {
     /// Validation: `60 <= access_token_lifetime <= 86400`
     #[validate(range(min = 60, max = 86400))]
     pub default_max_age: Option<i32>,
-    /// Validation: `[a-z0-9-_/:\s]{0,512}`
-    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s]{0,512}"))]
+    /// Validation: `[a-z0-9-_/:\s*]{0,512}`
+    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s*]{0,512}"))]
     pub scope: Option<String>,
     pub require_auth_time: Option<bool>,
 
@@ -296,7 +296,7 @@ pub struct LoginRequest {
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$"))]
     pub redirect_uri: String,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_scopes"))]
     pub scopes: Option<Vec<String>>,
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
@@ -324,7 +324,7 @@ pub struct LoginRefreshRequest {
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$"))]
     pub redirect_uri: String,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_scopes"))]
     pub scopes: Option<Vec<String>>,
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
@@ -458,8 +458,8 @@ pub struct DynamicClientRequest {
 
 #[derive(Serialize, Deserialize, Validate, ToSchema)]
 pub struct NewGroupRequest {
-    /// Validation: `^[a-z0-9-_/,:]{2,64}$`
-    #[validate(regex(path = "RE_GROUPS", code = "^[a-z0-9-_/,:]{2,64}$"))]
+    /// Validation: `^[a-z0-9-_/,:*]{2,64}$`
+    #[validate(regex(path = "RE_GROUPS", code = "^[a-z0-9-_/,:*]{2,64}$"))]
     pub group: String,
 }
 
@@ -545,8 +545,8 @@ pub struct ProviderRequest {
     /// Validation: max length is 256
     #[validate(length(max = 256))]
     pub client_secret: Option<String>,
-    /// Validation: `[a-z0-9-_/:\s]{0,512}`
-    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s]{0,512}"))]
+    /// Validation: `[a-z0-9-_/:\s*]{0,512}`
+    #[validate(regex(path = "RE_SCOPE_SPACE", code = "[a-z0-9-_/:\\s*]{0,512}"))]
     pub scope: String,
     /// Validation: `(-----BEGIN CERTIFICATE-----)[a-zA-Z0-9+/=\n]+(-----END CERTIFICATE-----)`
     #[validate(regex(
@@ -600,7 +600,7 @@ pub struct ProviderLoginRequest {
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$"))]
     pub redirect_uri: String,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_scopes"))]
     pub scopes: Option<Vec<String>>,
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
@@ -657,10 +657,10 @@ pub struct NewUserRequest {
     #[validate(regex(path = "RE_USER_NAME", code = "[a-zA-Z0-9À-ÿ-\\s]{2,32}"))]
     pub given_name: String,
     pub language: Language,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_groups"))]
     pub groups: Option<Vec<String>>,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_roles"))]
     pub roles: Vec<String>,
     #[validate(range(min = 1672527600, max = 4070905200))]
@@ -687,8 +687,8 @@ pub struct NewUserRegistrationRequest {
 
 #[derive(Serialize, Deserialize, Validate, ToSchema)]
 pub struct NewRoleRequest {
-    /// Validation: `^[a-z0-9-_/,:]{2,64}$`
-    #[validate(regex(path = "RE_GROUPS", code = "^[a-z0-9-_/,:]{2,64}$"))]
+    /// Validation: `^[a-z0-9-_/,:*]{2,64}$`
+    #[validate(regex(path = "RE_GROUPS", code = "^[a-z0-9-_/,:*]{2,64}$"))]
     pub role: String,
 }
 
@@ -712,8 +712,8 @@ pub struct PasskeyRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
 pub struct ScopeRequest {
     // `RE_GROUPS` is correct here
-    /// Validation: `^[a-z0-9-_/,:]{2,64}$`
-    #[validate(regex(path = "RE_GROUPS", code = "^[a-z0-9-_/,:]{2,64}$"))]
+    /// Validation: `^[a-z0-9-_/,:*]{2,64}$`
+    #[validate(regex(path = "RE_GROUPS", code = "^[a-z0-9-_/,:*]{2,64}$"))]
     pub scope: String,
     /// Validation: `^[a-zA-Z0-9-_/]{2,128}$`
     #[validate(custom(function = "validate_vec_attr"))]
@@ -862,7 +862,7 @@ pub struct UpdateClientRequest {
     /// Validation: `10 <= access_token_lifetime <= 86400`
     #[validate(range(min = 10, max = 86400))]
     pub access_token_lifetime: i32,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_scopes"))]
     pub scopes: Vec<String>,
     /// Validation: `Vec<^[a-z0-9-_/:\s]{0,64}$>`
@@ -894,10 +894,10 @@ pub struct UpdateUserRequest {
     pub language: Option<Language>,
     /// Validation: Applies password policy
     pub password: Option<String>,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_roles"))]
     pub roles: Vec<String>,
-    /// Validation: `Vec<^[a-z0-9-_/,:]{2,64}$>`
+    /// Validation: `Vec<^[a-z0-9-_/,:*]{2,64}$>`
     #[validate(custom(function = "validate_vec_groups"))]
     pub groups: Option<Vec<String>>,
     pub enabled: bool,
@@ -1137,7 +1137,7 @@ fn validate_vec_groups(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
         if !RE_GROUPS.is_match(v) {
-            err = Some("^[a-z0-9-_/,:]{2,64}$");
+            err = Some("^[a-z0-9-_/,:*]{2,64}$");
         }
     });
     if let Some(e) = err {
@@ -1150,7 +1150,7 @@ fn validate_vec_roles(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
         if !RE_GROUPS.is_match(v) {
-            err = Some("^[a-z0-9-_/,:]{2,64}$");
+            err = Some("^[a-z0-9-_/,:*]{2,64}$");
         }
     });
     if let Some(e) = err {
@@ -1163,7 +1163,7 @@ fn validate_vec_scopes(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
         if !RE_GROUPS.is_match(v) {
-            err = Some("^[a-z0-9-_/,:]{2,64}$");
+            err = Some("^[a-z0-9-_/,:*]{2,64}$");
         }
     });
     if let Some(e) = err {


### PR DESCRIPTION
This will allow `*` as being valid inside scope names as well to allow `urn:matrix:client:api:*` and it does does some pre-request input string validation for roles, groups and scopes names in case a user has copied a value with trailing spaces.