### PR TITLE
Feat: configurable cookie settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ docker run --rm -p 8080:8080 ghcr.io/sebadob/rauthy:0.22.1-lite
 
 **Note on using Safari:**
 
-If you want to test with Safari with plain HTTP, you need to add `-e DANGER_COOKIE_INSECURE=true`.
+If you want to test with Safari with plain HTTP, you need to add `-e COOKIE_MODE=danger-insecure`.
 Rauthy always builds secure cookies by default, but Safari does not treat localhost as secure like
-all other browsers. This option has been implemented in `v0.22.2-20240424-1`. So you might test with:
+all other browsers. This option has been implemented in `v0.23.0-beta3`. So you might test with:
 
 ```
-docker run --rm -p 8080:8080 -e DANGER_COOKIE_INSECURE=true ghcr.io/sebadob/rauthy:0.23.0-beta1-lite
+docker run --rm -p 8080:8080 -e COOKIE_MODE=danger-insecure ghcr.io/sebadob/rauthy:0.23.0-beta3-lite
 ```
 
 ## Contributing

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -2,11 +2,6 @@
 
 ## CURRENT WORK
 
-## TODO before v0.23.0
-
-- add `devices` + `refresh_tokens_devices` tables to `db_migrate()`
-- make cookie setting configurable -> path(/auth) vs __Host-*
-
 ## Stage 1 - essentials
 
 [x] finished

--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -107,21 +107,21 @@ AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
 # default: x-forwarded-user-mfa
 AUTH_HEADER_MFA=x-forwarded-user-mfa
 
-# You can set different security levels for Rauthy's cookie.
-# The safest option would be 'host', but may not be desireable when
+# You can set different security levels for Rauthy's cookies.
+# The safest option would be 'host', but may not be desirable when
 # you host an application on the same origin behind a reverse proxy.
 # In this case you might want to restrict to 'secure', which will then
 # take the COOKIE_PATH from below into account.
 # The last option is 'danger-insecure' which really should never be used
 # unless you are just testing on localhost on you are using Safari.
-COOKIE_MODE=host
+#COOKIE_MODE=host
 
 # If set to 'true', Rauthy will bind the cookie to the `/auth` path.
 # You may want to change this only for very specific reasons and if
 # you are in such a situation, where you need this, you will know it.
 # Otherwise don't change this value.
 # default: true
-COOKIE_SET_PATH=true
+#COOKIE_SET_PATH=true
 
 # The "catch all" route handler on `/` will compare the request path
 # against a hardcoded list of common scan targets from bots and attackers.

--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -107,6 +107,22 @@ AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
 # default: x-forwarded-user-mfa
 AUTH_HEADER_MFA=x-forwarded-user-mfa
 
+# You can set different security levels for Rauthy's cookie.
+# The safest option would be 'host', but may not be desireable when
+# you host an application on the same origin behind a reverse proxy.
+# In this case you might want to restrict to 'secure', which will then
+# take the COOKIE_PATH from below into account.
+# The last option is 'danger-insecure' which really should never be used
+# unless you are just testing on localhost on you are using Safari.
+COOKIE_MODE=host
+
+# If set to 'true', Rauthy will bind the cookie to the `/auth` path.
+# You may want to change this only for very specific reasons and if
+# you are in such a situation, where you need this, you will know it.
+# Otherwise don't change this value.
+# default: true
+COOKIE_SET_PATH=true
+
 # The "catch all" route handler on `/` will compare the request path
 # against a hardcoded list of common scan targets from bots and attackers.
 # If the path matches any of these targets, the IP will be blacklisted

--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -6,6 +6,13 @@ use std::env;
 use std::str::FromStr;
 use std::string::ToString;
 
+#[derive(Debug, PartialEq)]
+pub enum CookieMode {
+    Host,
+    Secure,
+    DangerInsecure,
+}
+
 pub const RAUTHY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const CONTENT_TYPE_WEBP: &str = "image/webp";
