### PR TITLE
Add Simplified Chinese translations

### DIFF
--- a/frontend/src/components/account/AccInfo.svelte
+++ b/frontend/src/components/account/AccInfo.svelte
@@ -171,7 +171,7 @@
     </div>
 
     <div class="row">
-        <div class={classLabel}><b>{t.user} {t.enabled}:</b></div>
+        <div class={classLabel}><b>{t.userEnabled}:</b></div>
         <CheckIcon check={user.enabled}/>
     </div>
 
@@ -191,7 +191,7 @@
     </div>
 
     <div class={classRow}>
-        <div class={classLabel}><b>{t.user} {t.created}:</b></div>
+        <div class={classLabel}><b>{t.userCreated}:</b></div>
         <span class="value">{formatDateFromTs(user.created_at)}</span>
     </div>
 

--- a/frontend/src/components/account/AccMain.svelte
+++ b/frontend/src/components/account/AccMain.svelte
@@ -63,7 +63,7 @@
         <LangSelector absolute absoluteRight updateBackend/>
 
         <div class="headerPhone">
-            <h3>{t.user} {t.account}</h3>
+            <h3>{t.account}</h3>
         </div>
 
         <div class="container">
@@ -93,7 +93,7 @@
         <LangSelector absolute updateBackend/>
 
         <div class="header">
-            <h3>{t.user} {t.account}</h3>
+            <h3>{t.account}</h3>
         </div>
 
         <div class="container">

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -63,7 +63,7 @@ export const EVENT_TYPES = [
     'UserPasswordReset',
     'Test',
 ]
