### PR TITLE
migrate `ErrorResponse.message` from `String` to `Cow<'static, str>`

### DIFF
--- a/rauthy-common/src/error_response.rs
+++ b/rauthy-common/src/error_response.rs
@@ -203,10 +203,7 @@ impl From<argon2::Error> for ErrorResponse {
 impl From<Box<bincode::ErrorKind>> for ErrorResponse {
     fn from(err: Box<bincode::ErrorKind>) -> Self {
         error!("Bincode Error: {:?}", err);
-        ErrorResponse::new(
-            ErrorResponseType::Internal,
-            "Serialization Error".to_string(),
-        )
+        ErrorResponse::new(ErrorResponseType::Internal, "Serialization Error")
     }
 }
 
@@ -215,7 +212,7 @@ impl From<chrono::ParseError> for ErrorResponse {
         trace!("{:?}", value);
         ErrorResponse::new(
             ErrorResponseType::BadRequest,
-            String::from("Unable to parse the correct DateTime"),
+            "Unable to parse the correct DateTime",
         )
     }
 }
@@ -225,7 +222,7 @@ impl From<BlockingError> for ErrorResponse {
         trace!("{:?}", value);
         ErrorResponse::new(
             ErrorResponseType::Internal,
-            String::from("Database Pool is gone, please re-try later"),
+            "Database Pool is gone, please re-try later",
         )
     }
 }
@@ -243,10 +240,7 @@ impl From<CacheError> for ErrorResponse {
 impl From<chacha20poly1305::Error> for ErrorResponse {
     fn from(e: chacha20poly1305::Error) -> Self {
         error!("{}", e);
-        ErrorResponse::new(
-            ErrorResponseType::Internal,
-            "Internal Encryption Error".to_string(),
-        )
+        ErrorResponse::new(ErrorResponseType::Internal, "Internal Encryption Error")
     }
 }
 
@@ -300,7 +294,7 @@ impl From<ParseColorError> for ErrorResponse {
         trace!("{:?}", value);
         ErrorResponse::new(
             ErrorResponseType::BadRequest,
-            "Cannot parse input to valid CSS color".to_string(),
+            "Cannot parse input to valid CSS color",
         )
     }
 }
@@ -326,7 +320,7 @@ impl From<actix_multipart::MultipartError> for ErrorResponse {
             _ => "MultipartError::Unknown",
         };
 
-        ErrorResponse::new(ErrorResponseType::BadRequest, text.to_string())
+        ErrorResponse::new(ErrorResponseType::BadRequest, text)
     }
 }
 

--- a/rauthy-common/src/error_response.rs
+++ b/rauthy-common/src/error_response.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Error;
 use serde_json_path::ParseError;
 use spow::pow::PowError;
+use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::string::FromUtf8Error;
 use time::OffsetDateTime;
@@ -66,15 +67,18 @@ impl Display for ErrorResponseType {
 pub struct ErrorResponse {
     pub timestamp: i64,
     pub error: ErrorResponseType,
-    pub message: String,
+    pub message: Cow<'static, str>,
 }
 
 impl ErrorResponse {
-    pub fn new(error: ErrorResponseType, message: String) -> Self {
+    pub fn new<C>(error: ErrorResponseType, message: C) -> Self
+    where
+        C: Into<Cow<'static, str>>,
+    {
         Self {
             timestamp: OffsetDateTime::now_utc().unix_timestamp(),
             error,
-            message,
+            message: message.into(),
         }
     }
 

--- a/rauthy-common/src/utils.rs
+++ b/rauthy-common/src/utils.rs
@@ -62,12 +62,9 @@ pub fn base64_encode(input: &[u8]) -> String {
 
 #[inline(always)]
 pub fn base64_decode(b64: &str) -> Result<Vec<u8>, ErrorResponse> {
-    B64_STD.decode(b64).map_err(|_| {
-        ErrorResponse::new(
-            ErrorResponseType::BadRequest,
-            "B64 decoding error".to_string(),
-        )
-    })
+    B64_STD
+        .decode(b64)
+        .map_err(|_| ErrorResponse::new(ErrorResponseType::BadRequest, "B64 decoding error"))
 }
 
 // Returns the given input as a base64 URL Encoded String
@@ -91,22 +88,16 @@ pub fn base64_url_no_pad_encode(input: &[u8]) -> String {
 
 #[inline(always)]
 pub fn base64_url_decode(b64: &str) -> Result<Vec<u8>, ErrorResponse> {
-    B64_URL_SAFE.decode(b64).map_err(|_| {
-        ErrorResponse::new(
-            ErrorResponseType::BadRequest,
-            "B64 decoding error".to_string(),
-        )
-    })
+    B64_URL_SAFE
+        .decode(b64)
+        .map_err(|_| ErrorResponse::new(ErrorResponseType::BadRequest, "B64 decoding error"))
 }
 
 #[inline(always)]
 pub fn base64_url_no_pad_decode(b64: &str) -> Result<Vec<u8>, ErrorResponse> {
-    B64_URL_SAFE_NO_PAD.decode(b64).map_err(|_| {
-        ErrorResponse::new(
-            ErrorResponseType::BadRequest,
-            "B64 decoding error".to_string(),
-        )
-    })
+    B64_URL_SAFE_NO_PAD
+        .decode(b64)
+        .map_err(|_| ErrorResponse::new(ErrorResponseType::BadRequest, "B64 decoding error"))
 }
 
 pub fn new_store_id() -> String {
@@ -127,7 +118,7 @@ where
     if body.is_none() {
         return Err(ErrorResponse::new(
             ErrorResponseType::Unauthorized,
-            "Invalid or malformed JWT Token".to_string(),
+            "Invalid or malformed JWT Token",
         ));
     }
     let body = body.unwrap();
@@ -141,7 +132,7 @@ where
             );
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Invalid JWT Token body".to_string(),
+                "Invalid JWT Token body",
             ));
         }
     };
@@ -152,7 +143,7 @@ where
             error!("Error deserializing JWT Token claims: {}", err);
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Invalid JWT Token claims".to_string(),
+                "Invalid JWT Token claims",
             ));
         }
     };

