### PR TITLE
Feat `TRUSTED_PROXIES` config var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cidr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d18b093eba54c9aaa1e3784d4361eb2ba944cf7d0a932a830132238f483e8d8"
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,6 +4493,7 @@ dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
  "chrono",
+ "cidr",
  "flume",
  "gethostname",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bincode = "1"
 cached = "0.51.0"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
+cidr = "0.2.2"
 cron = "0.12"
 cryptr = { version = "0.4", features = ["s3", "streaming"] }
 css-color = "0.2"

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -8,18 +8,13 @@
 
 ## Stage 2 - features - do before v1.0.0
 
-- `code_challenge` missing on `/authorize` -> show error earlier than after login
-
+- add "request time taken" to access logging middleware
+- possibility to check for existing valid email?
 - prettify the UI
 - check out the possibility to include SCIM
 - update the book with all the new features
 - benchmarks and performance tuning
 - maybe get a nicer logo
-
-### Notes for performance optimizations
-
-- all the `get_`s on the `Client` will probably be good with returning slices instead of real Strings
-  -> less memory allocations
 
 ### `rauthy-client` TODO's
 

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -944,6 +944,15 @@ HTTP_WORKERS=1
 # When rauthy is running behind a reverse proxy, set to true (default: false)
 PROXY_MODE=false
 
+# A `\n` separated list of trusted proxy CIDRs.
+# When `PROXY_MODE=true` or `PEER_IP_HEADER_NAME` is set,
+# these are mandatory to be able to extract the real client
+# IP properly and safely to prevent IP header spoofing.
+# All requests with a different source will be blocked.
+TRUSTED_PROXIES="
+192.168.14.0/24
+"
+
 # To enable or disable the additional HTTP server to expose the /metrics endpoint
 # default: true
 #METRICS_ENABLE=true

--- a/src/api/src/clients.rs
+++ b/src/api/src/clients.rs
@@ -180,7 +180,7 @@ pub async fn post_clients_dyn(
                 .finish());
         }
     } else {
-        let ip = real_ip_from_req(&req).unwrap_or_default();
+        let ip = real_ip_from_req(&req)?;
         ClientDyn::rate_limit_ip(&data, ip).await?;
     }
 

--- a/src/api/src/fed_cm.rs
+++ b/src/api/src/fed_cm.rs
@@ -449,7 +449,7 @@ async fn login_status_from_req(
                 }
             };
 