-export const LANGUAGES = ['DE', 'EN'];
+export const LANGUAGES = ['DE', 'EN', 'ZH'];
 export const TOKEN_ALGS = [
     'RS256',
     'RS384',

--- a/src/api_types/src/generic.rs
+++ b/src/api_types/src/generic.rs
@@ -33,6 +33,7 @@ pub enum I18nContent {
 pub enum Language {
     En,
     De,
+    ZhHans,
 }
 
 #[derive(Debug, Deserialize, Validate, ToSchema, IntoParams)]

--- a/src/models/src/entity/well_known.rs
+++ b/src/models/src/entity/well_known.rs
@@ -164,7 +164,7 @@ impl WellKnown {
         ];
 
         let service_documentation = "https://sebadob.github.io/rauthy/".to_string();
-        let ui_locales_supported = vec!["de".to_string(), "en".to_string()];
+        let ui_locales_supported = vec!["de".to_string(), "en".to_string(), "zh-hans".to_string()];
 
         WellKnown {
             issuer: String::from(issuer),

--- a/src/models/src/i18n/account.rs
+++ b/src/models/src/i18n/account.rs
@@ -21,7 +21,6 @@ pub struct I18nAccount<'a> {
     convert_account: &'a str,
     convert_account_p_1: &'a str,
     country: &'a str,
-    created: &'a str,
     device_id: &'a str,
     device_name: &'a str,
     devices: &'a str,
@@ -29,7 +28,6 @@ pub struct I18nAccount<'a> {
     email: &'a str,
     email_update_confirm: &'a str,
     email_verified: &'a str,
-    enabled: &'a str,
     family_name: &'a str,
     federated_convert_password_1: &'a str,
     federated_convert_password_2: &'a str,
@@ -70,6 +68,8 @@ pub struct I18nAccount<'a> {
     save: &'a str,
     street: &'a str,
     user: &'a str,
+    user_created: &'a str,
+    user_enabled: &'a str,
     user_expiry: &'a str,
     user_verified_tooltip: &'a str,
     valid_email: &'a str,
@@ -86,6 +86,7 @@ impl SsrJson for I18nAccount<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -97,9 +98,9 @@ impl SsrJson for I18nAccount<'_> {
 impl I18nAccount<'_> {
     fn build_en() -> Self {
         Self {
-            account: "Account",
+            account: "User Account",
             acc_type: "Account Type",
-            acc_type_passkey_text_1: r#"This is account is currently a passkey only account.
+            acc_type_passkey_text_1: r#"This account is currently a passkey only account.
 This means, that you do not have any password, because you don't need one."#,
             acc_type_passkey_text_2: r#"You can convert your account and add a password. But keep
 in mind, that this implies, that you need to verify each new device with the password additionally.
@@ -120,7 +121,6 @@ passkeys. Keep in mind, that only passkeys with the additional User Verification
 If you passkeys support this, you will find a small symbol behind the name of the key on the 'MFA'
 page."#,
             country: "Country",
-            created: "created",
             device_id: "ID",
             device_name: "Name",
             devices: "Devices",
@@ -130,14 +130,13 @@ page."#,
 sent out to your new address. You need to click the confirmation link inside it. Once it has been
 confirmed, your new address will be updated."#,
             email_verified: "E-Mail verified",
-            enabled: "Enabled",
             family_name: "Family Name",
             federated_convert_password_1: r#"You have a federated account. This means you log in
 by using an external authentication provider. Your current provider is:"#,
             federated_convert_password_2: r#"You can request a password reset via email. This will
 add a local password to your account upon completion. You would then be able to log in via your
 external provider or by local password. Do you want to request a reset?"#,
-            generate_random: "Generate Random",
+            generate_random: "Generate Randomly",
             given_name: "Given Name",
             groups: "Groups",
             invalid_input: "Invalid Input",
@@ -177,15 +176,17 @@ account, you can unlink it from the upstream provider."#,
             save: "Save",
             street: "Street",
             user: "User",
+            user_created: "User Created",
+            user_enabled: "User Enabled",
             user_expiry: "User Expires",
             user_verified_tooltip: "Secured with fingerprint or PIN",
-            valid_email: "Valid E-Mail format",
-            valid_given_name: "Your given name with 2 - 32 non-special characters",
-            valid_family_name: "Your family name with 2 - 32 non-special characters",
+            valid_email: "Invalid E-Mail format",
+            valid_given_name: "Your given name should have 2 - 32 non-special characters",
+            valid_family_name: "Your family name should have 2 - 32 non-special characters",
             web_id_desc: r#"You can configure the fields that should be exposed with your WebID.
 This is a feature used by some networks for decentralized logins. If you do not know what it is,
 you most probably do not need it."#,
-            web_id_desc_data: "You can add custom data fields to your WebID in valid turtle",
+            web_id_desc_data: "You can add custom data fields to your WebID in valid FOAF Vocabulary",
             web_id_expert_mode: "Enable Expert Mode",
             zip: "ZIP",
         }
@@ -193,7 +194,7 @@ you most probably do not need it."#,
 
     fn build_de() -> Self {
         Self {
-            account: "Account",
+            account: "Benutzer Account",
             acc_type: "Account Typ",
             acc_type_passkey_text_1: r#"Dies ist ein "Passkey-Only" Account. Das bedeutet, dass
 dieser Account kein Passwort hat und auch keines benötigt."#,
@@ -215,7 +216,6 @@ werden. Diese Umwandling löscht das Passwort und erlaubt den alleinigen Login m
 Passkeys. Nur Passkeys mit zusätzlicher Benutzerverifizierung werden akzeptiert. Diese sind auf der
 'MFA' Seite durch das zusätzliche Symbol hinter dem Passkey Namen gekennzeichnet."#,
             country: "Land",
-            created: "erstellt",
             device_id: "ID",
             device_name: "Name",
             devices: "Geräte",
@@ -225,7 +225,6 @@ Passkeys. Nur Passkeys mit zusätzlicher Benutzerverifizierung werden akzeptiert
 mit einem Bestätigungslink wurde an die neue Adresse geschickt. Das Update muss über den
 enthaltenen Link bestätigt werden. Nach der Bestätigung wird die neue Adresse gesetzt."#,
             email_verified: "E-Mail verifiziert",
-            enabled: "Aktiviert",
             family_name: "Nachname",
             federated_convert_password_1: r#"Dies ist ein verknüpfter Account. Das bedeutet, dass
 der Login via externem Provider zur Authenzifizierung geschieht. Der derzeitige Provider ist:"#,
@@ -273,6 +272,8 @@ Account gesetzt ist, kann die Verbindung zum Provider gelöst werden."#,
             save: "Speichern",
             street: "Straße",
             user: "Benutzer",
+            user_created: "Benutzer erstellt",
+            user_enabled: "Benutzer Aktiviert",
             user_expiry: "Benutzer Ablauf",
             user_verified_tooltip: "Abgesichert durch Fingerabdruck oder PIN",
             valid_email: "Gültige E-Mail Adresse",
@@ -285,6 +286,95 @@ Sollten Sie nicht wissen, was die WebID ist, brauchen Sie sie höchstwahrscheinl
 hinzufügen:"#,
             web_id_expert_mode: "Expertenmodus aktivieren",
             zip: "PLZ",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            account: "用户账户",
+            acc_type: "账户类型",
+            acc_type_passkey_text_1: r#"此账户目前为仅密钥登录账户。
+因此，此账户没有密码，也无需设置密码。"#,
+            acc_type_passkey_text_2: r#"您可以转换此账户并添加密码。
+但请注意，调整后在新设备上登录时需额外进行密码验证。
+如果您没有事先输入过至少一次密码，您将无法在任何设备上登录。"#,
+            acc_type_passkey_text_3: "您想要转换您的账户并添加一个密码吗？",
+            access_exp: "过期",
+            access_renew: "续期至",
+            access_renew_delete: "禁止续期",
+            birthdate: "生日",
+            cancel: "取消",
+            city: "城市",
+            change_password: "更改密码",
+            convert_account: "转换账户",
+            convert_account_p_1: r#"您可以将您的账户转换为仅密钥登陆账户。
+此转换将删除您的密码，您将仅能够通过注册的密钥进行登陆。
+请注意，只有支持额外用户验证的密钥可被用于登陆。
+如果您的密钥支持用户验证，您可以在“MFA”页面中，密钥名称的后面看到一个符号。"#,
+            country: "国家",
+            device_id: "ID",
+            device_name: "名称",
+            devices: "设备",
+            devices_desc: "链接到此账户的设备",
+            email: "电子邮箱",
+            email_update_confirm: r#"电子邮件地址未被更新。我们已向您的新邮箱发送了一封消息。
+您需要点击其中的确认链接，电子邮件地址将在被确认后更新。"#,
+            email_verified: "已验证电子邮箱",
+            family_name: "姓",
+            federated_convert_password_1: r#"您有一个联合账户。
+这意味着您是通过外部鉴权提供者登陆的。您当前的提供者是："#,
+            federated_convert_password_2: r#"您可以通过电子邮件请求密码重置。这将向您的本地账户添加密码，
+之后您可以通过本地密码或您的外部提供者进行登陆。您想要请求密码重置吗？"#,
+            generate_random: "随机生成",
+            given_name: "名",
+            groups: "组",
+            invalid_input: "无效输入",
+            key: "密钥",
+            key_unique: "密钥必须是唯一的",
+            last_login: "最后登录",
+            mfa: I18nAccountMfa::build_zh_hans(),
+            mfa_activated: "多因子认证",
+            nav_info: "信息",
+            nav_edit: "编辑",
+            nav_mfa: "多因子认证",
+            nav_password: "密码",
+            nav_logout: "退出登录",
+            never: "从不",
+            optional_values: "可选项",
+            password_confirm: "确认密码",
+            password_curr: "当前密码",
+            password_curr_req: "当前密码必填。",
+            password_new: "新密码",
+            password_new_req: "新密码必填",
+            password_no_match: "密码验证必填。",
+            password_expiry: "密码过期",
+            password_policy: I18nPasswordPolicy::build_zh_hans(),
+            password_policy_follow: "密码不符合要求。",
+            password_reset: "重置密码",
+            phone: "手机",
+            provider_link: "联合账户",
+            provider_link_desc: r#"您可以将此账户连接到下列登陆提供者之一。
+激活此功能后，您将被重定向至所选提供者的登陆页面。在成功登陆后，如果电子邮件匹配，您的账户将被连接。"#,
+            provider_unlink: "取消联合",
+            provider_unlink_desc: r#"仅当您已设置至少一个密码或登陆密钥后，您才能和登陆提供者取消连接。"#,
+            reg_date: "注册日期",
+            reg_ip: "注册IP地址",
+            roles: "角色",
+            save: "保存",
+            street: "街道",
+            user: "用户",
+            user_created: "创建于",
+            user_enabled: "启用",
+            user_expiry: "过期",
+            user_verified_tooltip: "指纹或PIN保护",
+            valid_email: "无效电子邮箱格式",
+            valid_given_name: "您的名字需要有2-32个非特殊字符",
+            valid_family_name: "您的姓氏需要有2-32个非特殊字符",
+            web_id_desc: r#"您可以选择哪些字段能够通过WebID发布。
+WebID被一些网络用于去中心化登陆。如果您不知道这是什么，您通常不需要选择。"#,
+            web_id_desc_data: "您可以以FOAF词汇格式向您的 WebID 添加自定义数据字段",
+            web_id_expert_mode: "启用专家模式",
+            zip: "邮政编码",
         }
     }
 }
@@ -316,6 +406,7 @@ impl SsrJson for I18nAccountMfa<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -372,6 +463,28 @@ impl I18nAccountMfa<'_> {
             test: "Test",
             test_error: "Fehler beim Starten des Tests",
             test_success: "Test erfolgreich",
+        }
+    }
+
+    pub(crate) fn build_zh_hans() -> Self {
+        Self {
+            p_1: "如果您计划在多个系统上使用您的MFA密钥，例如Windows和Android，您应该在Android上进行注册。",
+            p_2: "Android是支持无密码登陆特性最少的平台。能够在Android上进行注册的密钥也应能在其他平台上使用。",
+
+            delete: "删除",
+            error_reg: "开始注册过程时出现错误。",
+            invalid_key_used: "使用的密钥无效",
+            last_used: "最后使用",
+            no_key: "此槽位没有已注册的安全密钥",
+            register: "注册",
+            register_new: "注册新的密钥",
+            registerd: "注册时间",
+            registerd_keys: "已注册的密钥",
+            passkey_name: "密钥名称",
+            passkey_name_err: "需要名称需要有2-32个非特殊字符",
+            test: "测试",
+            test_error: "开始测试时出现错误",
+            test_success: "测试成功！",
         }
     }
 }

