### PR TITLE
bump up argon2id defaults everywhere

### DIFF
--- a/rauthy-book/src/config/config.md
+++ b/rauthy-book/src/config/config.md
@@ -582,11 +582,11 @@ ENC_KEY_ACTIVE=bVCyTsGaggVy5yqQ
 # for more information:
 # https://sebadob.github.io/rauthy/config/argon2.html
 # M_COST should never be below 32768 in production
-ARGON2_M_COST=32768
+ARGON2_M_COST=131072
 # T_COST should never be below 1 in production
-ARGON2_T_COST=3
+ARGON2_T_COST=4
 # P_COST should never be below 2 in production
-ARGON2_P_COST=2
+ARGON2_P_COST=8
 
 # Limits the maximum amount of parallel password hashes at
 # the exact same time to never exceed system memory while
@@ -594,8 +594,8 @@ ARGON2_P_COST=2
 # algorithm (default: 2)
 #
 # CAUTION: You must make sure, that you have at least
-# (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + ~30 MB of memory
-# available.
+# (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + idle memory
+# of your deployment available
 MAX_HASH_THREADS=1
 
 # The time in ms when to log a warning, if a request waited

--- a/rauthy-book/src/getting_started/k8s.md
+++ b/rauthy-book/src/getting_started/k8s.md
@@ -75,17 +75,17 @@ data:
   # The CACHE_AUTH_TOKEN is only needed for a deployment with HA_MODE == true
   # Secret token, which is used to authenticate the cache members
   #CACHE_AUTH_TOKEN:
-  
+
   # The database driver will be chosen at runtime depending on the given DATABASE_URL format. Examples:
   # Sqlite: 'sqlite:data/rauthy.db' or 'sqlite::memory:'
   # Postgres: 'postgresql://User:PasswordWithoutSpecialCharacters@localhost:5432/DatabaseName'
-  DATABASE_URL: 
-    
+  DATABASE_URL:
+
   # Format: "key_id/enc_key another_key_id/another_enc_key" - the enc_key itself must be exactly 32 characters long and
   # and should not contain special characters.
   # The ID must match '[a-zA-Z0-9]{2,20}'
   ENC_KEYS:
-  
+
   # Needed for sending E-Mails for password resets and so on
   SMTP_PASSWORD:
 ```
@@ -244,10 +244,8 @@ spec:
             requests:
               # Tune the memory requests value carefully. Make sure, that the
               # pods request at least:
-              # `ARGON2_M_COST` / 1024 * `MAX_HASH_THREADS` Mi
-              # With SQLite: for small deployments, add additional ~20-30Mi for
-              # "the rest", for larger ones ~50-70 Mi should be enough.
-              memory: 64Mi
+              # `ARGON2_M_COST` / 1024 * `MAX_HASH_THREADS` Mi + idle memory
+              memory: 164Mi
               # The CPU needs to be adjusted during runtime. This heavily
               # depends on your use case.
               cpu: 100m

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -604,18 +604,18 @@ ENC_KEY_ACTIVE=bVCyTsGaggVy5yqQ
 # for more information:
 # https://sebadob.github.io/rauthy/config/argon2.html
 # M_COST should never be below 32768 in production
-ARGON2_M_COST=32768
+ARGON2_M_COST=131072
 # T_COST should never be below 1 in production
-ARGON2_T_COST=3
+ARGON2_T_COST=4
 # P_COST should never be below 2 in production
-ARGON2_P_COST=2
+ARGON2_P_COST=8
 
 # Limits the maximum amount of parallel password hashes at the exact same time
 # to never exceed system memory while still allowing a good amount of memory
 # for the argon2id algorithm
 #
 # CAUTION: You must make sure, that you have at least
-# (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + ~30 MB of memory available.
+# (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + idle memory of your deployment available.
 # default: 2
 MAX_HASH_THREADS=1
 

--- a/rauthy.deploy.cfg
+++ b/rauthy.deploy.cfg
@@ -92,16 +92,16 @@ bVCyTsGaggVy5yqQ/UzluN29DZW41M3hTSkx6Y3NtZmRuQkR2TnJxUTYzcjQ=
 ENC_KEY_ACTIVE=bVCyTsGaggVy5yqQ
 
 # M_COST should never be below 32768 in production
-#ARGON2_M_COST=32768
+#ARGON2_M_COST=131072
 # T_COST should never be below 1 in production
-#ARGON2_T_COST=3
+#ARGON2_T_COST=4
 # P_COST should never be below 2 in production
-#ARGON2_P_COST=2
+#ARGON2_P_COST=8
 
 # Limits the maximum amount of parallel password hashes at the exact same time to never exceed system memory while
 # still allowing a good amount of memory for the argon2id algorithm (default: 2)
-# CAUTION: You must make sure, that you have at least (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + 30 MB of memory
-# available.
+# CAUTION: You must make sure, that you have at least (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + idle memory
+# of your deployment  available.
 MAX_HASH_THREADS=1
 
 #####################################

--- a/rauthy.test.cfg
+++ b/rauthy.test.cfg
@@ -14,8 +14,8 @@ RAUTHY_ADMIN_EMAIL="admin@localhost.de"
 
 # Limits the maximum amount of parallel password hashes at the exact same time to never exceed system memory while
 # still allowing a good amount of memory for the argon2id algorithm (default: 2)
-# Caution: You must make sure, that you have at least (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + ~30 MB of memory
-# available.
+# Caution: You must make sure, that you have at least (MAX_HASH_THREADS * ARGON2_M_COST / 1024) + idle memory
+# of your deployment available.
 MAX_HASH_THREADS=1
 
 # Format: "key_id | enc_key ; anothey_key_id | another_enc_key" - the enc_key itself must be exactly 32 characters long
@@ -26,7 +26,7 @@ bVCyTsGaggVy5yqQ/UzluN29DZW41M3hTSkx6Y3NtZmRuQkR2TnJxUTYzcjQ=
 ENC_KEY_ACTIVE=bVCyTsGaggVy5yqQ
 
 ARGON2_M_COST=32768
-ARGON2_T_COST=3
+ARGON2_T_COST=1
 ARGON2_P_COST=2
 
 # The server address to listen on. Can bind to a specific IP. (default: 0.0.0.0)


### PR DESCRIPTION
The default values for password hashing should be bumped up to have at least somewhat "safe" values for production.
In the end, this highly depends on the deployment and a lot of factors, but these should give a better starting point.