### PR TITLE
allow longer `client_id`s for ephemeral clients

### DIFF
--- a/rauthy-common/src/constants.rs
+++ b/rauthy-common/src/constants.rs
@@ -113,7 +113,7 @@ lazy_static! {
     pub static ref RE_BASE64: Regex = Regex::new(r"^[a-zA-Z0-9+/=]{4}$").unwrap();
     pub static ref RE_CHALLENGE: Regex = Regex::new(r"^(plain|S256)$").unwrap();
     pub static ref RE_CITY: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-]{0,48}$").unwrap();
-    pub static ref RE_CLIENT_ID_EPHEMERAL: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$").unwrap();
+    pub static ref RE_CLIENT_ID_EPHEMERAL: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$").unwrap();
     pub static ref RE_CLIENT_NAME: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-\s]{2,128}$").unwrap();
     pub static ref RE_CODE_CHALLENGE: Regex = Regex::new(r"^[a-zA-Z0-9-\._~]{43,128}$").unwrap();
     pub static ref RE_CODE_VERIFIER: Regex = Regex::new(r"^[a-zA-Z0-9-\._~+/=]+$").unwrap();

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -201,7 +201,7 @@ pub struct EncKeyMigrateRequest {
 pub struct EphemeralClientRequest {
     #[validate(regex(
         path = "RE_CLIENT_ID_EPHEMERAL",
-        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
+        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
     ))]
     pub client_id: String,
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,128}`


### PR DESCRIPTION
When you are using playgrounds in the web, you might get very long URLs for your test-client config. When you try to use these with the ephemeral clients feature, they get rejected because they may exceed the 128 character limit. This has been doubled and should not cause any issues any more.