--- a/src/models/src/i18n/authorize.rs
+++ b/src/models/src/i18n/authorize.rs
@@ -29,6 +29,7 @@ impl SsrJson for I18nAuthorize<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -82,6 +83,29 @@ hinzufügen."#,
             provide_mfa: "Bitte stellen Sie Ihr MFA Gerät zur Verfügung",
             request_expires: "Anfrage läuft ab",
             sign_up: "Benutzer Registrierung",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            client_force_mfa: r#"本次登陆强制使用多因子认证以增强安全性。
+要完成登陆，请登入您的账户并添加一个登陆密钥。"#,
+            email: "电子邮件地址",
+            email_bad_format: "错误的电子邮件地址格式",
+            email_required: "电子邮件地址必填。",
+            email_sent_msg: "如果您的电子邮件存在，我们已发送请求邮件。",
+            http_429: "过多无效输入，已锁定至：",
+            invalid_credentials: "无效证明",
+            invalid_key_used: "无效密钥",
+            login: "登陆",
+            mfa_ack: "已确认",
+            password: "密码",
+            password_forgotten: "忘记密码",
+            password_request: "请求",
+            password_required: "密码必填。",
+            provide_mfa: "请使用MFA设备登陆",
+            request_expires: "请求过期",
+            sign_up: "用户注册",
         }
     }
 }

