### PR TITLE
ui: pin `@swc/core` to `v1.6.0` to fix upstream bug of missing type info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,9 +2769,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -5980,9 +5980,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.0"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3318c4fc7126c339a40fbc025927d0328ca32259f68bfe4321660644c1f626"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@sveltejs/adapter-static": "^3.0.0",
         "@sveltejs/kit": "^2.4.3",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
+        "@swc/core": "1.6.0",
         "argon2-browser": "^1.18.0",
         "base64-arraybuffer": "^1.0.2",
         "eslint": "^8.16.0",
@@ -924,14 +925,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.0.tgz",
-      "integrity": "sha512-d4vMzH6ICllDwlPuhset2h8gu/USHdbyfJim+2hQEdxC0UONtfpmu38XBgNqRjStrji1Q5M10jfeUZL3cu1i8g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-Wynbo79uIVBgmq3TPcTMdtXUkqk69IPSVuzo7/Jl1OhR4msC7cUaoRB1216ZanWttrAZ4/g6u17w9XZG4fzp1A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.9"
+        "@swc/types": "^0.1.8"
       },
       "engines": {
         "node": ">=10"
@@ -941,16 +942,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.7.0",
-        "@swc/core-darwin-x64": "1.7.0",
-        "@swc/core-linux-arm-gnueabihf": "1.7.0",
-        "@swc/core-linux-arm64-gnu": "1.7.0",
-        "@swc/core-linux-arm64-musl": "1.7.0",
-        "@swc/core-linux-x64-gnu": "1.7.0",
-        "@swc/core-linux-x64-musl": "1.7.0",
-        "@swc/core-win32-arm64-msvc": "1.7.0",
-        "@swc/core-win32-ia32-msvc": "1.7.0",
-        "@swc/core-win32-x64-msvc": "1.7.0"
+        "@swc/core-darwin-arm64": "1.6.0",
+        "@swc/core-darwin-x64": "1.6.0",
+        "@swc/core-linux-arm-gnueabihf": "1.6.0",
+        "@swc/core-linux-arm64-gnu": "1.6.0",
+        "@swc/core-linux-arm64-musl": "1.6.0",
+        "@swc/core-linux-x64-gnu": "1.6.0",
+        "@swc/core-linux-x64-musl": "1.6.0",
+        "@swc/core-win32-arm64-msvc": "1.6.0",
+        "@swc/core-win32-ia32-msvc": "1.6.0",
+        "@swc/core-win32-x64-msvc": "1.6.0"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -962,9 +963,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.0.tgz",
-      "integrity": "sha512-2ylhM7f0HwUwLrFYZAe/dse8PCbPsYcJS3Dt7Q8NT3PUn7vy6QOMxNcOPPuDrnmaXqQQO3oxdmRapguTxaat9g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.0.tgz",
+      "integrity": "sha512-W1Mwk0WRrJ5lAVkYRPxpxOmwu8p9ASXeOmiORhXvE7DYREyI30005xlqSOITU1pfSNKj7G9u3+9DjsOzPPPbBw==",
       "cpu": [
         "arm64"
       ],
@@ -978,9 +979,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.7.0.tgz",
-      "integrity": "sha512-SgVnN4gT1Rb9YfTkp4FCUITqSs7Yj0uB2SUciu5CV3HuGvS5YXCUzh+KrwpLFtx8NIgivISKcNnb41mJi98X8Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.0.tgz",
+      "integrity": "sha512-EzxLnpPC1zgLb2Y0iVUG6b+/GUv43k6uJUIs52UzxOnBElYP/WeItI3RJ+LUMFzCpZMk/IxB10wofEoeQ1H/Xg==",
       "cpu": [
         "x64"
       ],
@@ -994,9 +995,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.0.tgz",
-      "integrity": "sha512-+Z9Dayart1iKJQEJJ9N/KS4z5EdXJE3WPFikY0jonKTo4Dd8RuyVz5yLvqcIMeVdz/SwximATaL6iJXw7hZS9A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.0.tgz",
+      "integrity": "sha512-uP/STDjWZ5N6lc8mxJFsex4NXDaqhfzd8UOrI3LfdV97+4faE4/BC6bVqDNHFFzZi0PHuVBxD6md7IfPjugk6A==",
       "cpu": [
         "arm"
       ],
@@ -1010,9 +1011,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.0.tgz",
-      "integrity": "sha512-UnLrCiZ1EI4shznJn0xP6DLgsXUSwtfsdgHhGYCrvbgVBBve3S9iFgVFEB3SPl7Q/TdowNbrN4zHU0oChfiNfw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.0.tgz",
+      "integrity": "sha512-UgNz6anowcnYzJtZohzpii31FOgouBHJqluiq+p2geX/agbC+KfOKwVXdljn95+Qc4ygBuw/hjKjgF2msOLeVg==",
       "cpu": [
         "arm64"
       ],
@@ -1026,9 +1027,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.0.tgz",
-      "integrity": "sha512-H724UANA+ptsfwKRr9mnaDa9cb5fw0oFysiGKTgb3DMYcgk3Od0jMTnXVPFSVpo7FlmyxeC9K8ueUPBOoOK6XA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.0.tgz",
+      "integrity": "sha512-xPV6qrnj4nFwXQbIv70C1Kn5z5Th53sirIY76aEonr78qeC6+ywaBZR4uLFNHsljVjyuvVQfTTcl2qraGhu6oQ==",
       "cpu": [
         "arm64"
       ],
@@ -1042,9 +1043,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.0.tgz",
-      "integrity": "sha512-SY3HA0K0Dpqt1HIfMLGpwL4hd4UaL2xHP5oZXPlRQPhUDZrbb4PbI3ZJnh66c63eL4ZR8EJ+HRFI0Alx5p69Zw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.0.tgz",
+      "integrity": "sha512-xTeWn4OT5uQ+DxT2cy94ngK8tF1U/5fMC49/V6FhCS2Wh+Xa/O+OWcOyKvYtk3b0eGYS4iNIRKgzog7fLSFtvQ==",
       "cpu": [
         "x64"
       ],
@@ -1058,9 +1059,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.0.tgz",
-      "integrity": "sha512-cEJ2ebtV1v/5Ilb55E05J6F5SrHKQWzUttIhR5Mkayyo+yvPslcpByuFC3D+J7X1ebziTOBpWuMpUdjLfh3SMQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.0.tgz",
+      "integrity": "sha512-3P01mYD5XbyaVLT0MGZmZE+ZdgmGSvuvIhSejRDBlEXqkFnH79nWds+KsE+91hzVU8XsgzX57Yzv4eO5dlIuPw==",
       "cpu": [
         "x64"
       ],
@@ -1074,9 +1075,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.0.tgz",
-      "integrity": "sha512-ecQOOmzEssz+m0pR4xDYCGuvn3E/l0nQ3tk5jp1NA1lsAy4bMV0YbYCHjptYvWL/UjhIerIp3IlCJ8x5DodSog==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.0.tgz",
+      "integrity": "sha512-xFuook1efU0ctzMAEeol4eI7J6+k/c/pMJpp/NP/4JJDnhlHwAi2iyiZcID8YZS+ePHgXMLndGdIMHVv/wIPkQ==",
       "cpu": [
         "arm64"
       ],
@@ -1090,9 +1091,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.0.tgz",
-      "integrity": "sha512-gz81seZkRn3zMnVOc7L5k6F4vQC82gIxmHiL+GedK+A37XI/X26AASU3zxvORnqQbwQYXQ+AEVckxBmFlz3v2g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.0.tgz",
+      "integrity": "sha512-VCJa5vTywxzASqvf9OEUM5SZBcNrWbuIkSGM5T9guuBzyrh/tSqVHjzOWL9qpP69uPVj5G/I5bJObLiUKErhvQ==",
       "cpu": [
         "ia32"
       ],
@@ -1106,9 +1107,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.0.tgz",
-      "integrity": "sha512-b5Fd1xEOw9uqBpj2lqsaR4Iq9UhiL84hNDcEsi6DQA7Y1l85waQAslTbS0E4/pJ1PISAs0jW0zIGLco1eaWBOg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.0.tgz",
+      "integrity": "sha512-L7i8WBSIJTQiMONJGHnznDydZmlJIqHjZ3VhBHeTTms8cEAuwkAVgzPwgr5cD9GhmcwdeBI9iYdOuKr1pUx19Q==",
       "cpu": [
         "x64"
       ],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,8 @@
     "vite": "^5.0.12",
     "vite-plugin-top-level-await": "1.4.1",
     "vite-plugin-wasm": "3.3.0",
-    "yup": "^1.0.2"
+    "yup": "^1.0.2",
+    "@swc/core": "1.6.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
`vite-plugin-top-level-await` can't build of broken `@swc/core:1.7`