--- a/rauthy-handlers/src/generic.rs
+++ b/rauthy-handlers/src/generic.rs
@@ -111,8 +111,7 @@ pub async fn post_i18n(
         I18nContent::EmailChangeConfirm => I18nEmailConfirmChangeHtml::build(&lang).as_json(),
         // Just return some default values for local dev -> dynamically built during prod
         I18nContent::Error => {
-            I18nError::build_with(&lang, StatusCode::NOT_FOUND, Some("<empty>".to_string()))
-                .as_json()
+            I18nError::build_with(&lang, StatusCode::NOT_FOUND, Some("<empty>")).as_json()
         }
         I18nContent::Index => I18nIndex::build(&lang).as_json(),
         I18nContent::Logout => I18nLogout::build(&lang).as_json(),

--- a/rauthy-handlers/src/oidc.rs
+++ b/rauthy-handlers/src/oidc.rs
@@ -138,7 +138,7 @@ pub async fn get_authorize(
             .unwrap_or(false)
     {
         let status = StatusCode::UNAUTHORIZED;
-        let body = Error1Html::build(&colors, &lang, status, Some("login_required".to_string()));
+        let body = Error1Html::build(&colors, &lang, status, Some("login_required"));
         return Ok(ErrorHtml::response(body, status));
     }
 
@@ -436,7 +436,7 @@ pub async fn post_device_auth(
     if let Err(err) = client.validate_flow(GRANT_TYPE_DEVICE_CODE) {
         return HttpResponse::Forbidden().json(OAuth2ErrorResponse {
             error: OAuth2ErrorTypeResponse::UnauthorizedClient,
-            error_description: Some(Cow::from(err.message)),
+            error_description: Some(err.message),
         });
     }
 
@@ -473,7 +473,7 @@ pub async fn post_device_auth(
         Err(err) => {
             return HttpResponse::InternalServerError().json(OAuth2ErrorResponse {
                 error: OAuth2ErrorTypeResponse::InvalidRequest,
-                error_description: Some(Cow::from(err.message)),
+                error_description: Some(err.message),
             });
         }
     };

--- a/rauthy-models/src/email.rs
+++ b/rauthy-models/src/email.rs
@@ -612,7 +612,7 @@ async fn conn_test_smtp_insecure(
             );
             Err(ErrorResponse::new(
                 ErrorResponseType::Internal,
-                "Could not connect to localhost SMTP relay".to_string(),
+                "Could not connect to localhost SMTP relay",
             ))
         }
     }

--- a/rauthy-models/src/entity/api_keys.rs
+++ b/rauthy-models/src/entity/api_keys.rs
@@ -193,10 +193,7 @@ impl ApiKeyEntity {
         token: &str,
     ) -> Result<ApiKey, ErrorResponse> {
         let (name, secret) = token.split_once('$').ok_or_else(|| {
-            ErrorResponse::new(
-                ErrorResponseType::BadRequest,
-                "Malformed API-Key".to_string(),
-            )
+            ErrorResponse::new(ErrorResponseType::BadRequest, "Malformed API-Key")
         })?;
 
         let idx = Self::cache_idx(name);
@@ -296,14 +293,14 @@ impl ApiKey {
                 } else {
                     Err(ErrorResponse::new(
                         ErrorResponseType::Forbidden,
-                        "Access denied".to_string(),
+                        "Access denied",
                     ))
                 };
             }
         }
         Err(ErrorResponse::new(
             ErrorResponseType::Forbidden,
-            "Access denied".to_string(),
+            "Access denied",
         ))
     }
 