--- a/src/models/src/i18n/device.rs
+++ b/src/models/src/i18n/device.rs
@@ -27,6 +27,7 @@ impl SsrJson for I18nDevice<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -42,7 +43,7 @@ impl I18nDevice<'_> {
             auto_redirect_account: "You will be redirected to your account now",
             close_window: "You can close this window now.",
             decline: "Decline",
-            desc: "Please enter the {{count}} character user code from your device.",
+            desc: "Please enter the {{count}} characters user code from your device.",
             desc_scopes: "The device requests access to:",
             err_too_short: "Input too short",
             err_too_long: "Input too long",
@@ -73,6 +74,26 @@ impl I18nDevice<'_> {
             title: "Gerät Authorisierung",
             user_code: "Benutzer Code",
             wrong_or_expired: "Ungültiger oder abgelaufener Code",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            accept: "接受",
+            auto_redirect_account: "您将被自动重定向至您的账户。",
+            close_window: "您现在可以关闭此窗口了。",
+            decline: "拒绝",
+            desc: "请输入来自您的设备的{{count}}位用户代码。",
+            desc_scopes: "此设备请求访问：",
+            err_too_short: "输入过短",
+            err_too_long: "输入过长",
+            invalid_input: "无效输入",
+            is_accepted: "请求已被接受。",
+            is_declined: "请求已被拒绝。",
+            submit: "提交",
+            title: "设备授权",
+            user_code: "用户代码",
+            wrong_or_expired: "代码错误或已过期",
         }
     }
 }

--- a/src/models/src/i18n/email_change_info_new.rs
+++ b/src/models/src/i18n/email_change_info_new.rs
@@ -17,6 +17,7 @@ impl SsrJson for I18nEmailChangeInfoNew<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -46,6 +47,17 @@ impl I18nEmailChangeInfoNew<'_> {
             validity: "Dieser Link ist aus Sicherheitsgründen nur für kurze Zeit gültig.",
             expires: "Link gültig bis:",
             button_text: "E-Mail Bestätigen",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            subject: "电子邮件更改请求",
+            header: "电子邮件更改请求：",
+            click_link: "点击下方链接以确认您的电子邮件地址。",
+            validity: "出于安全考虑，此链接仅在短时间内有效。",
+            expires: "链接过期时间：",
+            button_text: "确认电子邮件地址",
         }
     }
 }

