### PR TITLE
skip client validation on `/userinfo` if the client is ephemeral

### DIFF
--- a/dev_notes.md
+++ b/dev_notes.md
@@ -2,6 +2,8 @@
 
 ## CURRENT WORK
 
+- bug when setting attribute - after set -> undefined instead of ''
+
 ## Stage 1 - essentials
 
 [x] finished


### PR DESCRIPTION
The `/userinfo` endpoint should client validation, if the client is ephemeral, since it does not make much sense to check an ephemeral client against the database.