### PR TITLE
client: fix `device_grant` JWKS deserialization error with rauthy 0.23.0-beta1

### DIFF
--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rauthy-client"
-version = "0.4.0-20240427"
+version = "0.4.0-20240503"
 edition = "2021"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"
@@ -30,7 +30,7 @@ qrcode = ["device-code", "dep:qrcode"]
 # common
 base64 = "0.22.0"
 bincode = "1.3.3"
-cached = { version = "0.50.0", features = [] }
+cached = { version = "0.51", features = [] }
 chacha20poly1305 = { version = "0.10.1", features = ["std"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std"] }
 jwt-simple = { version = "0.12.6", default-features = false, features = ["pure-rust"] }

--- a/rauthy-client/src/provider.rs
+++ b/rauthy-client/src/provider.rs
@@ -87,7 +87,7 @@ pub struct OidcProvider {
     pub jwks_uri: String,
     // pub registration_endpoint: String,
     // pub check_session_iframe: String,
-    pub grant_types_supported: Vec<Flows>,
+    pub grant_types_supported: Vec<String>,
     pub response_types_supported: Vec<String>,
     pub id_token_signing_alg_values_supported: Vec<Algorithm>,
     pub token_endpoint_auth_signing_alg_values_supported: Vec<Algorithm>,
@@ -192,14 +192,4 @@ pub enum Algorithm {
 pub enum Challenge {
     plain,
     S256,
-}
-
-/// OIDC login flows
-#[allow(non_camel_case_types)]
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Flows {
-    authorization_code,
-    client_credentials,
-    password,
-    refresh_token,
 }


### PR DESCRIPTION
The `device_code` grant contains `:` from the RFC spec and could therefore not be deserialized into the current enum.
This PR changes the Enum to a String for the deserialization to support the new type and make the client to not crash.