--- a/src/models/src/i18n/email_change_info_old.rs
+++ b/src/models/src/i18n/email_change_info_old.rs
@@ -18,6 +18,7 @@ impl SsrJson for I18nEmailChangeInfoOld<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -48,6 +49,18 @@ impl I18nEmailChangeInfoOld<'_> {
             validity: "Dieser Link ist aus Sicherheitsgründen nur für kurze Zeit gültig.",
             expires: "Link gültig bis:",
             button_text: "Adresswechsel Blockieren",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            subject: "电子邮件更改请求",
+            header: "电子邮件更改请求：",
+            change_info: "有人请求更改您的账户的电子邮件地址。新邮箱为：",
+            click_link: "如果您没有请求此更改，请点击下方的链接阻止此更改。",
+            validity: "出于安全考虑，此链接仅在短时间内有效。",
+            expires: "链接过期时间：",
+            button_text: "阻止地址更改",
         }
     }
 }

--- a/src/models/src/i18n/email_confirm_change.rs
+++ b/src/models/src/i18n/email_confirm_change.rs
@@ -14,6 +14,7 @@ impl SsrJson for I18nEmailConfirmChange<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -36,6 +37,14 @@ impl I18nEmailConfirmChange<'_> {
             subject: "E-Mail Wechsel bestätigt für",
             msg: "Ihre E-Mail Adresse wurde erfolgreich geändert zu:",
             msg_from_admin: "Diese Änderung wurde durch einen Administrator durchgeführt.",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            subject: "电子邮件地址已更新：",
+            msg: "您的电子邮件地址已成功更新为：",
+            msg_from_admin: "此操作由管理员完成。",
         }
     }
 }

--- a/src/models/src/i18n/email_confirm_change_html.rs
+++ b/src/models/src/i18n/email_confirm_change_html.rs
@@ -15,6 +15,7 @@ impl SsrJson for I18nEmailConfirmChangeHtml<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -39,6 +40,15 @@ impl I18nEmailConfirmChangeHtml<'_> {
             text_changed: "Ihre E-Mail Adresse wurde erfolgreich geändert von",
             text_login: "Sie können sich jetzt mit der neuen Adresse einloggen.",
             to: "zu",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            title: "电子邮件地址已更新",
+            text_changed: "您的电子邮件地址已从",
+            text_login: "您现在可以使用您的新地址进行登陆。",
+            to: "更新为",
         }
     }
 }

--- a/src/models/src/i18n/email_password_new.rs
+++ b/src/models/src/i18n/email_password_new.rs
@@ -38,6 +38,23 @@ static TPL_DE_PASSWORD_NEW_BUTTON: Lazy<Option<String>> =
 static TPL_DE_PASSWORD_NEW_FOOTER: Lazy<Option<String>> =
     Lazy::new(|| env::var("TPL_DE_PASSWORD_NEW_FOOTER").ok());
 
+static TPL_ZH_HANS_PASSWORD_NEW_SUBJECT: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_SUBJECT").ok());
+static TPL_ZH_HANS_PASSWORD_NEW_HEADER: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_HEAZH_HANSR").ok());
+static TPL_ZH_HANS_PASSWORD_NEW_TEXT: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_TEXT").ok());
+static TPL_ZH_HANS_PASSWORD_NEW_CLICK_LINK: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_CLICK_LINK").ok());
+static TPL_ZH_HANS_PASSWORD_NEW_VALIDITY: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_VALIDITY").ok());
+static TPL_ZH_HANS_PASSWORD_NEW_EXPIRES: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_EXPIRES").ok());
+static TPL_ZH_HANS_PASSWORD_NEW_BUTTON: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_BUTTON").ok());
+static TPL_ZH_HANS_PASSWORD_NEW_FOOTER: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_PASSWORD_NEW_FOOTER").ok());
+
 #[derive(Debug, Serialize)]
 pub struct I18nEmailPasswordNew<'a> {
     pub subject: &'a str,