@@ -21,10 +28,10 @@ pub const TOKEN_API_KEY: &str = "API-Key";
 pub const TOKEN_BEARER: &str = "Bearer";
 pub const TOKEN_DPOP: &str = "DPoP";
 pub const TOKEN_DPOP_NONCE: &str = "DPoP-nonce";
-pub const COOKIE_SESSION: &str = "rauthy-session";
-pub const COOKIE_MFA: &str = "rauthy-mfa";
+pub const COOKIE_SESSION: &str = "RauthySession";
+pub const COOKIE_MFA: &str = "RauthyMfa";
 pub const COOKIE_LOCALE: &str = "locale";
-pub const COOKIE_UPSTREAM_CALLBACK: &str = "upstream_auth_callback";
+pub const COOKIE_UPSTREAM_CALLBACK: &str = "UpstreamAuthCallback";
 pub const PROVIDER_LINK_COOKIE: &str = "rauthy-provider-link";
 pub const PWD_RESET_COOKIE: &str = "rauthy-pwd-reset";
 pub const APP_ID_HEADER: &str = "mfa-app-id";
@@ -87,10 +94,6 @@ lazy_static! {
         .unwrap_or_else(|_| String::from("false"))
         .parse::<bool>()
         .expect("DEV_MODE cannot be parsed to bool - bad format");
-    pub static ref DANGER_COOKIE_INSECURE: bool = env::var("DANGER_COOKIE_INSECURE")
-        .unwrap_or_else(|_| String::from("false"))
-        .parse::<bool>()
-        .expect("DANGER_COOKIE_INSECURE cannot be parsed to bool - bad format");
     pub static ref DEV_DPOP_HTTP: bool = env::var("DEV_DPOP_HTTP")
         .unwrap_or_else(|_| String::from("false"))
         .parse::<bool>()
@@ -159,6 +162,20 @@ lazy_static! {
         .unwrap_or_else(|_| String::from("x-forwarded-user-given-name"));
     pub static ref AUTH_HEADER_MFA: String = env::var("AUTH_HEADER_MFA")
         .unwrap_or_else(|_| String::from("x-forwarded-user-mfa"));
+
+    pub static ref COOKIE_MODE: CookieMode = {
+        let var = env::var("COOKIE_MODE").unwrap_or_else(|_| "host".to_string());
+        match var.as_str() {
+            "host" => CookieMode::Host,
+            "secure" => CookieMode::Secure,
+            "danger-insecure" => CookieMode::DangerInsecure,
+            _ => panic!("COOKIE_MODE must be one of: host, secure, danger-insecure")
+        }
+    };
+    pub static ref COOKIE_SET_PATH: bool = env::var("COOKIE_SET_PATH")
+        .unwrap_or_else(|_| String::from("true"))
+        .parse::<bool>()
+        .expect("COOKIE_SET_PATH cannot be parsed to bool - bad format");
 
     pub static ref SUSPICIOUS_REQUESTS_BLACKLIST: u16 = env::var("SUSPICIOUS_REQUESTS_BLACKLIST")
         .unwrap_or_else(|_| String::from("1440"))

--- a/rauthy-handlers/src/generic.rs
+++ b/rauthy-handlers/src/generic.rs
@@ -764,3 +764,17 @@ pub async fn get_version(data: web::Data<AppState>) -> Result<HttpResponse, Erro
     };
     Ok(HttpResponse::Ok().json(resp))
 }
+
+/// Returns the remote IP that Rauthy has extracted for this client
+#[utoipa::path(
+    get,
+    path = "/whoami",
+    tag = "generic",
+    responses(
+        (status = 200, description = "Ok"),
+    ),
+)]
+#[get("/whoami")]
+pub async fn get_whoami(req: HttpRequest) -> String {
+    real_ip_from_req(&req).unwrap_or_default()
+}

--- a/rauthy-handlers/src/lib.rs
+++ b/rauthy-handlers/src/lib.rs
@@ -5,6 +5,7 @@
 use actix_web::{web, HttpRequest, HttpResponse};
 use rauthy_common::constants::COOKIE_MFA;
 use rauthy_common::error_response::ErrorResponse;