@@ -313,7 +310,7 @@ impl ApiKey {
             if Utc::now().timestamp() > exp {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::Unauthorized,
-                    "API Key has expired".to_string(),
+                    "API Key has expired",
                 ));
             }
         }
@@ -324,7 +321,7 @@ impl ApiKey {
         } else {
             Err(ErrorResponse::new(
                 ErrorResponseType::Unauthorized,
-                "Invalid API-Key".to_string(),
+                "Invalid API-Key",
             ))
         }
     }

--- a/rauthy-models/src/entity/auth_providers.rs
+++ b/rauthy-models/src/entity/auth_providers.rs
@@ -82,7 +82,7 @@ impl TryFrom<&str> for AuthProviderType {
             _ => {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Invalid AuthProviderType".to_string(),
+                    "Invalid AuthProviderType",
                 ))
             }
         };
@@ -471,7 +471,7 @@ impl AuthProvider {
         } else {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "either `metadata_url` or `issuer` must be given".to_string(),
+                "either `metadata_url` or `issuer` must be given",
             ));
         };
         let config_url = if url.starts_with("http://") || url.starts_with("https://") {
@@ -611,7 +611,7 @@ impl AuthProviderCallback {
         {
             None => Err(ErrorResponse::new(
                 ErrorResponseType::NotFound,
-                "Callback Code not found - timeout reached?".to_string(),
+                "Callback Code not found - timeout reached?",
             )),
             Some(slf) => Ok(slf),
         }

--- a/rauthy-models/src/entity/clients.rs
+++ b/rauthy-models/src/entity/clients.rs
@@ -386,7 +386,7 @@ impl Client {
         if !current.is_dynamic() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::Forbidden,
-                "Invalid request for non-dynamic client".to_string(),
+                "Invalid request for non-dynamic client",
             ));
         }
 
@@ -662,7 +662,7 @@ impl Client {
             trace!("MFA required for this client but the user has none");
             Err(ErrorResponse::new(
                 ErrorResponseType::MfaRequired,
-                "MFA is required for this client".to_string(),
+                "MFA is required for this client",
             ))
         } else {
             Ok(())
@@ -738,7 +738,7 @@ impl Client {
             trace!("Invalid `redirect_uri`");
             Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                String::from("Invalid redirect uri"),
+                "Invalid redirect uri",
             ))
         } else {
             Ok(())
@@ -755,7 +755,7 @@ impl Client {
                 trace!("'code_challenge' is missing");
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    String::from("'code_challenge' is missing"),
+                    "'code_challenge' is missing",
                 ));
             }
 