@@ -55,6 +72,7 @@ impl SsrJson for I18nEmailPasswordNew<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -111,6 +129,31 @@ impl I18nEmailPasswordNew<'_> {
                 .as_deref()
                 .unwrap_or("Passwort Setzen"),
             footer: TPL_DE_PASSWORD_NEW_FOOTER.as_deref(),
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            subject: TPL_ZH_HANS_PASSWORD_NEW_SUBJECT
+                .as_deref()
+                .unwrap_or("新密码"),
+            header: TPL_ZH_HANS_PASSWORD_NEW_HEADER
+                .as_deref()
+                .unwrap_or("新密码："),
+            text: TPL_ZH_HANS_PASSWORD_NEW_TEXT.as_deref(),
+            click_link: TPL_ZH_HANS_PASSWORD_NEW_CLICK_LINK
+                .as_deref()
+                .unwrap_or("点击下方链接以打开密码设置表单。"),
+            validity: TPL_ZH_HANS_PASSWORD_NEW_VALIDITY
+                .as_deref()
+                .unwrap_or("出于安全考虑，此链接仅在短时间内有效。"),
+            expires: TPL_ZH_HANS_PASSWORD_NEW_EXPIRES
+                .as_deref()
+                .unwrap_or("链接过期时间："),
+            button_text: TPL_ZH_HANS_PASSWORD_NEW_BUTTON
+                .as_deref()
+                .unwrap_or("设置密码"),
+            footer: TPL_ZH_HANS_PASSWORD_NEW_FOOTER.as_deref(),
         }
     }
 }

--- a/src/models/src/i18n/email_reset.rs
+++ b/src/models/src/i18n/email_reset.rs
@@ -36,6 +36,22 @@ static TPL_DE_RESET_BUTTON: Lazy<Option<String>> =
 static TPL_DE_RESET_FOOTER: Lazy<Option<String>> =
     Lazy::new(|| env::var("TPL_DE_RESET_FOOTER").ok());
 
+static TPL_ZH_HANS_RESET_SUBJECT: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_SUBJECT").ok());
+static TPL_ZH_HANS_RESET_HEADER: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_HEADER").ok());
+static TPL_ZH_HANS_RESET_TEXT: Lazy<Option<String>> = Lazy::new(|| env::var("TPL_ZH_HANS_RESET_TEXT").ok());
+static TPL_ZH_HANS_RESET_CLICK_LINK: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_CLICK_LINK").ok());
+static TPL_ZH_HANS_RESET_VALIDITY: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_VALIDITY").ok());
+static TPL_ZH_HANS_RESET_EXPIRES: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_EXPIRES").ok());
+static TPL_ZH_HANS_RESET_BUTTON: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_BUTTON").ok());
+static TPL_ZH_HANS_RESET_FOOTER: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_FOOTER").ok());
+
 #[derive(Debug, Serialize)]
 pub struct I18nEmailReset<'a> {
     pub subject: &'a str,
@@ -53,6 +69,7 @@ impl SsrJson for I18nEmailReset<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -105,6 +122,27 @@ impl I18nEmailReset<'_> {
                 .as_deref()
                 .unwrap_or("Passwort Zurücksetzen"),
             footer: TPL_DE_RESET_FOOTER.as_deref(),
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            subject: TPL_ZH_HANS_RESET_SUBJECT
+                .as_deref()
+                .unwrap_or("密码重置请求"),
+            header: TPL_ZH_HANS_RESET_HEADER
+                .as_deref()
+                .unwrap_or("密码重置请求："),
+            text: TPL_ZH_HANS_RESET_TEXT.as_deref(),
+            click_link: TPL_ZH_HANS_RESET_CLICK_LINK
+                .as_deref()
+                .unwrap_or("点击下方链接以打开密码重置表单。"),
+            validity: TPL_ZH_HANS_RESET_VALIDITY.as_deref().unwrap_or(
+                "出于安全考虑，此链接仅在短时间内有效。",
+            ),
+            expires: TPL_ZH_HANS_RESET_EXPIRES.as_deref().unwrap_or("链接过期时间"),
+            button_text: TPL_ZH_HANS_RESET_BUTTON.as_deref().unwrap_or("重置密码"),
+            footer: TPL_ZH_HANS_RESET_FOOTER.as_deref(),
         }
     }
 }

--- a/src/models/src/i18n/email_reset_info.rs
+++ b/src/models/src/i18n/email_reset_info.rs
@@ -16,6 +16,7 @@ impl SsrJson for I18nEmailResetInfo<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -42,6 +43,16 @@ impl I18nEmailResetInfo<'_> {
             expires_2: " läuft demnächst ab:",
             update: "Sie können es hier erneuern:",
             button_text: "Passwort Erneuern",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            subject: "您的密码即将过期",
+            expires_1: "",
+            expires_2: "的密码即将过期：",
+            update: "您可以在此处更新密码：",
+            button_text: "更新密码",
         }
     }
 }

--- a/src/models/src/i18n/error.rs
+++ b/src/models/src/i18n/error.rs
@@ -21,6 +21,7 @@ impl I18nError<'_> {
         match lang {
             Language::En => Self::build_en(status_code, details_text.map(|t| t.into())),
             Language::De => Self::build_de(status_code, details_text.map(|t| t.into())),
+            Language::ZhHans => Self::build_zh_hans(status_code, details_text.map(|t| t.into())),
         }
     }
 }