-            if session.is_valid(*SESSION_TIMEOUT_FED_CM, real_ip_from_req(req)) {
+            if session.is_valid(*SESSION_TIMEOUT_FED_CM, real_ip_from_req(req).ok()) {
                 (
                     FedCMLoginStatus::LoggedIn,
                     session.user_id.unwrap_or_default(),

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -136,14 +136,17 @@ pub async fn post_users(
     let user = User::create_from_new(&data, user.into_inner()).await?;
 
     data.tx_events
-        .send_async(Event::new_user(user.email.clone(), real_ip_from_req(&req)))
+        .send_async(Event::new_user(
+            user.email.clone(),
+            real_ip_from_req(&req)?.to_string(),
+        ))
         .await
         .unwrap();
     if user.is_admin() {
         data.tx_events
             .send_async(Event::new_rauthy_admin(
                 user.email.clone(),
-                real_ip_from_req(&req),
+                real_ip_from_req(&req)?.to_string(),
             ))
             .await
             .unwrap();
@@ -334,7 +337,10 @@ pub async fn post_users_register(
     let user = User::create_from_reg(&data, req_data.into_inner(), lang).await?;
 
     data.tx_events
-        .send_async(Event::new_user(user.email, real_ip_from_req(&req)))
+        .send_async(Event::new_user(
+            user.email,
+            real_ip_from_req(&req)?.to_string(),
+        ))
         .await
         .unwrap();
 
@@ -1212,7 +1218,7 @@ pub async fn put_user_by_id(
         data.tx_events
             .send_async(Event::new_rauthy_admin(
                 user.email.clone(),
-                real_ip_from_req(&req),
+                real_ip_from_req(&req)?.to_string(),
             ))
             .await
             .unwrap();

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -13,6 +13,7 @@ argon2 = { workspace = true }
 base64 = { workspace = true }
 chacha20poly1305 = { workspace = true }
 chrono = { workspace = true }
+cidr = { workspace = true }
 flume = { workspace = true }
 gethostname = { workspace = true }
 lazy_static = { workspace = true }

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -1,3 +1,4 @@
+use crate::utils::build_trusted_proxies;
 use crate::DbType;
 use actix_web::http::Uri;
 use lazy_static::lazy_static;
@@ -335,6 +336,7 @@ lazy_static! {
         .unwrap_or_else(|_| String::from("false"))
         .parse::<bool>()
         .unwrap_or(true);
+    pub static ref TRUSTED_PROXIES: Vec<cidr::IpCidr> = build_trusted_proxies();
 
     pub static ref OPEN_USER_REG: bool = env::var("OPEN_USER_REG")
         .unwrap_or_else(|_| String::from("false"))

--- a/src/middlewares/src/csrf_protection.rs
+++ b/src/middlewares/src/csrf_protection.rs
@@ -91,7 +91,7 @@ where
                     return service.call(req).await;
                 }
 
-                let ip = real_ip_from_svc_req(&req).unwrap_or_default();
+                let ip = real_ip_from_svc_req(&req)?;
                 warn!(
                     "CSRF / Sec-Header violation from {} on path {}",
                     ip,

--- a/src/middlewares/src/logging.rs
+++ b/src/middlewares/src/logging.rs
@@ -111,7 +111,7 @@ async fn handle_req(req: &ServiceRequest) -> Result<(), ErrorResponse> {
 
 async fn log_access(uri: &Uri, req: &ServiceRequest) -> Result<(), ErrorResponse> {
     let path = uri.path();
-    let ip = real_ip_from_svc_req(req).unwrap_or_else(|| "<UNKNOWN>".to_string());
+    let ip = real_ip_from_svc_req(req)?;
 
     match *LOG_LEVEL_ACCESS {
         LogLevelAccess::Debug => {

--- a/src/middlewares/src/principal.rs
+++ b/src/middlewares/src/principal.rs
@@ -128,7 +128,7 @@ async fn get_session_from_cookie(
     match Session::find(data, session_id).await {
         Ok(mut session) => {
             let remote_ip = if *SESSION_VALIDATE_IP {
-                real_ip_from_svc_req(req)
+                real_ip_from_svc_req(req).ok()
             } else {
                 None
             };
@@ -151,6 +151,7 @@ async fn get_session_from_cookie(
                     Ok(Some(session))
                 }
             } else {
+                debug!("Access to {} with invalid Session Peer IP", req.path());
                 Ok(None)
             }
         }

--- a/src/models/src/entity/clients_dyn.rs
+++ b/src/models/src/entity/clients_dyn.rs
@@ -10,6 +10,7 @@ use rauthy_error::{ErrorResponse, ErrorResponseType};
 use redhac::{cache_get, cache_get_from, cache_get_value, cache_insert, cache_remove, AckLevel};
 use serde::{Deserialize, Serialize};
 use sqlx::{query, query_as, FromRow};
+use std::net::IpAddr;
 
 #[derive(Debug, Serialize, Deserialize, FromRow)]
 pub struct ClientDyn {
@@ -158,12 +159,12 @@ impl ClientDyn {
     /// If not, the IP will be cached with an Ok(()).
     pub async fn rate_limit_ip(
         data: &web::Data<AppState>,
-        ip: String,
+        ip: IpAddr,
     ) -> Result<(), ErrorResponse> {
         if let Some(ts) = cache_get!(
             i64,
             CACHE_NAME_CLIENTS_DYN.to_string(),
-            ip.clone(),
+            ip.to_string(),
             &data.caches.ha_cache_config,
             true
         )
@@ -177,7 +178,7 @@ impl ClientDyn {
             let now = Utc::now().timestamp();
             cache_insert(
                 CACHE_NAME_CLIENTS_DYN.to_string(),
-                ip,
+                ip.to_string(),
                 &data.caches.ha_cache_config,
                 &now,
                 AckLevel::Once,

--- a/src/models/src/entity/magic_links.rs
+++ b/src/models/src/entity/magic_links.rs
@@ -208,14 +208,14 @@ impl MagicLink {
                     if *PASSWORD_RESET_COOKIE_BINDING {
                         return Err(err);
                     } else {
-                        let ip = real_ip_from_req(req).unwrap_or_default();
+                        let ip = real_ip_from_req(req)?;
                         warn!("PASSWORD_RESET_COOKIE_BINDING disabled -> ignoring invalid binding cookie from {}", ip);
                     }
                 }
             } else if *PASSWORD_RESET_COOKIE_BINDING {
                 return Err(err);
             } else {
-                let ip = real_ip_from_req(req).unwrap_or_default();
+                let ip = real_ip_from_req(req)?;
                 warn!("PASSWORD_RESET_COOKIE_BINDING disabled -> ignoring invalid binding cookie from {}", ip);
             }
         }

--- a/src/models/src/entity/users.rs
+++ b/src/models/src/entity/users.rs
@@ -1154,7 +1154,7 @@ impl User {
         send_email_confirm_change(data, &user, &old_email, &user.email, false).await;
 
         let event_text = format!("{} -> {}", old_email, user.email);
-        let ip = real_ip_from_req(&req);
+        let ip = real_ip_from_req(&req).ok();
         data.tx_events
             .send_async(Event::user_email_change(event_text, ip))
             .await

--- a/src/models/src/events/event.rs
+++ b/src/models/src/events/event.rs
@@ -15,6 +15,7 @@ use rauthy_notify::{Notification, NotificationLevel};
 use serde::{Deserialize, Serialize};
 use sqlx::{query, query_as};
 use std::fmt::{Display, Formatter};
+use std::net::IpAddr;
 use std::str::FromStr;
 use tracing::error;
 
@@ -544,21 +545,21 @@ impl Event {
         )
     }
 
-    pub fn new_user(email: String, ip: Option<String>) -> Self {
+    pub fn new_user(email: String, ip: String) -> Self {
         Self::new(
             EVENT_LEVEL_NEW_USER.get().cloned().unwrap(),
             EventType::NewUserRegistered,
-            ip,
+            Some(ip),
             None,
             Some(email),
         )
     }
 
-    pub fn new_rauthy_admin(email: String, ip: Option<String>) -> Self {
+    pub fn new_rauthy_admin(email: String, ip: String) -> Self {
         Self::new(
             EVENT_LEVEL_NEW_RAUTHY_ADMIN.get().cloned().unwrap(),
             EventType::NewRauthyAdmin,
-            ip,
+            Some(ip),
             None,
             Some(email),
         )
@@ -630,31 +631,31 @@ impl Event {
         )
     }
 
-    pub fn secrets_migrated(ip: Option<String>) -> Self {
+    pub fn secrets_migrated(ip: IpAddr) -> Self {
         Self::new(
             EVENT_LEVEL_SECRETS_MIGRATED.get().cloned().unwrap(),
             EventType::SecretsMigrated,
-            ip,
+            Some(ip.to_string()),
             None,
             None,
         )
     }
 
-    pub fn test(ip: Option<String>) -> Self {
+    pub fn test(ip: IpAddr) -> Self {
         Self::new(
             EventLevel::Info,
             EventType::Test,
-            ip,
+            Some(ip.to_string()),
             None,
             Some("This is a Test-Event".to_string()),
         )
     }
 
-    pub fn user_email_change(text: String, ip: Option<String>) -> Self {
+    pub fn user_email_change(text: String, ip: Option<IpAddr>) -> Self {
         Self::new(
             EVENT_LEVEL_USER_EMAIL_CHANGE.get().cloned().unwrap(),
             EventType::UserEmailChange,
-            ip,
+            ip.map(|ip| ip.to_string()),
             None,
             Some(text),
         )

--- a/src/models/src/templates.rs
+++ b/src/models/src/templates.rs
@@ -1431,13 +1431,13 @@ impl PwdResetHtml<'_> {
 
 #[derive(Default, Template)]
 #[template(path = "error/429.html")]
-pub struct TooManyRequestsHtml<'a> {
-    pub ip: &'a str,
+pub struct TooManyRequestsHtml {
+    pub ip: String,
     pub exp: i64,
 }
 
-impl TooManyRequestsHtml<'_> {
-    pub fn build(ip: &str, exp: i64) -> String {
+impl TooManyRequestsHtml {
+    pub fn build(ip: String, exp: i64) -> String {
         TooManyRequestsHtml { ip, exp }.render().unwrap()
     }
 }

--- a/src/service/src/password_reset.rs
+++ b/src/service/src/password_reset.rs
@@ -193,12 +193,12 @@ pub async fn handle_put_user_password_reset<'a>(
     user.email_verified = true;
     user.save(data, None, None).await?;
 
-    let ip = match real_ip_from_req(&req) {
+    let ip = match real_ip_from_req(&req).ok() {
         None => {
             error!("Extracting clients real IP from HttpRequest during password reset");
             "UNKNOWN".to_string()
         }
-        Some(ip) => ip,
+        Some(ip) => ip.to_string(),
     };
     data.tx_events
         .send_async(Event::user_password_reset(


### PR DESCRIPTION
To prevent client IP spoofing via headers with `PROXY_MODE=true` or a set `PEER_IP_HEADER_NAME´, `TRUSTED_PROXIES` is a new config var that needs to be set properly in the future.  

If any of these variables are set, `TRUSTED_PROXIES` is mandatory and Rauthy will only accept requests from direct sources inside `TRUSTED_PROXIES`.

The value accepts a list of multiple CIDR's, so you have all the flexibility you need.