+use rauthy_models::api_cookie::ApiCookie;
 use rauthy_models::entity::api_keys::ApiKey;
 use rauthy_models::entity::principal::Principal;
 use rauthy_models::entity::sessions::Session;
@@ -68,9 +69,11 @@ pub async fn map_auth_step(
             if let Some((name, value)) = res.header_origin {
                 resp.headers_mut().insert(name, value);
             }
-
+            //
             // if there is no mfa_cookie present, set a new one
-            if let Ok(mfa_cookie) = WebauthnCookie::parse_validate(&req.cookie(COOKIE_MFA)) {
+            if let Ok(mfa_cookie) =
+                WebauthnCookie::parse_validate(&ApiCookie::from_req(req, COOKIE_MFA))
+            {
                 if mfa_cookie.email != res.email {
                     add_req_mfa_cookie(&mut resp, res.email.clone()).map_err(|err| (err, true))?;
                 }

--- a/rauthy-handlers/src/middleware/principal.rs
+++ b/rauthy-handlers/src/middleware/principal.rs
@@ -6,6 +6,7 @@ use futures::future::LocalBoxFuture;
 use rauthy_common::constants::{COOKIE_SESSION, SESSION_VALIDATE_IP, TOKEN_API_KEY};
 use rauthy_common::error_response::{ErrorResponse, ErrorResponseType};
 use rauthy_common::utils::real_ip_from_svc_req;
+use rauthy_models::api_cookie::ApiCookie;
 use rauthy_models::app_state::AppState;
 use rauthy_models::entity::api_keys::{ApiKey, ApiKeyEntity};
 use rauthy_models::entity::principal::Principal;
@@ -117,7 +118,7 @@ async fn get_session_from_cookie(
     req: &ServiceRequest,
     data: &web::Data<AppState>,
 ) -> Result<Option<Session>, ErrorResponse> {
-    let session_id = match req.cookie(COOKIE_SESSION) {
+    let session_id = match ApiCookie::from_svc_req(req, COOKIE_SESSION) {
         None => {
             return Ok(None);
         }

--- a/rauthy-handlers/src/oidc.rs
+++ b/rauthy-handlers/src/oidc.rs
@@ -13,6 +13,7 @@ use rauthy_common::constants::{
 };
 use rauthy_common::error_response::{ErrorResponse, ErrorResponseType};
 use rauthy_common::utils::real_ip_from_req;
+use rauthy_models::api_cookie::ApiCookie;
 use rauthy_models::app_state::AppState;
 use rauthy_models::entity::api_keys::{AccessGroup, AccessRights};
 use rauthy_models::entity::auth_providers::AuthProviderTemplate;
@@ -111,7 +112,7 @@ pub async fn get_authorize(
 
     // check if the user needs to do the Webauthn login each time
     let mut action = FrontendAction::None;
-    if let Ok(mfa_cookie) = WebauthnCookie::parse_validate(&req.cookie(COOKIE_MFA)) {
+    if let Ok(mfa_cookie) = WebauthnCookie::parse_validate(&ApiCookie::from_req(&req, COOKIE_MFA)) {
         if let Ok(user) = User::find_by_email(&data, mfa_cookie.email.clone()).await {
             // we need to check this, because a user could deactivate MFA in another browser or
             // be deleted while still having existing mfa cookies somewhere else

--- a/rauthy-handlers/src/openapi.rs
+++ b/rauthy-handlers/src/openapi.rs
@@ -71,6 +71,7 @@ use utoipa::{openapi, OpenApi};
         generic::get_ready,
         generic::ping,
         generic::get_version,
+        generic::get_whoami,
 
         groups::get_groups,
         groups::post_group,

--- a/rauthy-main/src/main.rs
+++ b/rauthy-main/src/main.rs
@@ -516,6 +516,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                             .service(generic::post_i18n)
                             .service(generic::post_update_language)
                             .service(generic::get_version)
+                            .service(generic::get_whoami)
                             .service(oidc::get_authorize)
                             .service(oidc::post_authorize)
                             .service(oidc::post_authorize_refresh)

--- a/rauthy-main/tests/handler_auth.rs
+++ b/rauthy-main/tests/handler_auth.rs
@@ -268,7 +268,6 @@ async fn test_authorization_code_flow() -> Result<(), Box<dyn Error>> {
         ],
         access_token_alg: JwkKeyPairAlg::RS384,
         id_token_alg: JwkKeyPairAlg::EdDSA,
-        refresh_token: true,
         auth_code_lifetime: 120,
         access_token_lifetime: 60,
         scopes: vec![

--- a/rauthy-main/tests/zza_handler_cust_attrs.rs
+++ b/rauthy-main/tests/zza_handler_cust_attrs.rs
@@ -119,7 +119,6 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         flows_enabled: c.flows_enabled,
         access_token_alg: JwkKeyPairAlg::from(c.access_token_alg),
         id_token_alg: JwkKeyPairAlg::from(c.id_token_alg),
-        refresh_token: c.refresh_token,
         auth_code_lifetime: c.auth_code_lifetime,
         access_token_lifetime: c.access_token_lifetime,
         scopes,

--- a/rauthy-main/tests/zzc_handler_clients.rs
+++ b/rauthy-main/tests/zzc_handler_clients.rs
@@ -40,7 +40,6 @@ async fn test_clients() -> Result<(), Box<dyn Error>> {
     assert_eq!(client.flows_enabled.len(), 1);
     assert_eq!(client.access_token_alg, "EdDSA");
     assert_eq!(client.id_token_alg, "EdDSA");
-    assert_eq!(client.refresh_token, false);
     assert_eq!(client.auth_code_lifetime, 10);
     assert_eq!(client.access_token_lifetime, 10);
     assert_eq!(client.scopes.len(), 2);
@@ -99,7 +98,6 @@ async fn test_clients() -> Result<(), Box<dyn Error>> {
         flows_enabled,
         access_token_alg: JwkKeyPairAlg::RS256,
         id_token_alg: JwkKeyPairAlg::RS256,
-        refresh_token: true,
         auth_code_lifetime: 60,
         access_token_lifetime: 900,
         scopes: vec![
@@ -148,7 +146,6 @@ async fn test_clients() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(client.access_token_alg, "RS256");
     assert_eq!(client.id_token_alg, "RS256");
-    assert_eq!(client.refresh_token, true);
     assert_eq!(client.auth_code_lifetime, 60);
     assert_eq!(client.access_token_lifetime, 900);
     assert!(client.scopes.contains(&"openid".to_string()));

--- a/rauthy-main/tests/zzz_ip_blacklist.rs
+++ b/rauthy-main/tests/zzz_ip_blacklist.rs
@@ -25,7 +25,7 @@ async fn test_ip_blacklist() -> Result<(), Box<dyn Error>> {
     assert_eq!(res.status(), StatusCode::OK);
 
     // get the IP with which we are coming in at the backend from this test
-    let url_ip = format!("{}/whoami?typ=ip", get_backend_url());
+    let url_ip = format!("{}/whoami", get_backend_url());
     let res = client.get(&url_ip).send().await?;
     assert_eq!(res.status(), StatusCode::OK);
     let ip = res.text().await?.parse::<Ipv4Addr>().unwrap();

--- a/rauthy-models/src/api_cookie.rs
+++ b/rauthy-models/src/api_cookie.rs
@@ -1,0 +1,64 @@
+use actix_web::cookie::{Cookie, SameSite};
+use actix_web::dev::ServiceRequest;
+use actix_web::{cookie, HttpRequest};
+use rauthy_common::constants::{CookieMode, COOKIE_MODE, COOKIE_SET_PATH};
+use std::borrow::Cow;
+use std::fmt::Display;
+use tracing::warn;
+
+pub struct ApiCookie;
+
+impl ApiCookie {
+    pub fn build<'c, N, V>(name: N, value: V, max_age: i64) -> Cookie<'c>
+    where
+        N: Into<Cow<'c, str>> + Display,
+        V: Into<Cow<'c, str>> + Display,
+    {
+        let path = if *COOKIE_SET_PATH { "/auth" } else { "/" };
+        let (name, secure, path) = match *COOKIE_MODE {
+            CookieMode::Host => (format!("__Host-{}", name), true, "/"),
+            CookieMode::Secure => (format!("__Secure-{}", name), true, path),
+            CookieMode::DangerInsecure => {
+                warn!("Building INSECURE session cookie - you MUST NEVER use this in production");
+                (name.to_string(), false, path)
+            }
+        };
+        let max_age = if max_age < 1 {
+            cookie::time::Duration::ZERO
+        } else {
+            cookie::time::Duration::seconds(max_age)
+        };
+
+        Cookie::build(name, value)
+            .secure(secure)
+            .http_only(true)
+            .same_site(SameSite::Lax)
+            .max_age(max_age)
+            .path(path)
+            .finish()
+    }
+
+    pub fn from_req<'c, N>(req: &HttpRequest, cookie_name: N) -> Option<Cookie<'c>>
+    where
+        N: Into<Cow<'c, str>> + Display,
+    {
+        let name = match *COOKIE_MODE {
+            CookieMode::Host => format!("__Host-{}", cookie_name),
+            CookieMode::Secure => format!("__Secure-{}", cookie_name),
+            CookieMode::DangerInsecure => cookie_name.to_string(),
+        };
+        req.cookie(&name)
+    }
+
+    pub fn from_svc_req<'c, N>(req: &ServiceRequest, cookie_name: N) -> Option<Cookie<'c>>
+    where
+        N: Into<Cow<'c, str>> + Display,
+    {
+        let name = match *COOKIE_MODE {
+            CookieMode::Host => format!("__Host-{}", cookie_name),
+            CookieMode::Secure => format!("__Secure-{}", cookie_name),
+            CookieMode::DangerInsecure => cookie_name.to_string(),
+        };
+        req.cookie(&name)
+    }
+}

--- a/rauthy-models/src/api_cookie.rs
+++ b/rauthy-models/src/api_cookie.rs
@@ -19,7 +19,7 @@ impl ApiCookie {
             CookieMode::Host => (format!("__Host-{}", name), true, "/"),
             CookieMode::Secure => (format!("__Secure-{}", name), true, path),
             CookieMode::DangerInsecure => {
-                warn!("Building INSECURE session cookie - you MUST NEVER use this in production");
+                warn!("Building INSECURE cookie - you MUST NEVER use this in production");
                 (name.to_string(), false, path)
             }
         };

--- a/rauthy-models/src/entity/jwk.rs
+++ b/rauthy-models/src/entity/jwk.rs
@@ -905,6 +905,7 @@ mod tests {
                 typ: JwtTokenType::Refresh,
                 uid: "user_id_13337".to_string(),
                 cnf: None,
+                did: None,
             },
             coarsetime::Duration::from_secs(300),
         );

--- a/rauthy-models/src/entity/magic_links.rs
+++ b/rauthy-models/src/entity/magic_links.rs
@@ -1,3 +1,4 @@
+use crate::api_cookie::ApiCookie;
 use crate::app_state::AppState;
 use actix_web::{web, HttpRequest};
 use rauthy_common::constants::{PASSWORD_RESET_COOKIE_BINDING, PWD_CSRF_HEADER, PWD_RESET_COOKIE};
@@ -202,7 +203,7 @@ impl MagicLink {
                 ),
             );
 
-            let cookie_opt = req.cookie(PWD_RESET_COOKIE);
+            let cookie_opt = ApiCookie::from_req(req, PWD_RESET_COOKIE);
             if let Some(cookie) = cookie_opt {
                 // the extracted cookie from the request starts with 'rauthy-pwd-reset='
                 if !cookie.value().ends_with(self.cookie.as_ref().unwrap()) {

--- a/rauthy-models/src/language.rs
+++ b/rauthy-models/src/language.rs
@@ -69,6 +69,8 @@ impl TryFrom<&HttpRequest> for Language {
     type Error = ErrorResponse;
 
     fn try_from(value: &HttpRequest) -> Result<Self, Self::Error> {
+        // Do not use ApiCookie::from_req here since this cookie is non-sensitive and
+        // set via the UI and JS
         if let Some(cookie) = value.cookie(COOKIE_LOCALE) {
             debug!("locale cookie {:?}", cookie);
             return Ok(Language::from(cookie.value()));

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -14,6 +14,7 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use utoipa::ToSchema;
 
+pub mod api_cookie;
 pub mod app_state;
 pub mod email;
 pub mod entity;

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -118,21 +118,21 @@ AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
 # default: x-forwarded-user-mfa
 AUTH_HEADER_MFA=x-forwarded-user-mfa
 
-# You can set different security levels for Rauthy's cookie.
-# The safest option would be 'host', but may not be desireable when
+# You can set different security levels for Rauthy's cookies.
+# The safest option would be 'host', but may not be desirable when
 # you host an application on the same origin behind a reverse proxy.
 # In this case you might want to restrict to 'secure', which will then
 # take the COOKIE_PATH from below into account.
 # The last option is 'danger-insecure' which really should never be used
 # unless you are just testing on localhost on you are using Safari.
-COOKIE_MODE=host
+#COOKIE_MODE=host
 
 # If set to 'true', Rauthy will bind the cookie to the `/auth` path.
 # You may want to change this only for very specific reasons and if
 # you are in such a situation, where you need this, you will know it.
 # Otherwise don't change this value.
 # default: true
-COOKIE_SET_PATH=false
+#COOKIE_SET_PATH=true
 
 # The "catch all" route handler on `/` will compare the request path
 # against a hardcoded list of common scan targets from bots and attackers.

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -8,12 +8,6 @@
 # !!! DO NOT USE IN PRODUCTION !!!
 DEV_MODE=true
 
-# Can be set to 'true' to build an insecure cookie for local testing.
-# This is only needed for Safari in local development, since
-# it does not treat localhost as a secure environment.
-# default: false
-DANGER_COOKIE_INSECURE=false
-
 # This will replace the redirect port for the auth provider
 # callback URI to make the login flow work, when the UI is running
 # in dev mode. Without this set, the redirect URI will always be
@@ -123,6 +117,22 @@ AUTH_HEADER_FAMILY_NAME=x-forwarded-user-family-name
 AUTH_HEADER_GIVEN_NAME=x-forwarded-user-given-name
 # default: x-forwarded-user-mfa
 AUTH_HEADER_MFA=x-forwarded-user-mfa
+
+# You can set different security levels for Rauthy's cookie.
+# The safest option would be 'host', but may not be desireable when
+# you host an application on the same origin behind a reverse proxy.
+# In this case you might want to restrict to 'secure', which will then
+# take the COOKIE_PATH from below into account.
+# The last option is 'danger-insecure' which really should never be used
+# unless you are just testing on localhost on you are using Safari.
+COOKIE_MODE=host
+
+# If set to 'true', Rauthy will bind the cookie to the `/auth` path.
+# You may want to change this only for very specific reasons and if
+# you are in such a situation, where you need this, you will know it.
+# Otherwise don't change this value.
+# default: true
+COOKIE_SET_PATH=false
 
 # The "catch all" route handler on `/` will compare the request path
 # against a hardcoded list of common scan targets from bots and attackers.


### PR DESCRIPTION
Rauthy's cookie settings are now configurable to provide more flexibility depending on the final deployment and integration with possibly other apps hosted on the same domain or even origin.

The still unreleased `DANGER_COOKIE_INSECURE`  value has been removed again and instead we have 2 new config variables:

```
# You can set different security levels for Rauthy's cookies.
# The safest option would be 'host', but may not be desirable when
# you host an application on the same origin behind a reverse proxy.
# In this case you might want to restrict to 'secure', which will then
# take the COOKIE_PATH from below into account.
# The last option is 'danger-insecure' which really should never be used
# unless you are just testing on localhost on you are using Safari.
COOKIE_MODE=host

# If set to 'true', Rauthy will bind the cookie to the `/auth` path.
# You may want to change this only for very specific reasons and if
# you are in such a situation, where you need this, you will know it.
# Otherwise don't change this value.
# default: true
COOKIE_SET_PATH=true
```