### PR TITLE
show the full backend error in the UI in case of a provider callback error

### DIFF
--- a/frontend/src/routes/providers/callback/+page.svelte
+++ b/frontend/src/routes/providers/callback/+page.svelte
@@ -56,7 +56,8 @@
             error = t.clientForceMfa;
             clientMfaForce = true;
         } else {
-            error = `Uncovered HTTP return status '${res.status}'. This should never happen, please report this bug.`;
+            let body = await res.json();
+            error = `HTTP ${res.status}: ${body}`;
         }
     });
 


### PR DESCRIPTION
#458 
Change the error message on the auth provider callback endpoint to make it easier to debug.  
If you get something like an HTTP 400, it is most often a provider error, because everything else is covered.  

This change will simply forward the backend error like it is.