### PR TITLE
feat: suspicious req blacklist

### DIFF
--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -113,7 +113,16 @@ AUTH_HEADER_MFA=x-forwarded-user-mfa
 # preemptively for the set time in minutes.
 # You can disable it with setting it to `0`.
 # default: 1440
-BLACKLIST_SUSPICIOUS_REQUESTS=1440
+SUSPICIOUS_REQUESTS_BLACKLIST=1440
+
+# This will emit a log with level of warning if a request to `/` has
+# been made that has not been caught by any of the usual routes and
+# and handlers. Apart from a request to just `/` which will end in
+# a redirect to `/auth/v1`, all additional path's will be logged.
+# This can help to improve the internal suspicious blocklist in the
+# future.
+# default: false
+SUSPICIOUS_REQUESTS_LOG=true
 
 #####################################
 ############# BACKUPS ###############

--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -107,6 +107,14 @@ AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
 # default: x-forwarded-user-mfa
 AUTH_HEADER_MFA=x-forwarded-user-mfa
 
+# The "catch all" route handler on `/` will compare the request path
+# against a hardcoded list of common scan targets from bots and attackers.
+# If the path matches any of these targets, the IP will be blacklisted
+# preemptively for the set time in minutes.
+# You can disable it with setting it to `0`.
+# default: 1440
+BLACKLIST_SUSPICIOUS_REQUESTS=1440
+
 #####################################
 ############# BACKUPS ###############
 #####################################

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -160,6 +160,11 @@ lazy_static! {
     pub static ref AUTH_HEADER_MFA: String = env::var("AUTH_HEADER_MFA")
         .unwrap_or_else(|_| String::from("x-forwarded-user-mfa"));
 
+    pub static ref BLACKLIST_SUSPICIOUS_REQUESTS: u16 = env::var("AGGRESSIVE_SCAN_BLOCK_MINUTES")
+        .unwrap_or_else(|_| String::from("1440"))
+        .parse::<u16>()
+        .expect("AGGRESSIVE_SCAN_BLOCK_MINUTES cannot be parsed to u16 - bad format");
+
     pub static ref PUB_URL: String = env::var("PUB_URL").expect("PUB_URL env var is not set");
     pub static ref PUB_URL_WITH_SCHEME: String = {
         let scheme = if env::var("LISTEN_SCHEME").as_deref() == Ok("http") && !*PROXY_MODE {

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -160,10 +160,14 @@ lazy_static! {
     pub static ref AUTH_HEADER_MFA: String = env::var("AUTH_HEADER_MFA")
         .unwrap_or_else(|_| String::from("x-forwarded-user-mfa"));
 
-    pub static ref BLACKLIST_SUSPICIOUS_REQUESTS: u16 = env::var("AGGRESSIVE_SCAN_BLOCK_MINUTES")
+    pub static ref SUSPICIOUS_REQUESTS_BLACKLIST: u16 = env::var("SUSPICIOUS_REQUESTS_BLACKLIST")
         .unwrap_or_else(|_| String::from("1440"))
         .parse::<u16>()
-        .expect("AGGRESSIVE_SCAN_BLOCK_MINUTES cannot be parsed to u16 - bad format");
+        .expect("SUSPICIOUS_REQUESTS_BLACKLIST cannot be parsed to u16 - bad format");
+    pub static ref SUSPICIOUS_REQUESTS_LOG: bool = env::var("SUSPICIOUS_REQUESTS_LOG")
+        .unwrap_or_else(|_| String::from("false"))
+        .parse::<bool>()
+        .expect("SUSPICIOUS_REQUESTS_LOG cannot be parsed to bool - bad format");
 
     pub static ref PUB_URL: String = env::var("PUB_URL").expect("PUB_URL env var is not set");
     pub static ref PUB_URL_WITH_SCHEME: String = {

--- a/rauthy-handlers/src/generic.rs
+++ b/rauthy-handlers/src/generic.rs
@@ -2,10 +2,11 @@ use crate::{Assets, ReqPrincipal};
 use actix_web::http::header::{HeaderValue, CONTENT_TYPE};
 use actix_web::http::{header, StatusCode};
 use actix_web::{get, post, put, web, HttpRequest, HttpResponse, Responder};
+use chrono::Utc;
 use cryptr::EncKeys;
 use rauthy_common::constants::{
-    APPLICATION_JSON, CACHE_NAME_LOGIN_DELAY, HEADER_ALLOW_ALL_ORIGINS, HEADER_HTML,
-    IDX_LOGIN_TIME, RAUTHY_VERSION,
+    APPLICATION_JSON, BLACKLIST_SUSPICIOUS_REQUESTS, CACHE_NAME_LOGIN_DELAY,
+    HEADER_ALLOW_ALL_ORIGINS, HEADER_HTML, IDX_LOGIN_TIME, RAUTHY_VERSION,
 };
 use rauthy_common::error_response::ErrorResponse;
 use rauthy_common::utils::real_ip_from_req;
@@ -20,6 +21,7 @@ use rauthy_models::entity::pow::PowEntity;
 use rauthy_models::entity::sessions::Session;
 use rauthy_models::entity::users::User;
 use rauthy_models::events::event::Event;
+use rauthy_models::events::ip_blacklist_handler::{IpBlacklist, IpBlacklistReq};
 use rauthy_models::i18n::account::I18nAccount;
 use rauthy_models::i18n::authorize::I18nAuthorize;
 use rauthy_models::i18n::device::I18nDevice;
@@ -48,8 +50,9 @@ use rauthy_service::encryption;
 use redhac::{cache_get, cache_get_from, cache_get_value, QuorumHealth, QuorumState};
 use semver::Version;
 use std::borrow::Cow;
+use std::ops::Add;
 use std::str::FromStr;
-use tracing::error;
+use tracing::{error, warn};
 
 #[get("/")]
 pub async fn get_index(
@@ -672,9 +675,35 @@ pub async fn get_ready(data: web::Data<AppState>) -> impl Responder {
     HttpResponse::Ok().finish()
 }
 
-/// Redirects from root to the "real root" /auth/v1/
+/// Catch all - redirects from root to the "real root" /auth/v1/
+/// If `BLACKLIST_SUSPICIOUS_REQUESTS` is set, it will also compare the
+/// request path against common bot / hacker scan targets and blacklist preemptively.
 #[get("/")]
-pub async fn redirect() -> impl Responder {
+pub async fn catch_all(data: web::Data<AppState>, req: HttpRequest) -> impl Responder {
+    if *BLACKLIST_SUSPICIOUS_REQUESTS > 0 {
+        let path = req.path();
+        if rauthy_service::aggressive_scan_block::is_scan_target(path) {
+            let ip = real_ip_from_req(&req).unwrap_or_default();
+            warn!(
+                "Blacklisting suspicious target path request '{}' from {}",
+                path, ip,
+            );
+            let exp = Utc::now().add(chrono::Duration::minutes(
+                *BLACKLIST_SUSPICIOUS_REQUESTS as i64,
+            ));
+            if let Err(err) = data
+                .tx_ip_blacklist
+                .send_async(IpBlacklistReq::Blacklist(IpBlacklist { ip, exp }))
+                .await
+            {
+                error!(
+                    "Error blacklisting suspicious request - please repot this bug: {:?}",
+                    err
+                );
+            }
+        }
+    }
+
     HttpResponse::MovedPermanently()
         .insert_header((
             header::LOCATION,

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -458,7 +458,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
             )
             .wrap(pub_metrics.clone())
             .service(oidc::get_well_known)
-            .service(generic::redirect)
+            .service(generic::catch_all)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first
             .wrap(RauthyIpBlacklistMiddleware)

--- a/rauthy-service/src/aggressive_scan_block.rs
+++ b/rauthy-service/src/aggressive_scan_block.rs
@@ -1,0 +1,30 @@
+const START_WITH_TARGETS: [&str; 7] = [
+    "wp-admin",
+    "docker-compose",
+    "etc/",
+    ".aws",
+    ".env",
+    ".kube/",
+    ".ssh/",
+];
+
+const ENDS_WITH_TARGETS: [&str; 8] = [
+    ".json", ".yaml", ".yml", ".php", ".sql", ".xml", ".tar.gz", ".zip",
+];
+
+/// Scans the given url path for common scan targets from bots and attackers.
+pub fn is_scan_target(request_path: &str) -> bool {
+    for target in START_WITH_TARGETS {
+        if request_path.starts_with(target) {
+            return true;
+        }
+    }
+
+    for target in ENDS_WITH_TARGETS {
+        if request_path.ends_with(target) {
+            return true;
+        }
+    }
+
+    false
+}

--- a/rauthy-service/src/lib.rs
+++ b/rauthy-service/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod aggressive_scan_block;
 pub mod auth;
 pub mod client;
 pub mod encryption;

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -124,6 +124,14 @@ AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
 # default: x-forwarded-user-mfa
 AUTH_HEADER_MFA=x-forwarded-user-mfa
 
+# The "catch all" route handler on `/` will compare the request path
+# against a hardcoded list of common scan targets from bots and attackers.
+# If the path matches any of these targets, the IP will be blacklisted
+# preemptively for the set time in minutes.
+# You can disable it with setting it to `0`.
+# default: 1440
+BLACKLIST_SUSPICIOUS_REQUESTS=1440
+
 #####################################
 ############# BACKUPS ###############
 #####################################

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -130,7 +130,16 @@ AUTH_HEADER_MFA=x-forwarded-user-mfa
 # preemptively for the set time in minutes.
 # You can disable it with setting it to `0`.
 # default: 1440
-BLACKLIST_SUSPICIOUS_REQUESTS=1440
+SUSPICIOUS_REQUESTS_BLACKLIST=1440
+
+# This will emit a log with level of warning if a request to `/` has
+# been made that has not been caught by any of the usual routes and
+# and handlers. Apart from a request to just `/` which will end in
+# a redirect to `/auth/v1`, all additional path's will be logged.
+# This can help to improve the internal suspicious blocklist in the
+# future.
+# default: false
+SUSPICIOUS_REQUESTS_LOG=true
 
 #####################################
 ############# BACKUPS ###############


### PR DESCRIPTION
I recently see an increase in automated scanning in access logs from bots and other "people" for common misconfiguration, leaking secrets, and so on.  
This lead me to implementing a simple scanner in Rauthy's "catch all" route handler which will preemtively block IPs that do these scans. In the future these maybe can be reported automatically to [crowdsec](https://github.com/crowdsecurity/crowdsec).

There is a new config variable:

```
# The "catch all" route handler on `/` will compare the request path
# against a hardcoded list of common scan targets from bots and attackers.
# If the path matches any of these targets, the IP will be blacklisted
# preemptively for the set time in minutes.
# You can disable it with setting it to `0`.
# default: 1440
SUSPICIOUS_REQUESTS_BLACKLIST=1440

# This will emit a log with level of warning if a request to `/` has
# been made that has not been caught by any of the usual routes and
# and handlers. Apart from a request to just `/` which will end in
# a redirect to `/auth/v1`, all additional path's will be logged.
# This can help to improve the internal suspicious blocklist in the
# future.
# default: false
SUSPICIOUS_REQUESTS_LOG=true
```