--- a/rauthy-models/src/entity/clients_dyn.rs
+++ b/rauthy-models/src/entity/clients_dyn.rs
@@ -201,7 +201,7 @@ impl ClientDyn {
         if self.registration_token_plain()? != bearer {
             Err(ErrorResponse::new(
                 ErrorResponseType::WWWAuthenticate("invalid_token".to_string()),
-                "Invalid registration_token".to_string(),
+                "Invalid registration_token",
             ))
         } else {
             Ok(())

--- a/rauthy-models/src/entity/continuation_token.rs
+++ b/rauthy-models/src/entity/continuation_token.rs
@@ -23,7 +23,7 @@ impl TryFrom<&str> for ContinuationToken {
         if value.len() < 16 {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Invalid continuation_token".to_string(),
+                "Invalid continuation_token",
             ));
         }
 

--- a/rauthy-models/src/entity/dpop_proof.rs
+++ b/rauthy-models/src/entity/dpop_proof.rs
@@ -231,7 +231,7 @@ impl DPoPProof {
                     if let Err(nonce) = slf.validate_nonce(data).await {
                         return Err(ErrorResponse::new(
                             ErrorResponseType::UseDpopNonce((origin, nonce)),
-                            "DPoP 'nonce' is required in DPoP proof".to_string(),
+                            "DPoP 'nonce' is required in DPoP proof",
                         ));
                     }
 
@@ -339,7 +339,7 @@ impl DPoPProof {
                     Ok(v) => v,
                     Err(err) => {
                         error!("Cache lookup error during DPoP nonce generation: {:?}", err);
-                        err.message
+                        err.message.to_string()
                     }
                 };
                 return Err(latest);
@@ -349,7 +349,7 @@ impl DPoPProof {
                 Ok(v) => v,
                 Err(err) => {
                     error!("Cache lookup error during DPoP nonce generation: {:?}", err);
-                    err.message
+                    err.message.to_string()
                 }
             };
             return Err(latest);

--- a/rauthy-models/src/entity/dpop_proof.rs
+++ b/rauthy-models/src/entity/dpop_proof.rs
@@ -154,7 +154,7 @@ impl DPoPProof {
         match value.split_once('.') {
             None => Err(ErrorResponse::new(
                 ErrorResponseType::DPoP(origin.map(String::from)),
-                "Invalid DPoP header format".to_string(),
+                "Invalid DPoP header format",
             )),
 
             Some((header, rest)) => {
@@ -173,7 +173,7 @@ impl DPoPProof {
                 match rest.split_once('.') {
                     None => Err(ErrorResponse::new(
                         ErrorResponseType::DPoP(origin.map(String::from)),
-                        "Invalid DPoP claims format".to_string(),
+                        "Invalid DPoP claims format",
                     )),
                     Some((claims, signature)) => {
                         let bytes = base64_url_no_pad_decode(claims)?;
@@ -220,7 +220,7 @@ impl DPoPProof {
                 if !RE_TOKEN_68.is_match(b64) {
                     Err(ErrorResponse::new(
                         ErrorResponseType::DPoP(origin),
-                        "DPoP header must be in Token68 format".to_string(),
+                        "DPoP header must be in Token68 format",
                     ))
                 } else {
                     let slf = Self::try_from_str(origin.as_deref(), b64)?;

--- a/rauthy-models/src/entity/groups.rs
+++ b/rauthy-models/src/entity/groups.rs
@@ -28,7 +28,7 @@ impl Group {
             if g.name == group_req.group {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Group already exists".to_string(),
+                    "Group already exists",
                 ));
             }
         }

--- a/rauthy-models/src/entity/jwk.rs
+++ b/rauthy-models/src/entity/jwk.rs
@@ -45,12 +45,7 @@ macro_rules! sign_jwt {
                 key.with_key_id(&$key_pair.kid).sign($claims)
             }
         }
-        .map_err(|_| {
-            ErrorResponse::new(
-                ErrorResponseType::Internal,
-                "Error signing JWT Token".to_string(),
-            )
-        })
+        .map_err(|_| ErrorResponse::new(ErrorResponseType::Internal, "Error signing JWT Token"))
     };
 }
 
@@ -87,9 +82,7 @@ macro_rules! validate_jwt {
                     .verify_token::<$type>($token, Some($options))
             }
         }
-        .map_err(|_| {
-            ErrorResponse::new(ErrorResponseType::Unauthorized, "Invalid Token".to_string())
-        })
+        .map_err(|_| ErrorResponse::new(ErrorResponseType::Unauthorized, "Invalid Token"))
     };
 }
 
@@ -221,7 +214,7 @@ impl JWKSPublicKey {
         } else {
             Err(ErrorResponse::new(
                 ErrorResponseType::Internal,
-                "No 'alg' in JwkKeyPublicKey".to_string(),
+                "No 'alg' in JwkKeyPublicKey",
             ))
         }
     }
@@ -233,7 +226,7 @@ impl JWKSPublicKey {
         } else {
             Err(ErrorResponse::new(
                 ErrorResponseType::Internal,
-                "No 'n' in JwkKeyPublicKey".to_string(),
+                "No 'n' in JwkKeyPublicKey",
             ))
         }
     }
@@ -245,7 +238,7 @@ impl JWKSPublicKey {
         } else {
             Err(ErrorResponse::new(
                 ErrorResponseType::Internal,
-                "No 'e' in JwkKeyPublicKey".to_string(),
+                "No 'e' in JwkKeyPublicKey",
             ))
         }
     }
@@ -256,7 +249,7 @@ impl JWKSPublicKey {
         } else {
             Err(ErrorResponse::new(
                 ErrorResponseType::Internal,
-                "No 'x' in JwkKeyPublicKey".to_string(),
+                "No 'x' in JwkKeyPublicKey",
             ))
         }
     }

--- a/rauthy-models/src/entity/jwk_token_validation.rs
+++ b/rauthy-models/src/entity/jwk_token_validation.rs
@@ -15,12 +15,12 @@ impl JWKSPublicKey {
     /// Until this is solved, I will only have the RSA keys prepared, but actually only support
     /// EdDSA for now.
     pub fn validate_token_signature(&self, token: &str) -> Result<(), ErrorResponse> {
-        let (header, rest) = token.split_once('.').ok_or_else(|| {
-            ErrorResponse::new(ErrorResponseType::BadRequest, "Malformed token".to_string())
-        })?;
-        let (claims, sig_str) = rest.split_once('.').ok_or_else(|| {
-            ErrorResponse::new(ErrorResponseType::BadRequest, "Malformed token".to_string())
-        })?;
+        let (header, rest) = token
+            .split_once('.')
+            .ok_or_else(|| ErrorResponse::new(ErrorResponseType::BadRequest, "Malformed token"))?;
+        let (claims, sig_str) = rest
+            .split_once('.')
+            .ok_or_else(|| ErrorResponse::new(ErrorResponseType::BadRequest, "Malformed token"))?;
         // TODO this can be made more efficient without creating a new String -> only &[u8] needed
         let message = format!("{}.{}", header, claims);
         let sig_bytes = base64_url_no_pad_decode(sig_str).unwrap();
@@ -77,7 +77,7 @@ impl JWKSPublicKey {
         warn!("JWT Token validation error");
         Err(ErrorResponse::new(
             ErrorResponseType::Unauthorized,
-            "Invalid JWT Token".to_string(),
+            "Invalid JWT Token",
         ))
     }
 }

--- a/rauthy-models/src/entity/logos.rs
+++ b/rauthy-models/src/entity/logos.rs
@@ -168,7 +168,7 @@ impl Logo {
             "image/jpeg" | "image/png" => Self::upsert_jpg_png(data.clone(), id, logo, typ).await,
             _ => Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Invalid mime type for auth provider logo".to_string(),
+                "Invalid mime type for auth provider logo",
             )),
         }
     }

