### PR TITLE
UI: set user attr values to empty string instead of undefined after add new

### DIFF
--- a/frontend/src/components/admin/userAttr/AttrTileAddNew.svelte
+++ b/frontend/src/components/admin/userAttr/AttrTileAddNew.svelte
@@ -37,7 +37,10 @@
         let res = await postAttr(formValues);
         if (res.ok) {
             expandContainer = false;
-            formValues = {};
+            let formValues = {
+                name: '',
+                desc: '',
+            };
             onSave();
         } else {
             let body = await res.json();


### PR DESCRIPTION
There was a small bug in the UI after adding new custom user attributes, which would set the input field values to `undefined` instead of an empty string during the reset.