@@ -30,6 +31,7 @@ impl SsrJson for I18nError<'_> {
         match lang {
             Language::En => Self::build_en(StatusCode::NOT_FOUND, None),
             Language::De => Self::build_de(StatusCode::NOT_FOUND, None),
+            Language::ZhHans => Self::build_zh_hans(StatusCode::NOT_FOUND, None),
         }
     }
 
@@ -71,6 +73,26 @@ impl I18nError<'_> {
             error: status_code.to_string(),
             error_text,
             details: "Details Anzeigen",
+            details_text,
+        }
+    }
+
+    fn build_zh_hans(status_code: StatusCode, details_text: Option<Cow<'static, str>>) -> Self {
+        let error_text = match status_code {
+            StatusCode::BAD_REQUEST => {
+                "您的请求异常，请参见详情。"
+            }
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                "拒绝访问——您未被允许访问此资源。"
+            }
+            StatusCode::INTERNAL_SERVER_ERROR => "内部服务器错误",
+            _ => "找不到请求的资源",
+        };
+
+        Self {
+            error: status_code.to_string(),
+            error_text,
+            details: "显示详情",
             details_text,
         }
     }

--- a/src/models/src/i18n/index.rs
+++ b/src/models/src/i18n/index.rs
@@ -15,6 +15,7 @@ impl SsrJson for I18nIndex<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -37,6 +38,14 @@ impl I18nIndex<'_> {
             register: "Registrieren",
             account_login: "Account",
             admin_login: "Admin",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            register: "注册",
+            account_login: "登陆",
+            admin_login: "管理",
         }
     }
 }

--- a/src/models/src/i18n/logout.rs
+++ b/src/models/src/i18n/logout.rs
@@ -15,6 +15,7 @@ impl SsrJson for I18nLogout<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -38,6 +39,14 @@ impl I18nLogout<'_> {
             confirm_msg:
                 "Sind Sie sicher, dass Sie sich ausloggen und die Session beenden möchten?",
             cancel: "Abbrechen",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            logout: "退出登录",
+            confirm_msg: "您确定要退出登录并结束会话吗？",
+            cancel: "取消",
         }
     }
 }

--- a/src/models/src/i18n/password_policy.rs
+++ b/src/models/src/i18n/password_policy.rs
@@ -39,4 +39,17 @@ impl I18nPasswordPolicy<'_> {
             not_recent: "Keins der letzten Passwörter",
         }
     }
+
+    pub(crate) fn build_zh_hans() -> Self {
+        Self {
+            password_policy: "密码要求",
+            length_min: "最小长度",
+            length_max: "最长长度",
+            lowercase_min: "最少小写字母",
+            uppercase_min: "最少大写字母",
+            digits_min: "最少数字",
+            special_min: "最少特殊字符",
+            not_recent: "不是最近使用过的密码之一",
+        }
+    }
 }

--- a/src/models/src/i18n/password_reset.rs
+++ b/src/models/src/i18n/password_reset.rs
@@ -36,6 +36,7 @@ impl SsrJson for I18nPasswordReset<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -60,8 +61,8 @@ impl I18nPasswordReset<'_> {
             new_acc_desc_1:
                 "You have the option between two account types: passwordless or traditional password",
             new_acc_desc_2: r#"The passwordless account is always preferred, because it provides
-a way stronger security. You will need at least one passkey (Yubikey, Apple Touch ID, Windows Hello,
-...) to create such an account. Your device must embreace the Fido2 standard. For more information
+a way with stronger security. You will need at least one passkey (Yubikey, Apple Touch ID, Windows Hello,
+...) to create such an account. Your device must embrace the FIDO2 standard. For more information
 about this, you may follow this link: "#,
             new_account: "New Account",
             password_reset: "Password Reset",
@@ -112,6 +113,37 @@ FIDO2 Standard gerecht wird. Für weitere Informationen können Sie diesem Link 
             success_passkey_2: r#"Bitte loggen Sie sich direkt in Ihren Account ein und registrieren
 Sie mindestens einen weiteren Backup Passkey. Ein passwortloser Account kann nicht den Passwort
 Reset via E-Mail nutzen für den Fall, dass der derzeitige Passkey abhanden kommt."#,