--- a/rauthy-models/src/entity/magic_links.rs
+++ b/rauthy-models/src/entity/magic_links.rs
@@ -50,7 +50,7 @@ impl TryFrom<&str> for MagicLinkUsage {
             _ => {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Invalid string for MagicLinkUsage parsing".to_string(),
+                    "Invalid string for MagicLinkUsage parsing",
                 ))
             }
         };
@@ -198,9 +198,7 @@ impl MagicLink {
         if self.cookie.is_some() {
             let err = ErrorResponse::new(
                 ErrorResponseType::Forbidden,
-                String::from(
-                    "The requested password reset link is already tied to another session",
-                ),
+                "The requested password reset link is already tied to another session",
             );
 
             let cookie_opt = ApiCookie::from_req(req, PWD_RESET_COOKIE);
@@ -228,14 +226,14 @@ impl MagicLink {
                 None => {
                     return Err(ErrorResponse::new(
                         ErrorResponseType::Unauthorized,
-                        String::from("CSRF Token is missing"),
+                        "CSRF Token is missing",
                     ));
                 }
                 Some(token) => {
                     if self.csrf_token != token.to_str().unwrap_or("") {
                         return Err(ErrorResponse::new(
                             ErrorResponseType::Unauthorized,
-                            String::from("Invalid CSRF Token"),
+                            "Invalid CSRF Token",
                         ));
                     }
                 }
@@ -245,21 +243,21 @@ impl MagicLink {
         if self.user_id != user_id {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                String::from("The user id is invalid"),
+                "The user id is invalid",
             ));
         }
 
         if self.exp < OffsetDateTime::now_utc().unix_timestamp() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                String::from("This link has expired already"),
+                "This link has expired already",
             ));
         }
 
         if self.used {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                String::from("The requested passwort reset link was already used"),
+                "The requested passwort reset link was already used",
             ));
         }
 

--- a/rauthy-models/src/entity/pow.rs
+++ b/rauthy-models/src/entity/pow.rs
@@ -40,7 +40,7 @@ impl PowEntity {
             None => {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::NotFound,
-                    "PoW not found".to_string(),
+                    "PoW not found",
                 ));
             }
         };

--- a/rauthy-models/src/entity/principal.rs
+++ b/rauthy-models/src/entity/principal.rs
@@ -21,7 +21,7 @@ impl Principal {
         principal.into_inner().ok_or_else(|| {
             ErrorResponse::new(
                 ErrorResponseType::Unauthorized,
-                String::from("Only allowed as a logged in user"),
+                "Only allowed as a logged in user",
             )
         })
     }
@@ -33,7 +33,7 @@ impl Principal {
         } else {
             Err(ErrorResponse::new(
                 ErrorResponseType::Unauthorized,
-                "No valid session".to_string(),
+                "No valid session",
             ))
         }
     }
@@ -53,7 +53,7 @@ impl Principal {
         if self.user_id() != Ok(id) {
             Err(ErrorResponse::new(
                 ErrorResponseType::Forbidden,
-                "You are not allowed to modify this user".to_string(),
+                "You are not allowed to modify this user",
             ))
         } else {
             Ok(())
@@ -71,10 +71,7 @@ impl Principal {
             .as_ref()
             .and_then(|s| s.user_id.as_deref())
             .ok_or_else(|| {
-                ErrorResponse::new(
-                    ErrorResponseType::NotFound,
-                    "No session for principal".to_string(),
-                )
+                ErrorResponse::new(ErrorResponseType::NotFound, "No session for principal")
             })
     }
 
@@ -98,7 +95,7 @@ impl Principal {
         } else {
             Err(ErrorResponse::new(
                 ErrorResponseType::Unauthorized,
-                "No API Key found".to_string(),
+                "No API Key found",
             ))
         }
     }
@@ -110,7 +107,7 @@ impl Principal {
         if !self.is_admin() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::Forbidden,
-                "Rauthy admin access only".to_string(),
+                "Rauthy admin access only",
             ));
         }
 
