### PR TITLE
Allow more CJK characters to appear in user name

### DIFF
--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -18,11 +18,23 @@ export const REGEX_PHONE = /^\+[0-9\s]{0,32}$/gm;
 export const REGEX_STREET = /^[a-zA-Z0-9À-ÿ-.\s]{0,48}$/gm;
 export const REGEX_CITY = /^[a-zA-Z0-9À-ÿ-]{0,48}$/gm;
 export const REGEX_API_KEY = /^[a-zA-Z0-9_/-]{2,24}$/gm;
-export const REGEX_NAME = /^[\w\sÀ-ÿ\-]{1,32}$/gm;
+// This regex includes:
+//   ASCII alphabet, numeric characters
+//   single white space characters
+//   hyphen-minus '-'
+//   Unicode BMP:
+//     - some letters in Latin-1 Supplement
+//     - all of Katakana, CJK Unified Ideographs, CJK Unified Ideographs Ext A,
+//         CJK Radicals Supplement, Katakana Phonetic Extensions
+//     - most of Hiragana, CJK Compatibility Ideographs, 
+//         Kangxi Radicals
+//     - a part of Halfwidth and Fullwidth Forms
+//   Unicode SMP and SIP planes are not included due to JavaScript regex limitations
+export const REGEX_NAME = /^[\w\sÀ-ÿ\-\u3041-\u3096\u30A0-\u30FF\u3400-\u4DB5\u4E00-\u9FCB\uF900-\uFA6A\u2E80-\u2FD5\uFF66-\uFF9F\uFFA1-\uFFDC\u31F0-\u31FF]{1,32}$/gm;
 export const REGEX_ATTR_DESC = /^[a-zA-Z0-9\-_/\s]{0,128}$/gm;
 export const REGEX_ATTR_KEY = /^[a-zA-Z0-9\-_/]{2,32}$/gm;
 export const REGEX_CLIENT_ID = /^[a-zA-Z0-9\-_/]{2,128}$/gm;
-export const REGEX_CLIENT_NAME = /^[a-zA-Z0-9À-ÿ\-\s]{0,128}$/m;
+export const REGEX_CLIENT_NAME = /^[a-zA-Z0-9À-ÿ\-\s\u3041-\u3096\u30A0-\u30FF\u3400-\u4DB5\u4E00-\u9FCB\uF900-\uFA6A\u2E80-\u2FD5\uFF66-\uFF9F\uFFA1-\uFFDC\u31F0-\u31FF]{0,128}$/m;
 export const REGEX_CONTACT = /^[a-zA-Z0-9+.@/:]{0,48}$/gm;
 export const REGEX_LOWERCASE_SPACE = /^[a-z0-9-_\/\s]{2,128}$/gm;
 export const REGEX_PROVIDER_SCOPE = /^[a-z0-9-_\/:\s]{0,128}$/gm;

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -117,7 +117,7 @@ lazy_static! {
     pub static ref RE_CHALLENGE: Regex = Regex::new(r"^(plain|S256)$").unwrap();
     pub static ref RE_CITY: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-]{0,48}$").unwrap();
     pub static ref RE_CLIENT_ID_EPHEMERAL: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$").unwrap();
-    pub static ref RE_CLIENT_NAME: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-\s]{2,128}$").unwrap();
+    pub static ref RE_CLIENT_NAME: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{2,128}$").unwrap();
     pub static ref RE_CODE_CHALLENGE: Regex = Regex::new(r"^[a-zA-Z0-9-\._~]{43,128}$").unwrap();
     pub static ref RE_CODE_VERIFIER: Regex = Regex::new(r"^[a-zA-Z0-9-\._~+/=]+$").unwrap();
     pub static ref RE_CONTACT: Regex = Regex::new(r"^[a-zA-Z0-9\+.@/:]{0,48}$").unwrap();
@@ -137,7 +137,7 @@ lazy_static! {
     pub static ref RE_SEARCH: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%@]+$").unwrap();
     pub static ref RE_STREET: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-.\s]{0,48}$").unwrap();
     pub static ref RE_URI: Regex = Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]+$").unwrap();
-    pub static ref RE_USER_NAME: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-\s]{1,32}$").unwrap();
+    pub static ref RE_USER_NAME: Regex = Regex::new(r"^[a-zA-Z0-9À-ÿ-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{1,32}$").unwrap();
     pub static ref RE_TOKEN_68: Regex = Regex::new(r"^[a-zA-Z0-9-._~+/]+=*$").unwrap();
     pub static ref RE_TOKEN_ENDPOINT_AUTH_METHOD: Regex = Regex::new(r"^(client_secret_post|client_secret_basic|none)$").unwrap();
 


### PR DESCRIPTION
This PR adds more code-blocks in Unicode Basic Multilingual Plane (BMP) to allow CJK characters.

This should include most of the common characters in names of who lives in East Asia.
Some symbols that should never appear in people's names are excluded.