+        }
+    }
+
+    pub fn build_zh_hans() -> Self {
+        Self {
+            password_policy: I18nPasswordPolicy::build_zh_hans(),
+
+            account_login: "账户登录",
+            bad_format: "格式错误",
+            fido_link: "https://fidoalliance.org/fido2/?lang=zh-hans",
+            generate: "生成",
+            mfa: I18nAccountMfa::build_zh_hans(),
+            new_acc_desc_1:
+                "您可以在无密码账户和传统的密码账户之中选择其一。",
+            new_acc_desc_2: r#"无密码账户应被优先考虑，因为其提供更强的安全性。
+您需要至少一个支持FIDO2标准的通行密钥（Yubikey、Apple Touch ID或Windows Hello等）以完成账户创建。
+获取更多信息："#,
+            new_account: "新账户",
+            password_reset: "密码重置",
+            password: "密码",
+            passwordless: "FIDO通行密钥",
+            password_confirm: "密码确认",
+            password_no_match: "密码不匹配",
+            required: "必填",
+            save: "保存",
+            success_1: "密码已成功更新。",
+            success_2: "您将被重定向。",
+            success_3: "如果您未被重定向，请点击此链接：",
+            success_passkey_1: "您的通行密钥已成功注册。",
+            success_passkey_2: r#"请登入您的账户并尽快注册一个备份密钥。
+对于仅密钥登陆的账户，在丢失您当前的密钥时，您无法通过电子邮件进行密码重置。"#,
         }
     }
 }

--- a/src/models/src/i18n/register.rs
+++ b/src/models/src/i18n/register.rs
@@ -25,6 +25,7 @@ impl SsrJson for I18nRegister<'_> {
         match lang {
             Language::En => Self::build_en(),
             Language::De => Self::build_de(),
+            Language::ZhHans => Self::build_zh_hans(),
         }
     }
 
@@ -44,7 +45,7 @@ impl I18nRegister<'_> {
             email_check: "Please check your E-Mail inbox",
             family_name: "Family Name",
             given_name: "Given Name",
-            regex_name: "Name with 2 - 32 non-special characters",
+            regex_name: "Name should have 2 - 32 non-special characters",
             register: "Register",
             required: "Required",
             success: "Registration successful",
@@ -67,6 +68,24 @@ impl I18nRegister<'_> {
             required: "Notwendig",
             success: "Registrierung erfolgreich",
             user_reg: "Benutzer Registrierung",
+        }
+    }
+
+    fn build_zh_hans() -> Self {
+        Self {
+            domain_allowed: "允许的域名：",
+            domain_err: "此电子邮件域名不被允许",
+            domain_restricted: "电子邮件域名被限制",
+            email: "电子邮件",
+            email_bad_format: "错误的电子邮件地址格式",
+            email_check: "请检查您的电子邮件收件箱",
+            family_name: "姓氏",
+            given_name: "名字",
+            regex_name: "名字应有2-32个非特殊字符。",
+            register: "注册",
+            required: "必填",
+            success: "注册成功",
+            user_reg: "用户注册",
         }
     }
 }

--- a/src/models/src/language.rs
+++ b/src/models/src/language.rs
@@ -15,17 +15,19 @@ use tracing::debug;
 pub enum Language {
     En,
     De,
+    ZhHans,
 }
 
 impl Language {
-    fn all_available<'a>() -> [&'a str; 4] {
-        ["en", "en-US", "de", "de-DE"]
+    fn all_available<'a>() -> [&'a str; 6] {
+        ["en", "en-US", "de", "de-DE", "zh", "zh-Hans"]
     }
 
     pub fn as_str(&self) -> &str {
         match self {
             Language::En => "en",
             Language::De => "de",
+            Language::ZhHans => "zh-Hans",
         }
     }
 }
@@ -59,6 +61,7 @@ impl From<&str> for Language {
         match value {
             "de" | "de-DE" => Self::De,
             "en" | "en-US" => Self::En,
+            "zh" | "zh-hans" | "zh-Hans" => Self::ZhHans,
             _ => Self::default(),
         }
     }
@@ -97,6 +100,7 @@ impl From<rauthy_api_types::generic::Language> for Language {
         match value {
             rauthy_api_types::generic::Language::En => Self::En,
             rauthy_api_types::generic::Language::De => Self::De,
+            rauthy_api_types::generic::Language::ZhHans => Self::ZhHans,
         }
     }
 }
@@ -106,6 +110,7 @@ impl From<Language> for rauthy_api_types::generic::Language {
         match value {
             Language::En => Self::En,
             Language::De => Self::De,
+            Language::ZhHans => Self::ZhHans,
         }
     }
 }


### PR DESCRIPTION
This PR adds Simplified Chinese (zh-Hans) translations, and updates some English strings.

The next step is to let CJK characters not regarded as special character and add an option to make family name optional (Mongolian people does not have family names, and also some people may not want to use their real name).