@@ -157,7 +154,7 @@ impl Principal {
         if !self.is_admin() && session.user_id.as_deref() != Some(user_id) {
             Err(ErrorResponse::new(
                 ErrorResponseType::Forbidden,
-                "Access is forbidden with this user".to_string(),
+                "Access is forbidden with this user",
             ))
         } else {
             Ok(())
@@ -173,7 +170,7 @@ impl Principal {
             trace!("Validating the session failed - was not in auth state");
             Err(ErrorResponse::new(
                 ErrorResponseType::Unauthorized,
-                "Unauthorized session or invalid user ID".to_string(),
+                "Unauthorized session or invalid user ID",
             ))
         }
     }

--- a/rauthy-models/src/entity/refresh_tokens.rs
+++ b/rauthy-models/src/entity/refresh_tokens.rs
@@ -97,7 +97,7 @@ impl RefreshToken {
             Ok(res) => Ok(res),
             Err(_) => Err(ErrorResponse::new(
                 ErrorResponseType::NotFound,
-                "Refresh Token does not exist".to_string(),
+                "Refresh Token does not exist",
             )),
         }
     }

--- a/rauthy-models/src/entity/refresh_tokens_devices.rs
+++ b/rauthy-models/src/entity/refresh_tokens_devices.rs
@@ -97,7 +97,7 @@ impl RefreshTokenDevice {
             Ok(res) => Ok(res),
             Err(_) => Err(ErrorResponse::new(
                 ErrorResponseType::NotFound,
-                "Device Refresh Token does not exist".to_string(),
+                "Device Refresh Token does not exist",
             )),
         }
     }

--- a/rauthy-models/src/entity/roles.rs
+++ b/rauthy-models/src/entity/roles.rs
@@ -28,7 +28,7 @@ impl Role {
             if s.name == role_req.role {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Role already exists".to_string(),
+                    "Role already exists",
                 ));
             }
         }
@@ -66,7 +66,7 @@ impl Role {
         if role.name == "rauthy_admin" {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Anti-Lockout Rule: The 'rauthy_admin' role cannot be deleted".to_string(),
+                "Anti-Lockout Rule: The 'rauthy_admin' role cannot be deleted",
             ));
         }
 

--- a/rauthy-models/src/entity/scopes.rs
+++ b/rauthy-models/src/entity/scopes.rs
@@ -37,7 +37,7 @@ impl Scope {
             if s.name == scope_req.scope {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Scope already exists".to_string(),
+                    "Scope already exists",
                 ));
             }
         }
@@ -47,7 +47,7 @@ impl Scope {
         {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "OpenID default scopes cannot have custom mappings".to_string(),
+                "OpenID default scopes cannot have custom mappings",
             ));
         }
 
@@ -91,7 +91,7 @@ impl Scope {
         if scope.name == "openid" {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                String::from("The 'openid' scope cannot be deleted"),
+                "The 'openid' scope cannot be deleted",
             ));
         }
 
@@ -196,7 +196,7 @@ impl Scope {
         if scope.name == "openid" {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                String::from("The 'openid' scope cannot be changed"),
+                "The 'openid' scope cannot be changed",
             ));
         }
 
@@ -205,7 +205,7 @@ impl Scope {
         {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "OpenID default scopes cannot have custom mappings".to_string(),
+                "OpenID default scopes cannot have custom mappings",
             ));
         }
 

--- a/rauthy-models/src/entity/sessions.rs
+++ b/rauthy-models/src/entity/sessions.rs
@@ -454,7 +454,7 @@ impl Session {
             _ => {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "supported search idx for users: id / session_id, user_id, ip".to_string(),
+                    "supported search idx for users: id / session_id, user_id, ip",
                 ))
             }
         };
@@ -509,7 +509,7 @@ impl Session {
             if now.unix_timestamp() > ts {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::Forbidden,
-                    "User has expired".to_string(),
+                    "User has expired",
                 ));
             } else {
                 let target = now
@@ -560,7 +560,7 @@ impl Session {
         if session_req.is_none() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                String::from("Session cookie is missing"),
+                "Session cookie is missing",
             ));
         }
         Ok(session_req.into_inner().unwrap())
@@ -684,7 +684,7 @@ impl Session {
         if csrf.is_err() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::CSRFTokenError,
-                String::from("CSRF Token not present in HTTP Header"),
+                "CSRF Token not present in HTTP Header",
             ));
         }
         if self.csrf_token.eq(csrf.unwrap()) {
@@ -692,7 +692,7 @@ impl Session {
         }
         Err(ErrorResponse::new(
             ErrorResponseType::CSRFTokenError,
-            String::from("CSRF Token is not correct"),
+            "CSRF Token is not correct",
         ))
     }
 

--- a/rauthy-models/src/entity/user_attr.rs
+++ b/rauthy-models/src/entity/user_attr.rs
@@ -31,7 +31,7 @@ impl UserAttrConfigEntity {
         if Self::find(data, new_attr.name.clone()).await.is_ok() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "User attribute config does already exist".to_string(),
+                "User attribute config does already exist",
             ));
         }
 

