### PR TITLE
Upstream IdP Tokens compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -4596,6 +4597,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path",
+ "serde_with",
  "spow",
  "sqlx",
  "time",
@@ -5606,6 +5608,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ semver = { version = "1.0.19", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_json_path = "0.6.7"
+serde_with = { version = "3.8.1", features = ["macros"] }
 spow = "0.2"
 sqlx = { version = "0.7", features = ["macros", "migrate", "postgres", "runtime-tokio", "sqlite", "tls-rustls", "uuid"] }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing", "serde"] }

--- a/rauthy-models/Cargo.toml
+++ b/rauthy-models/Cargo.toml
@@ -66,6 +66,7 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_json_path = { workspace = true }
+serde_with = { workspace = true }
 spow = { workspace = true }
 sqlx = { workspace = true }
 time = { workspace = true }


### PR DESCRIPTION
Sadly, we need to get rid of the string slice deserialization for upstream IdP tokens and move to `Cow<_>` and proper `String`s for compatibility reasons. When an upstream IdP does not use UTF8 characters but unicode encoding inside JWT's, `&'a str` deserialization will fail.

fixes #458 