### PR TITLE
Migrate to webauthn-rs:0.5 and prepare v0.23.0-beta2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "av1-grain"
@@ -877,6 +877,17 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56894edf5cd1efa7068d7454adeb7ce0b3da4ffa5ab08cfc06165bbc62f0c7"
+dependencies = [
+ "base64 0.21.7",
+ "paste",
+ "serde",
 ]
 
 [[package]]
@@ -1269,7 +1280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aa76ef19968577838a34d02848136bb9b6bdbfd7675fb968fe9c931bc434b33"
 dependencies = [
  "base64 0.13.1",
- "base64urlsafedata",
+ "base64urlsafedata 0.1.3",
  "hex",
  "openssl",
  "serde",
@@ -1656,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-runtime"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
 ]
@@ -1676,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-sync"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8db70494c13cae4ce67b4b4dafdaf828cf0df7237ab5b9e2fcabee4965d0a0a"
+checksum = "2cc213ac28dbe3eda41e1c1e40fad9a04b3ee3bb12f18dee5930a36aca7fa0e8"
 dependencies = [
  "deadpool-runtime",
 ]
@@ -3652,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3675,9 +3686,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -4711,9 +4722,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "relative-path"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -6782,12 +6793,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "webauthn-rs"
-version = "0.4.8"
+name = "webauthn-attestation-ca"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db00711c712414e93b019c4596315085792215bc2ac2d5872f9e8913b0a6316"
+checksum = "9b0f2ebaf5650ca15b515a761f31ed6477fa2312491cf632a71102ac22b82784"
 dependencies = [
- "base64urlsafedata",
+ "base64urlsafedata 0.5.0",
+ "openssl",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb9d7cdc9ec26e3e06f7e8ee1433e6fa3627c6c075ab3effbc3a2280c2f526c0"
+dependencies = [
+ "base64urlsafedata 0.5.0",
  "serde",
  "tracing",
  "url",
@@ -6797,17 +6821,19 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.4.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294c78c83f12153a51e1cf1e6970b5da1397645dada39033a9c3173a8fc4fc2b"
+checksum = "cf1ee1dc7f4138b8fd05a74a6eae93ddaf504c5a60861f1eb95d9de3172900b3"
 dependencies = [
- "base64 0.13.1",
- "base64urlsafedata",
+ "base64 0.21.7",
+ "base64urlsafedata 0.5.0",
  "compact_jwt",
  "der-parser",
+ "hex",
  "nom",
  "openssl",
  "rand",
+ "rand_chacha",
  "serde",
  "serde_cbor_2",
  "serde_json",
@@ -6815,17 +6841,19 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webauthn-attestation-ca",
  "webauthn-rs-proto",
  "x509-parser",
 ]
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.4.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24e638361a63ba5c0a0be6a60229490fcdf33740ed63df5bb6bdb627b52a138"
+checksum = "1f1c6dc254607f48eec3bdb35b86b377202436859ca1e4c9290afafd7349dcc3"
 dependencies = [
- "base64urlsafedata",
+ "base64 0.21.7",
+ "base64urlsafedata 0.5.0",
  "serde",
  "serde_json",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy"
-version = "0.23.0-beta1"
+version = "0.23.0-beta2"
 dependencies = [
  "actix-service",
  "actix-web",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-common"
-version = "0.23.0-beta1"
+version = "0.23.0-beta2"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-handlers"
-version = "0.23.0-beta1"
+version = "0.23.0-beta2"
 dependencies = [
  "actix",
  "actix-multipart",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-models"
-version = "0.23.0-beta1"
+version = "0.23.0-beta2"
 dependencies = [
  "accept-language",
  "actix",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-notify"
-version = "0.23.0-beta1"
+version = "0.23.0-beta2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-service"
-version = "0.23.0-beta1"
+version = "0.23.0-beta2"
 dependencies = [
  "actix-web",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 exclude = ["rauthy-client"]
 
 [workspace.package]
-version = "0.23.0-beta1"
+version = "0.23.0-beta2"
 edition = "2021"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 # v0.18 breaks a lot of things - sticking to 0.16 for now
 validator = { version = "0.16", features = ["derive"] }
-webauthn-rs = { version = "0.4", features = [
+webauthn-rs = { version = "0.5", features = [
     "danger-allow-state-serialisation", "danger-credential-internals", "resident-key-support"
 ] }
-webauthn-rs-proto = "0.4.9"
+webauthn-rs-proto = "0.5"

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -8,6 +8,7 @@
 
 ## Stage 2 - features - do before v1.0.0
 
+- migrate from `rusty_s3` to `s3_simple` to get rid of presigned URLs
 - prettify the UI
 - check out the possibility to include SCIM
 - update the book with all the new features
@@ -21,8 +22,8 @@
 
 ### `rauthy-client` TODO's
 
-- check possibility of `no_std` with `device_code` flow -> embedded devices
 - automatic `refresh_token` handler for `device_code` grant flow
+- add `fetch_userinfo()` for a `PrincipalOidc`
 - when implementing userinfo lookup, add an fn to validate the `at_hash` as well
 
 ## Stage 3 - Possible nice to haves

--- a/rauthy-models/src/entity/webauthn.rs
+++ b/rauthy-models/src/entity/webauthn.rs
@@ -25,7 +25,9 @@ use time::OffsetDateTime;
 use tracing::{error, info, warn};
 use utoipa::ToSchema;
 use webauthn_rs::prelude::*;
-use webauthn_rs_proto::{AuthenticatorSelectionCriteria, UserVerificationPolicy};
+use webauthn_rs_proto::{
+    AuthenticatorSelectionCriteria, ResidentKeyRequirement, UserVerificationPolicy,
+};
 
 #[derive(Debug, Clone, FromRow, Deserialize, Serialize)]
 pub struct PasskeyEntity {
@@ -59,7 +61,7 @@ impl PasskeyEntity {
             name,
             passkey_user_id: passkey_user_id.to_string(),
             passkey,
-            credential_id: pk.cred_id().0.clone(),
+            credential_id: pk.cred_id().to_vec(),
             registered: now,
             last_used: now,
             user_verified: Some(user_verified),
@@ -797,6 +799,7 @@ pub async fn reg_start(
                     } else {
                         Some(AuthenticatorSelectionCriteria {
                             authenticator_attachment: None,
+                            resident_key: Some(ResidentKeyRequirement::Discouraged),
                             require_resident_key: false,
                             user_verification: UserVerificationPolicy::Required,
                         })

--- a/rauthy-models/src/migration/db_migrate.rs
+++ b/rauthy-models/src/migration/db_migrate.rs
@@ -44,7 +44,7 @@ pub async fn anti_lockout(db: &DbPool, issuer: &str) -> Result<(), ErrorResponse
     debug!("Executing anti_lockout_check");
 
     let (redirect_uris, allowed_origins) = if *DEV_MODE {
-        let (ip, _) = PUB_URL.split_once(':').unwrap();
+        let (ip, _) = PUB_URL.split_once(':').expect("PUB_URL must have a port");
         let origin = if ip != "localhost" {
             format!("https://{}:5173", ip)
         } else {

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -872,7 +872,7 @@ LISTEN_PORT_HTTP=8080
 LISTEN_PORT_HTTPS=8443
 
 # The scheme to use locally, valid values: http | https | http_https (default: http_https)
-LISTEN_SCHEME=http_https
+LISTEN_SCHEME=http
 
 # The Public URL of the whole deployment
 # The LISTEN_SCHEME + PUB_URL must match the HTTP ORIGIN HEADER later on, which is especially important when running


### PR DESCRIPTION
Internal migration of `webauthn-rs` to v0.5.  
We will have another beta release just to be 100% sure that no existing keys break with the migration.