--- a/rauthy-models/src/entity/users.rs
+++ b/rauthy-models/src/entity/users.rs
@@ -370,7 +370,7 @@ impl User {
             debug!("FedCM user not found");
             ErrorResponse::new(
                 ErrorResponseType::WWWAuthenticate("user-not-found".to_string()),
-                "The user has not been found".to_string(),
+                "The user has not been found",
             )
         })?;
 
@@ -379,7 +379,7 @@ impl User {
             debug!("FedCM user is disabled");
             return Err(ErrorResponse::new(
                 ErrorResponseType::WWWAuthenticate("user-disabled".to_string()),
-                "The user has been disabled".to_string(),
+                "The user has been disabled",
             ));
         }
 
@@ -548,7 +548,7 @@ impl User {
         if slf.password.is_none() && !slf.has_webauthn_enabled() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "You must have at least a password or passkey set up before you can remove a provider link".to_string(),
+                "You must have at least a password or passkey set up before you can remove a provider link",
             ));
         }
 
@@ -683,7 +683,7 @@ impl User {
             _ => {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "supported search idx for users: id / user_id, email".to_string(),
+                    "supported search idx for users: id / user_id, email",
                 ))
             }
         };
@@ -797,14 +797,14 @@ impl User {
                 if svc_req.user_id != user.id {
                     return Err(ErrorResponse::new(
                         ErrorResponseType::Forbidden,
-                        "User ID does not match".to_string(),
+                        "User ID does not match",
                     ));
                 }
                 svc_req.delete(data).await?;
             } else {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Cannot set a new password without the current one".to_string(),
+                    "Cannot set a new password without the current one",
                 ));
             }
             password = Some(pwd_new);
@@ -880,7 +880,7 @@ impl User {
         if user.account_type() != AccountType::Password {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Only AccountType::Password can be converted".to_string(),
+                "Only AccountType::Password can be converted",
             ));
         }
 
@@ -888,8 +888,7 @@ impl User {
         if !user.has_webauthn_enabled() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Account type conversion can only happen with at least one active Passkey"
-                    .to_string(),
+                "Account type conversion can only happen with at least one active Passkey",
             ));
         }
 

--- a/rauthy-models/src/entity/webauthn.rs
+++ b/rauthy-models/src/entity/webauthn.rs
@@ -385,7 +385,7 @@ impl WebauthnCookie {
         if cookie.is_none() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "Webauthn Cookie is missing".to_string(),
+                "Webauthn Cookie is missing",
             ));
         }
         let cookie = cookie.as_ref().unwrap();
@@ -396,7 +396,7 @@ impl WebauthnCookie {
         if slf.exp < OffsetDateTime::now_utc() {
             Err(ErrorResponse::new(
                 ErrorResponseType::SessionExpired,
-                "Webauthn Cookie has expired".to_string(),
+                "Webauthn Cookie has expired",
             ))
         } else {
             Ok(slf)
@@ -438,7 +438,7 @@ impl WebauthnData {
         match res {
             None => Err(ErrorResponse::new(
                 ErrorResponseType::NotFound,
-                "Webauthn Data not found".to_string(),
+                "Webauthn Data not found",
             )),
             Some(res) => Ok(res),
         }
@@ -539,7 +539,7 @@ impl WebauthnLoginReq {
         match res {
             None => Err(ErrorResponse::new(
                 ErrorResponseType::NotFound,
-                "Webauthn Login Request Data not found".to_string(),
+                "Webauthn Login Request Data not found",
             )),
             Some(res) => Ok(res),
         }
@@ -598,7 +598,7 @@ impl WebauthnServiceReq {
         match res {
             None => Err(ErrorResponse::new(
                 ErrorResponseType::NotFound,
-                "Webauthn Service Request Data not found".to_string(),
+                "Webauthn Service Request Data not found",
             )),
             Some(res) => Ok(res),
         }
@@ -658,7 +658,7 @@ pub async fn auth_start(
         // may be the case if the user has presence only keys and the config has changed
         return Err(ErrorResponse::new(
             ErrorResponseType::NotFound,
-            "No Security Keys with active user verification found".to_string(),
+            "No Security Keys with active user verification found",
         ));
     }
 
@@ -690,7 +690,7 @@ pub async fn auth_start(
             error!("Webauthn challenge authentication: {:?}", err);
             Err(ErrorResponse::new(
                 ErrorResponseType::Internal,
-                "Internal error with Webauthn Challenge Authentication".to_string(),
+                "Internal error with Webauthn Challenge Authentication",
             ))
         }
     }
@@ -721,7 +721,7 @@ pub async fn auth_finish(
                 );
                 return Err(ErrorResponse::new(
                     ErrorResponseType::Forbidden,
-                    "User Presence only is not allowed - Verification is needed".to_string(),
+                    "User Presence only is not allowed - Verification is needed",
                 ));
             }
 
@@ -827,7 +827,7 @@ pub async fn reg_start(
             error!("Webauthn challenge register: {:?}", err);
             Err(ErrorResponse::new(
                 ErrorResponseType::Internal,
-                "Internal error with Webauthn Challenge Registration".to_string(),
+                "Internal error with Webauthn Challenge Registration",
             ))
         }
     }
@@ -852,7 +852,7 @@ pub async fn reg_finish(
     if res.is_none() {
         return Err(ErrorResponse::new(
             ErrorResponseType::BadRequest,
-            "Webauthn Registration Request not found".to_string(),
+            "Webauthn Registration Request not found",
         ));
     }
     cache_remove(
@@ -881,7 +881,7 @@ pub async fn reg_finish(
                 );
                 return Err(ErrorResponse::new(
                     ErrorResponseType::Forbidden,
-                    "User Presence only is not allowed - Verification is needed".to_string(),
+                    "User Presence only is not allowed - Verification is needed",
                 ));
             }
 

--- a/rauthy-models/src/events/event.rs
+++ b/rauthy-models/src/events/event.rs
@@ -69,7 +69,7 @@ impl FromStr for EventLevel {
             _ => {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::Internal,
-                    "Cannot parse EventLevel".to_string(),
+                    "Cannot parse EventLevel",
                 ));
             }
         };

--- a/rauthy-models/src/language.rs
+++ b/rauthy-models/src/language.rs
@@ -88,7 +88,7 @@ impl TryFrom<&HttpRequest> for Language {
 
         Err(ErrorResponse::new(
             ErrorResponseType::NotFound,
-            "Could not find and extract  a locale cookie or the accept-language header".to_string(),
+            "Could not find and extract  a locale cookie or the accept-language header",
         ))
     }
 }

