### PR TITLE
fix: wrong config vars read priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## UNRELEASE
+
+### Changes
+
+#### Config Read
+
+The current behavior of reading in config variables was not working as intended.
+
+Rauthy reads the `rauthy.cfg` as a file first and the environment variables afterward. This makes it possible to
+configure it in any way you like and even mix and match.  
+However, the idea was that any existing variables in the environment should overwrite config variables and therefore
+have the higher priority. This was exactly the other way around up until `v0.24.1` and has been fixed now.
+
+How Rauthy parses config variables now correctly:
+
+1. read `rauthy.cfg`
+2. read env var
+3. all existing env vars will overwrite existing vars from `rauthy.cfg` and therefore have the higher priority
+
+[]()
+
 ## 0.24.1
 
 The last weeks were mostly for updating the documentation and including all the new features that came to Rauthy in
@@ -17,13 +38,13 @@ Security issues in external crates have been fixed:
 
 ### Changes
 
-# `S3_DANGER_ACCEPT_INVALID_CERTS` renamed
+#### `S3_DANGER_ACCEPT_INVALID_CERTS` renamed
 
 The config var `S3_DANGER_ACCEPT_INVALID_CERTS` has been renamed to `S3_DANGER_ALLOW_INSECURE`. This is not a breaking
 change right now, because for now Rauthy will accept both versions to not introduce a breaking change, but the
 deprecated values will be removed after v0.24.
 
-### S3 Compatibility
+#### S3 Compatibility
 
 Quite a few internal dependencies have been updated to the latest versions (where it made sense).
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -4,7 +4,7 @@
 
 ## Documentation TODO
 
-- mention i18n possibilities
+-> events view wide -> button height 30px -> error with overflow
 
 ## Stage 1 - essentials
 

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         dotenvy::from_filename("rauthy.test.cfg").ok();
     } else {
         dotenvy::from_filename("rauthy.cfg").expect("'rauthy.cfg' error");
-        dotenvy::dotenv().ok();
+        dotenvy::dotenv_override().ok();
     }
 
     let log_level = setup_logging();


### PR DESCRIPTION
The current behavior of reading in config variables was not working as intended.

Rauthy reads the `rauthy.cfg` as a file first and the environment variables afterward. This makes it possible to
configure it in any way you like and even mix and match.  
However, the idea was that any existing variables in the environment should overwrite config variables and therefore
have the higher priority. This was exactly the other way around up until `v0.24.1` and has been fixed now.

How Rauthy parses config variables now correctly:

1. read `rauthy.cfg`
2. read env var
3. all existing env vars will overwrite existing vars from `rauthy.cfg` and therefore have the higher priority