### PR TITLE
feat: link provider to existing account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,18 @@ at the bottom as well.
 A new button has been introduced to the account view of federated accounts.  
 You can now "Unlink" an account from an upstream provider, if you have set it up with at least
 a password or passkey before.
+
 [8b1d9a8](https://github.com/sebadob/rauthy/commit/8b1d9a882b0d4b059f3ed884deaacfcdeb109856)
+
+#### Link Existing Account to Provider
+
+This is the counterpart to the unlink feature from above.
+This makes it possible to link an already existing, unlinked user account to an upstream auth provider.
+The only condition is a matching `email` claim after successful login. Apart from that, there are quite a few things
+going on behind the scenes and you must trigger this provider link from an authorized, valid session from inside your
+user account view. This is necessary to prevent account takeovers if an upstream provider has been hacked in some way.
+
+[]()
 
 #### Bootstrap default Admin in production
 
@@ -200,7 +211,8 @@ The allowed names for roles, groups and scopes have been adjusted. Rauthy allows
 now and containing `:` or `*`. This will make it possible to define custom scopes with names like
 `urn:matrix:client:api:guest` or `urn:matrix:client:api:*`.
 
-[]()
+[a5982d9](https://github.com/sebadob/rauthy/commit/a5982d91f37a2f2917ed4215dc6ded216dc0fd69)
+[50d0214](https://github.com/sebadob/rauthy/commit/50d021440eb50473977ec851a46c0bc979bbd12b)
 
 ### Bugfixes
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -4,9 +4,7 @@
 
 ## TODO before v0.23.0
 
-- link to upstream provider with existing account
 - sessions view needs pagination
-- check out the possibility to include SCIM
 
 ## Stage 1 - essentials
 
@@ -15,6 +13,7 @@
 ## Stage 2 - features - do before v1.0.0
 
 - prettify the UI
+- check out the possibility to include SCIM
 - update the book with all the new features
 - benchmarks and performance tuning
 - maybe get a nicer logo

--- a/frontend/src/components/account/AccInfo.svelte
+++ b/frontend/src/components/account/AccInfo.svelte
@@ -2,10 +2,11 @@
     import CheckIcon from "$lib/CheckIcon.svelte";
     import {buildWebIdUri, formatDateFromTs} from "../../utils/helpers.js";
     import {onMount} from "svelte";
-    import {getAuthProvidersTemplate} from "../../utils/helpers.js";
     import Button from "$lib/Button.svelte";
-    import Tooltip from "$lib/Tooltip.svelte";
     import {deleteUserProviderLink} from "../../utils/dataFetching.js";
+    import Modal from "$lib/Modal.svelte";
+    import getPkce from "oauth-pkce";
+    import {PKCE_VERIFIER_UPSTREAM} from "../../utils/constants.js";
 
     export let t;
     export let user = {};
@@ -15,12 +16,36 @@
     export let viewModePhone = false;
 
     let unlinkErr = false;
+    let showModal = true;
+    // let showModal = false;
+    let providersAvailable = [];
 
     $: isFederated = user.account_type.startsWith('federated');
     $: accType = isFederated ? `${user.account_type}: ${authProvider?.name || ''}` : user.account_type;
 
     $: classRow = viewModePhone ? 'rowPhone' : 'row';
     $: classLabel = viewModePhone ? 'labelPhone' : 'label';
+
+    onMount(() => {
+        // value for dev testing only
+        const providersTpl = [{
+            "id": "7F6N7fb3el3P5XimjJSaeD2o",
+            "name": "Rauthy IAM"
+        }, {"id": "7F6N7fb3el3P5XimjJSaeD2O", "name": "Rauthy IAM 2"}];
+        // const providersTpl = document?.getElementsByTagName("template").namedItem("auth_providers")?.innerHTML;
+        console.log(providersTpl);
+        providersAvailable = providersTpl;
+    })
+
+    function linkProvider(id) {
+        console.error('TODO linkProvider');
+        // getPkce(64, (error, {challenge, verifier}) => {
+        //     if (!error) {
+        //         localStorage.setItem(PKCE_VERIFIER_UPSTREAM, verifier);
+        //         providerLoginPkce(id, challenge);
+        //     }
+        // });
+    }
 
     async function unlinkProvider() {
         let res = await deleteUserProviderLink();
@@ -70,8 +95,39 @@
                         </div>
                     {/if}
                 </div>
-            {:else}
-                <!-- TODO -->
+            {:else if providersAvailable.length > 0}
+                <div
+                        role="button"
+                        tabindex="0"
+                        class="provider-link"
+                        on:click={() => showModal = !showModal}
+                        on:keypress={() => showModal = !showModal}
+                >
+                    {t.providerLink}
+                </div>
+                <Modal bind:showModal>
+                    <p>
+                        {t.providerLinkDesc}
+                    </p>
+
+                    <div class="providers">
+                        {#each providersAvailable as provider (provider.id)}
+                            <Button on:click={() => linkProvider(provider.id)} level={3}>
+                                <div class="flex-inline">
+                                    <img
+                                            src="{`/auth/v1/providers/${provider.id}/img`}"
+                                            alt=""
+                                            width="20"
+                                            height="20"
+                                    />
+                                    <span class="provider-name">
+                                        {provider.name}
+                                    </span>
+                                </div>
+                            </Button>
+                        {/each}
+                    </div>
+                </Modal>
             {/if}
         </div>
     </div>
@@ -133,13 +189,62 @@
             </span>
         </div>
     {/if}
-
 </div>
 
 <style>
     .container {
         margin: 0 .25rem;
         padding: 10px;
+    }
+
+    dialog {
+        animation: fade-out 0.7s ease-out;
+    }
+
+    dialog[open] {
+        animation: fade-in 0.7s ease-out;
+    }
+
+    dialog[open]::backdrop {
+        animation: backdrop-fade-in 0.7s ease-out forwards;
+    }
+
+    @keyframes fade-in {
+        0% {
+            opacity: 0;
+            transform: scaleY(0);
+            display: none;
+        }
+
+        100% {
+            opacity: 1;
+            transform: scaleY(1);
+            display: block;
+        }
+    }
+
+    @keyframes fade-out {
+        0% {
+            opacity: 1;
+            transform: scaleY(1);
+            display: block;
+        }
+
+        100% {
+            opacity: 0;
+            transform: scaleY(0);
+            display: none;
+        }
+    }
+
+    @keyframes backdrop-fade-in {
+        0% {
+            background-color: rgb(0 0 0 / 0%);
+        }
+
+        100% {
+            background-color: rgb(0 0 0 / 25%);
+        }
     }
 
     .label {
@@ -154,9 +259,29 @@
         margin-left: -5px;
     }
 
+    .flex-inline {
+        display: inline-flex;
+        align-items: center;
+        gap: .5rem;
+    }
+
     .link-err {
         margin-left: 5px;
         color: var(--col-err);
+    }
+
+    .provider-link {
+        color: var(--col-act2);
+        cursor: pointer;
+    }
+
+    .provider-name {
+        margin-bottom: -4px;
+    }
+
+    .providers {
+        margin-top: .66rem;
+        display: flex;
     }
 
     .row {

--- a/frontend/src/components/account/AccMain.svelte
+++ b/frontend/src/components/account/AccMain.svelte
@@ -40,7 +40,7 @@
     }
 
     $: if (providers) {
-        if (user.account_type.startsWith('federated')) {
+        if (user.account_type?.startsWith('federated')) {
             authProvider = providers.filter(p => p.id === user.auth_provider_id)[0];
         }
     }

--- a/frontend/src/lib/Modal.svelte
+++ b/frontend/src/lib/Modal.svelte
@@ -1,0 +1,90 @@
+<script>
+    import IconStop from "$lib/icons/IconStop.svelte";
+
+    /** @type {boolean} */
+    export let showModal;
+
+    /** @type {HTMLDialogElement} */
+    let dialog;
+
+    $: if (dialog && showModal) dialog.showModal();
+</script>
+
+<!-- According to MDN docs, a dialog element must not have a tabindex -->
+<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-noninteractive-element-interactions -->
+<dialog
+        bind:this={dialog}
+        on:close={() => (showModal = false)}
+        on:click|self={() => dialog.close()}
+>
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div on:click|stopPropagation>
+        <div
+                role="button"
+                tabindex="0"
+                class="close"
+                on:click={() => dialog.close()}
+        >
+            <IconStop color="var(--col-err)" width={24}/>
+        </div>
+        <div class="inner">
+            <slot></slot>
+        </div>
+    </div>
+</dialog>
+
+<style>
+    dialog {
+        border-radius: 3px;
+        border: none;
+        padding: 0;
+    }
+
+    dialog::backdrop {
+        background: rgba(0, 0, 0, 0.3);
+    }
+
+    dialog > div {
+        padding: 1rem;
+    }
+
+    dialog > div > div {
+        position: relative;
+    }
+
+    dialog[open] {
+        animation: zoom 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+
+    @keyframes zoom {
+        from {
+            transform: scale(0.95);
+        }
+        to {
+            transform: scale(1);
+        }
+    }
+
+    dialog[open]::backdrop {
+        animation: fade 0.2s ease-out;
+    }
+
+    @keyframes fade {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+
+    .close {
+        margin: -1rem -1rem 0 0;
+        cursor: pointer;
+        text-align: right;
+    }
+
+    .inner {
+        margin-top: -.5rem;
+    }
+</style>

--- a/frontend/src/lib/Modal.svelte
+++ b/frontend/src/lib/Modal.svelte
@@ -28,7 +28,13 @@
             <IconStop color="var(--col-err)" width={24}/>
         </div>
         <div class="inner">
-            <slot></slot>
+            <!--
+            Just make sure that whatever we have in here will be loaded / fetched lazy.
+            There is no need to load resources like images if the dialog is closed anyway.
+            -->
+            {#if showModal}
+                <slot></slot>
+            {/if}
         </div>
     </div>
 </dialog>

--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -407,7 +407,7 @@
                         <Button on:click={() => providerLogin(provider.id)} level={3}>
                             <div class="flex-inline">
                                 <img src="{`/auth/v1/providers/${provider.id}/img`}" alt="" width="20" height="20"/>
-                                {provider.name}
+                                <span class="providerName">{provider.name}</span>
                             </div>
                         </Button>
                     {/each}
@@ -513,6 +513,11 @@
 
     .providers {
         margin-top: .66rem;
+    }
+
+    .providerName {
+        /*margin-bottom: -14px;*/
+        margin-top: 4px;
     }
 
     .reg {

--- a/frontend/src/routes/providers/callback/+page.svelte
+++ b/frontend/src/routes/providers/callback/+page.svelte
@@ -42,6 +42,9 @@
             // -> all good, but needs additional passkey validation
             error = '';
             webauthnData = await res.json();
+        } else if (res.status === 204) {
+            // in case of a 204, we have done a user federation on an existing account -> just redirect
+            window.location.replace('/auth/v1/account');
         } else if (res.status === 403) {
             // we will get a forbidden if for instance the user already exists but without
             // any upstream provider link (or the wrong one)

--- a/frontend/src/utils/dataFetching.js
+++ b/frontend/src/utils/dataFetching.js
@@ -217,6 +217,14 @@ export async function getUserPasskeys(id) {
     });
 }
 
+export async function postUserProviderLink(id, data) {
+    return await fetch(`/auth/v1/providers/${id}/link`, {
+        method: 'POST',
+        headers: getCsrfHeaders(),
+        body: JSON.stringify(data),
+    });
+}
+
 export async function deleteUserProviderLink() {
     return await fetch('/auth/v1/providers/link', {
         method: 'DELETE',

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -25,6 +25,7 @@ pub const COOKIE_SESSION: &str = "rauthy-session";
 pub const COOKIE_MFA: &str = "rauthy-mfa";
 pub const COOKIE_LOCALE: &str = "locale";
 pub const COOKIE_UPSTREAM_CALLBACK: &str = "upstream_auth_callback";
+pub const PROVIDER_LINK_COOKIE: &str = "rauthy-provider-link";
 pub const PWD_RESET_COOKIE: &str = "rauthy-pwd-reset";
 pub const APP_ID_HEADER: &str = "mfa-app-id";
 pub const CSRF_HEADER: &str = "csrf-token";

--- a/rauthy-handlers/src/lib.rs
+++ b/rauthy-handlers/src/lib.rs
@@ -80,6 +80,11 @@ pub async fn map_auth_step(
 
             Ok((resp, res.has_password_been_hashed))
         }
+
+        AuthStep::ProviderLink => {
+            // TODO generate a new event type in this case?
+            Ok((HttpResponse::NoContent().finish(), false))
+        }
     }
 }
 

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -500,6 +500,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                             .service(auth_providers::delete_provider)
                             .service(auth_providers::get_provider_img)
                             .service(auth_providers::put_provider_img)
+                            .service(auth_providers::post_provider_link)
                             .service(blacklist::get_blacklist)
                             .service(blacklist::post_blacklist)
                             .service(blacklist::delete_blacklist)

--- a/rauthy-models/src/i18n/account.rs
+++ b/rauthy-models/src/i18n/account.rs
@@ -165,9 +165,9 @@ external provider or by local password. Do you want to request a reset?"#,
             password_reset: "Password Reset",
             phone: "Phone",
             provider_link: "Federate Account",
-            provider_link_desc: r#"You can allow linking to a federated account for a short period
-of time. After activating this function, you will get logged out and redirect to the login page.
-You can then choose an upstream provider which will be linked to this account, if the email matches."#,
+            provider_link_desc: r#"You can link this account to one of the following login providers.
+After activating this function, you will be redirected to the login page of the chosen one.
+After a successful login and if the email matches, your account will be linked."#,
             provider_unlink: "Unlink Federation",
             provider_unlink_desc: r#"Only if you have set up at least a password or a passkey for this
 account, you can unlink it from the upstream provider."#,
@@ -260,10 +260,10 @@ Login entweder per externem Provider oder lokalem Password möglich. Passwort Re
             password_reset: "Passwort Reset",
             phone: "Telefon",
             provider_link: "Account Verbinden",
-            provider_link_desc: r#"Das Verbinden dieses Accounts mit einem externen Provider kann
-für eine kurze Zeit erlaubt werden. Nach der Aktivierung foldet ein Ausloggen mit Umleitung zur
-Login Seite. Dort kann dann ein Account Provider gewählt werden. Sollte nach erfolgreichem Login
-die E-Mail Adresse übereinstimmen, wird sie mit diesem Account verbunden."#,
+            provider_link_desc: r#"Dieser Account kann mit einem der folgenden Login Provider
+verbunden werden. Nach der Aktivierung des Prozesses wird eine Weiterleitung auf die Login Seite
+des gewählten Providers ausgelöst. Nach erfolgreichem Login und bei Übereinstimmung der E-Mail
+Adressen wird dieser Account verknüpft."#,
             provider_unlink: "Verbindung Trennen",
             provider_unlink_desc: r#"Nur wenn mindestens ein Passwort oder ein Passkey für diesen
 Account gesetzt ist, kann die Verbindung zum Provider gelöst werden."#,

--- a/rauthy-models/src/i18n/index.rs
+++ b/rauthy-models/src/i18n/index.rs
@@ -27,16 +27,16 @@ impl I18nIndex<'_> {
     fn build_en() -> Self {
         Self {
             register: "Register",
-            account_login: "Account Login",
-            admin_login: "Admin Login",
+            account_login: "Account",
+            admin_login: "Admin",
         }
     }
 
     fn build_de() -> Self {
         Self {
             register: "Registrieren",
-            account_login: "Account Login",
-            admin_login: "Admin Login",
+            account_login: "Account",
+            admin_login: "Admin",
         }
     }
 }

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -28,6 +28,7 @@ pub mod templates;
 pub enum AuthStep {
     LoggedIn(AuthStepLoggedIn),
     AwaitWebauthn(AuthStepAwaitWebauthn),
+    ProviderLink,
 }
 
 pub struct AuthStepLoggedIn {

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -23,7 +23,7 @@ DANGER_COOKIE_INSECURE=false
 # provider login while running the UI in dev mode. Point it to the
 # full address, where ever your UI is running.
 # This will only be respected when `DEV_MODE == true` as well.
-#DEV_MODE_PROVIDER_CALLBACK_URL="localhost:5173
+#DEV_MODE_PROVIDER_CALLBACK_URL="localhost:5173"
 
 # Can be set to 'true' during local development to allow an HTTP scheme for the DPoP 'htu' claim
 # Will only be applied if `DEV_MODE == true` as well.
@@ -620,7 +620,7 @@ ENABLE_EPHEMERAL_CLIENTS=true
 # Can be set to 'true' to enable WebID functionality like needed
 # for things like Solid OIDC.
 # default: false
-ENABLE_WEB_ID=true
+#ENABLE_WEB_ID=true
 
 # If set to 'true', 'solid' will be added to the 'aud' claim from the ID token
 # for ephemeral clients.


### PR DESCRIPTION
The "unlink" from upstream auth provider already exsits.

This PR will take care about the possibility to link an existing, un-linked account to a configured upstream auth provider.