--- a/rauthy-models/src/lib.rs
+++ b/rauthy-models/src/lib.rs
@@ -254,7 +254,7 @@ impl FromStr for JwtAmrValue {
             _ => {
                 return Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Unknown value for 'amr' claim".to_string(),
+                    "Unknown value for 'amr' claim",
                 ))
             }
         };

--- a/rauthy-models/src/request.rs
+++ b/rauthy-models/src/request.rs
@@ -850,7 +850,7 @@ impl TokenRequest {
             match decoded.split_once(':') {
                 None => Err(ErrorResponse::new(
                     ErrorResponseType::BadRequest,
-                    "Bad Authorization header".to_string(),
+                    "Bad Authorization header",
                 )),
                 Some((client_id, client_secret)) => {
                     Ok((client_id.to_string(), Some(client_secret.to_string())))

--- a/rauthy-models/src/templates.rs
+++ b/rauthy-models/src/templates.rs
@@ -17,6 +17,7 @@ use askama_actix::Template;
 use rauthy_common::constants::{
     DEVICE_GRANT_USER_CODE_LENGTH, HEADER_HTML, OPEN_USER_REG, USER_REG_DOMAIN_RESTRICTION,
 };
+use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Debug, Clone)]
@@ -314,7 +315,7 @@ impl ErrorHtml<'_> {
         colors: &Colors,
         lang: &Language,
         status_code: StatusCode,
-        details_text: Option<String>,
+        details_text: Option<Cow<'static, str>>,
     ) -> String {
         let res = ErrorHtml {
             lang: lang.as_str(),
@@ -376,12 +377,15 @@ pub struct Error1Html<'a> {
 }
 
 impl Error1Html<'_> {
-    pub fn build(
+    pub fn build<C>(
         colors: &Colors,
         lang: &Language,
         status_code: StatusCode,
-        details_text: Option<String>,
-    ) -> String {
+        details_text: Option<C>,
+    ) -> String
+    where
+        C: Into<Cow<'static, str>>,
+    {
         let res = Error1Html {
             lang: lang.as_str(),
             col_act1: &colors.act1,
@@ -430,12 +434,15 @@ pub struct Error2Html<'a> {
 }
 
 impl Error2Html<'_> {
-    pub fn build(
+    pub fn build<C>(
         colors: &Colors,
         lang: &Language,
         status_code: StatusCode,
-        details_text: Option<String>,
-    ) -> String {
+        details_text: Option<C>,
+    ) -> String
+    where
+        C: Into<Cow<'static, str>>,
+    {
         let res = Error2Html {
             lang: lang.as_str(),
             col_act1: &colors.act1,
@@ -484,12 +491,15 @@ pub struct Error3Html<'a> {
 }
 
 impl Error3Html<'_> {
-    pub fn build(
+    pub fn build<C>(
         colors: &Colors,
         lang: &Language,
         status_code: StatusCode,
-        details_text: Option<String>,
-    ) -> String {
+        details_text: Option<C>,
+    ) -> String
+    where
+        C: Into<Cow<'static, str>>,
+    {
         let res = Error3Html {
             lang: lang.as_str(),
             col_act1: &colors.act1,


### PR DESCRIPTION
This is a performance and efficiency improvement in most error cases. The new struct definition for `ErrorResponse` needs less memory allocations.