### PR TITLE
Support listening on UNIX domain sockets

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [Forward Authentication](config/forward_auth.md)
     - [Bootstrapping](config/bootstrap.md)
     - [Database Migrations](config/db_migration.md)
+    - [UNIX Doamin Sockets](config/unix_socket.md)
 
 - [Authentication Providers](auth_providers/index.md)
     - [Github](./auth_providers/github.md)

--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -954,7 +954,8 @@ POW_EXP=30
 #LISTEN_PORT_HTTPS=8443
 
 # The scheme to use locally, valid values:
-# http | https | http_https (default: http_https)
+# http | https | http_https | unix_http | unix_https (default: http_https)
+# For more details about the UNIX domain socket, check out its documentation page.
 LISTEN_SCHEME=http
 
 # The Public URL of the whole deployment

--- a/book/src/config/unix_socket.md
+++ b/book/src/config/unix_socket.md
@@ -16,6 +16,6 @@ Note that `unix_https` does not make a socket with TLS. When `unix_https` is use
 
 UNIX domain sockets should be used with a reverse proxy. Without such a proxy, Rauthy could not know the IP address of visitors, and it will see all visitors as 192.0.0.8, the IPv4 dummy address. Rate-limits and IP blacklists will apply on all visitors at the same time.
 
-After setting up a reverse proxy, please also remember to set your proxy to send peer IP in headers (for example, `X-Forwarded-For`), and set `PROXY_MODE` to let Rauthy read the IP.
+After setting up a reverse proxy, please also remember to set your proxy to send peer IP in headers (for example, `X-Forwarded-For`), and set `PROXY_MODE` to let Rauthy read the IP. Once everything is set, check the `/auth/v1/whoami` endpoint to see if your IP address is shown correctly.
 
 It is also recommended to use POSIX ACLs to limit access to Rauthy socket to your reverse proxy, so other UNIX users won't be able to connect to the socket directly and bypass the reverse proxy.

--- a/book/src/config/unix_socket.md
+++ b/book/src/config/unix_socket.md
@@ -1,0 +1,21 @@
+# UNIX Doamin Sockets
+
+Rauthy supports listening on a UNIX domain socket. To enable this feature, you will need to specify the following configurations.
+
+```
+LISTEN_SCHEME=unix_http/unix_https
+LISTEN_ADDRESS=path_to_server.sock
+PROXY_MODE=true
+```
+
+```admonish caution
+Note that `unix_https` does not make a socket with TLS. When `unix_https` is used, the socket will still be plain HTTP!
+
+`unix_https` specifies the scheme to be prepended to `PUB_URL`, so whether to use`unix_http` and `unix_https` depends on the scheme you are using on the reverse-proxy.
+```
+
+UNIX domain sockets should be used with a reverse proxy. Without such a proxy, Rauthy could not know the IP address of visitors, and it will see all visitors as 192.0.0.8, the IPv4 dummy address. Rate-limits and IP blacklists will apply on all visitors at the same time.
+
+After setting up a reverse proxy, please also remember to set your proxy to send peer IP in headers (for example, `X-Forwarded-For`), and set `PROXY_MODE` to let Rauthy read the IP.
+
+It is also recommended to use POSIX ACLs to limit access to Rauthy socket to your reverse proxy, so other UNIX users won't be able to connect to the socket directly and bypass the reverse proxy.

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ default:
 
 _run +args:
     @{{docker}} run --rm -it \
-      -v $HOME/.cargo/registry:{{container_cargo_registry}} \
+      -v $CARGO_HOME/registry:{{container_cargo_registry}} \
       -v {{invocation_directory()}}/:/work/ \
       {{map_docker_user}} \
       -e DATABASE_URL={{db_url_sqlite}} \
@@ -43,7 +43,7 @@ _run +args:
 
 _run-pg +args:
     @{{docker}} run --rm -it \
-      -v $HOME/.cargo/registry:{{container_cargo_registry}} \
+      -v $CARGO_HOME/registry:{{container_cargo_registry}} \
       -v {{invocation_directory()}}/:/work/ \
       {{map_docker_user}} \
       -e DATABASE_URL={{db_url_postgres}} \
@@ -53,7 +53,7 @@ _run-pg +args:
 
 _run-ui +args:
     @{{docker}} run --rm -it \
-      -v $HOME/.cargo/registry:{{container_cargo_registry}} \
+      -v $CARGO_HOME/registry:{{container_cargo_registry}} \
       -v {{invocation_directory()}}/:/work/ \
       -e npm_config_cache=/work/.npm_cache \
       {{map_docker_user}} \
@@ -64,7 +64,7 @@ _run-ui +args:
 
 _run-bg +args:
     @{{docker}} run --rm -d \
-      -v $HOME/.cargo/registry:{{container_cargo_registry}} \
+      -v $CARGO_HOME/registry:{{container_cargo_registry}} \
       -v {{invocation_directory()}}/:/work/ \
       {{map_docker_user}} \
       -e DATABASE_URL={{db_url_sqlite}} \
@@ -74,7 +74,7 @@ _run-bg +args:
 
 _run-bg-pg +args:
     @{{docker}} run --rm -d \
-      -v $HOME/.cargo/registry:{{container_cargo_registry}} \
+      -v $CARGO_HOME/registry:{{container_cargo_registry}} \
       -v {{invocation_directory()}}/:/work/ \
       {{map_docker_user}} \
       -e DATABASE_URL={{db_url_postgres}} \
@@ -270,7 +270,7 @@ test-backend: test-backend-stop migrate prepare
 
     just _run cargo build
     {{docker}} run --rm -it \
-      -v $HOME/.cargo/registry:{{container_cargo_registry}} \
+      -v $CARGO_HOME/registry:{{container_cargo_registry}} \
       -v {{invocation_directory()}}/:/work/ \
       {{map_docker_user}} \
       -e DATABASE_URL={{db_url_sqlite}} \

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -950,8 +950,9 @@ LISTEN_PORT_HTTP=8080
 # default: 8443
 LISTEN_PORT_HTTPS=8443
 
-# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https (default: http_https)
+# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https
 # For more details about the UNIX domain socket, check out its documentation page.
+# default: http_https
 LISTEN_SCHEME=http_https
 
 # The Public URL of the whole deployment

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -941,6 +941,7 @@ POW_EXP=30
 #####################################
 
 # The server address to listen on. Can bind to a specific IP. (default: 0.0.0.0)
+# When LISTEN_SCHEME is set to use UNIX sockets, this specifies the path to listen on.
 LISTEN_ADDRESS=0.0.0.0
 
 # The listen ports for HTTP / HTTPS, depending on the activated 'LISTEN_SCHEME'
@@ -949,8 +950,9 @@ LISTEN_PORT_HTTP=8080
 # default: 8443
 LISTEN_PORT_HTTPS=8443
 
-# The scheme to use locally, valid values: http | https | http_https (default: http_https)
-#LISTEN_SCHEME=http_https
+# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https (default: http_https)
+# For more details about the UNIX domain socket, check out its documentation page.
+LISTEN_SCHEME=http_https
 
 # The Public URL of the whole deployment
 # The LISTEN_SCHEME + PUB_URL must match the HTTP ORIGIN HEADER later on, which is especially important when running

--- a/rauthy.deploy.cfg
+++ b/rauthy.deploy.cfg
@@ -192,7 +192,8 @@ ADMIN_FORCE_MFA=false
 # default: 8443
 #LISTEN_PORT_HTTPS=8443
 
-# The scheme to use locally, valid values: http | https | http_https (default: http_https)
+# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https (default: http_https)
+# For more details about the UNIX domain socket, check out its documentation page.
 LISTEN_SCHEME=http
 
 # The Public URL of the whole deployment

--- a/rauthy.deploy.cfg
+++ b/rauthy.deploy.cfg
@@ -192,8 +192,9 @@ ADMIN_FORCE_MFA=false
 # default: 8443
 #LISTEN_PORT_HTTPS=8443
 
-# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https (default: http_https)
+# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https
 # For more details about the UNIX domain socket, check out its documentation page.
+# default: http_https
 LISTEN_SCHEME=http
 
 # The Public URL of the whole deployment

--- a/rauthy.test.cfg
+++ b/rauthy.test.cfg
@@ -38,7 +38,8 @@ LISTEN_PORT_HTTP=8081
 # default: 8443
 LISTEN_PORT_HTTPS=8444
 
-# The scheme to use locally, valid values: http | https | http_https (default: http_https)
+# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https (default: http_https)
+# For more details about the UNIX domain socket, check out its documentation page.
 LISTEN_SCHEME=http
 
 # The hostname used for host guard headers. If the HTTP 'Host' header does not match this, rauthy will reject

--- a/rauthy.test.cfg
+++ b/rauthy.test.cfg
@@ -38,8 +38,9 @@ LISTEN_PORT_HTTP=8081
 # default: 8443
 LISTEN_PORT_HTTPS=8444
 
-# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https (default: http_https)
+# The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https
 # For more details about the UNIX domain socket, check out its documentation page.
+# default: http_https
 LISTEN_SCHEME=http
 
 # The hostname used for host guard headers. If the HTTP 'Host' header does not match this, rauthy will reject

--- a/src/api/src/openapi.rs
+++ b/src/api/src/openapi.rs
@@ -315,7 +315,9 @@ impl ApiDoc {
         // contact.email = Some(ADMIN);
         // doc.info.contact = Some(contact);
 
-        let scheme = if !*PROXY_MODE && app_state.listen_scheme == ListenScheme::Http {
+        let scheme = if (!*PROXY_MODE && app_state.listen_scheme == ListenScheme::Http)
+            || app_state.listen_scheme == ListenScheme::UnixHttp
+        {
             "http://"
         } else {
             "https://"

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -18,6 +18,7 @@ use rauthy_common::constants::{
     SWAGGER_UI_INTERNAL, UPSTREAM_AUTH_CALLBACK_TIMEOUT_SECS, WEBAUTHN_DATA_EXP, WEBAUTHN_REQ_EXP,
 };
 use rauthy_common::password_hasher;
+use rauthy_common::utils::UseDummyAddress;
 use rauthy_handlers::openapi::ApiDoc;
 use rauthy_handlers::{
     api_keys, auth_providers, blacklist, clients, events, fed_cm, generic, groups, oidc, roles,
@@ -643,6 +644,10 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
 
         if *SWAGGER_UI_EXTERNAL {
             app = app.service(swagger.clone());
+        }
+
+        if matches!(app_state.listen_scheme, ListenScheme::UnixHttp | ListenScheme::UnixHttps) {
+            app = app.app_data(UseDummyAddress);
         }
 
         app

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -679,6 +679,10 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                 .run()
                 .await
         }
+
+        ListenScheme::UnixHttp | ListenScheme::UnixHttps => {
+            server.bind_uds(listen_addr)?.run().await
+        }
     }
 }
 

--- a/src/bin/tests/common.rs
+++ b/src/bin/tests/common.rs
@@ -55,6 +55,8 @@ pub fn get_backend_url() -> String {
         .to_lowercase()
     {
         x if x == "https" || x == "http" || x == "http_https" => x,
+        x if x == "unix_http" => "http".to_string(),
+        x if x == "unix_https" => "https".to_string(),
         _ => panic!("Bad 'LISTEN_SCHEME'"),
     };
     let host = env::var("PUB_URL").expect("PUB_URL env var is not set");

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -202,7 +202,9 @@ lazy_static! {
 
     pub static ref PUB_URL: String = env::var("PUB_URL").expect("PUB_URL env var is not set");
     pub static ref PUB_URL_WITH_SCHEME: String = {
-        let scheme = if env::var("LISTEN_SCHEME").as_deref() == Ok("http") && !*PROXY_MODE {
+        let listen_scheme = env::var("LISTEN_SCHEME");
+        let scheme = if (listen_scheme.as_deref() == Ok("http") && !*PROXY_MODE)
+            || listen_scheme.as_deref() == Ok("unix_http") {
             "http"
         } else {
             "https"
@@ -211,7 +213,9 @@ lazy_static! {
     };
 
     pub static ref PROVIDER_CALLBACK_URI: String = {
-        let scheme = if env::var("LISTEN_SCHEME").as_deref() == Ok("http") && !*PROXY_MODE {
+        let listen_scheme = env::var("LISTEN_SCHEME");
+        let scheme = if (listen_scheme.as_deref() == Ok("http") && !*PROXY_MODE)
+            || listen_scheme.as_deref() == Ok("unix_http") {
             "http"
         } else {
             "https"

--- a/src/models/src/app_state.rs
+++ b/src/models/src/app_state.rs
@@ -91,11 +91,11 @@ impl AppState {
                 ListenScheme::HttpHttps
             }
             "unix_http" => {
-                info!("Listen URL: unix+http://{}", listen_addr);
+                info!("Listen URL: unix+http:{}", listen_addr);
                 ListenScheme::UnixHttp
             }
             "unix_https" => {
-                info!("Listen URL: unix+https://{}", listen_addr);
+                info!("Listen URL: unix+https:{}", listen_addr);
                 ListenScheme::UnixHttps
             }
             _ => panic!(

--- a/src/models/src/app_state.rs
+++ b/src/models/src/app_state.rs
@@ -68,30 +68,40 @@ impl AppState {
 
         // server listen address
         let listen_addr = env::var("LISTEN_ADDRESS").unwrap_or_else(|_| String::from("0.0.0.0"));
-        let (listen_scheme, port) = match env::var("LISTEN_SCHEME")
+        let listen_scheme = match env::var("LISTEN_SCHEME")
             .unwrap_or_else(|_| String::from("http_https"))
             .as_str()
         {
             "http" => {
                 let port = env::var("LISTEN_PORT_HTTP").unwrap_or_else(|_| "8080".to_string());
-                (ListenScheme::Http, port)
+                info!("Listen URL: http://{}:{}", listen_addr, port);
+                ListenScheme::Http
             }
             "https" => {
                 let port = env::var("LISTEN_PORT_HTTPS").unwrap_or_else(|_| "8443".to_string());
-                (ListenScheme::Https, port)
+                info!("Listen URL: https://{}:{}", listen_addr, port);
+                ListenScheme::Https
             }
             "http_https" => {
                 let port_http = env::var("LISTEN_PORT_HTTP").unwrap_or_else(|_| "8080".to_string());
                 let port_https =
                     env::var("LISTEN_PORT_HTTPS").unwrap_or_else(|_| "8443".to_string());
                 let port = format!("{{{}|{}}}", port_http, port_https);
-                (ListenScheme::HttpHttps, port)
+                info!("Listen URL: {{http|https}}://{}:{}", listen_addr, port);
+                ListenScheme::HttpHttps
+            }
+            "unix_http" => {
+                info!("Listen URL: unix+http://{}", listen_addr);
+                ListenScheme::UnixHttp
+            }
+            "unix_https" => {
+                info!("Listen URL: unix+https://{}", listen_addr);
+                ListenScheme::UnixHttps
             }
             _ => panic!(
                 "'LISTEN_SCHEME' environment variable not correctly set (http | https | http_https)"
             ),
         };
-        info!("Listen URL: {}://{}:{}", listen_scheme, listen_addr, port);
 
         // public url
         let public_url = env::var("PUB_URL").expect("PUB_URL env var is not set");
@@ -125,7 +135,7 @@ impl AppState {
 
         let issuer_scheme = if matches!(
             listen_scheme,
-            ListenScheme::HttpHttps | ListenScheme::Https
+            ListenScheme::HttpHttps | ListenScheme::Https | ListenScheme::UnixHttps
         ) || *PROXY_MODE
         {
             "https"

--- a/src/models/src/entity/clients.rs
+++ b/src/models/src/entity/clients.rs
@@ -1176,6 +1176,8 @@ pub fn is_origin_external<'a>(
             ListenScheme::Http => scheme == "http",
             ListenScheme::Https => scheme == "https",
             ListenScheme::HttpHttps => scheme == "http" || scheme == "https",
+            ListenScheme::UnixHttp => scheme == "http",
+            ListenScheme::UnixHttps => scheme == "https",
         }
     };
     if !scheme_ok {

--- a/src/models/src/i18n/account.rs
+++ b/src/models/src/i18n/account.rs
@@ -186,7 +186,8 @@ account, you can unlink it from the upstream provider."#,
             web_id_desc: r#"You can configure the fields that should be exposed with your WebID.
 This is a feature used by some networks for decentralized logins. If you do not know what it is,
 you most probably do not need it."#,
-            web_id_desc_data: "You can add custom data fields to your WebID in valid FOAF Vocabulary",
+            web_id_desc_data:
+                "You can add custom data fields to your WebID in valid FOAF Vocabulary",
             web_id_expert_mode: "Enable Expert Mode",
             zip: "ZIP",
         }

--- a/src/models/src/i18n/email_reset.rs
+++ b/src/models/src/i18n/email_reset.rs
@@ -40,7 +40,8 @@ static TPL_ZH_HANS_RESET_SUBJECT: Lazy<Option<String>> =
     Lazy::new(|| env::var("TPL_ZH_HANS_RESET_SUBJECT").ok());
 static TPL_ZH_HANS_RESET_HEADER: Lazy<Option<String>> =
     Lazy::new(|| env::var("TPL_ZH_HANS_RESET_HEADER").ok());
-static TPL_ZH_HANS_RESET_TEXT: Lazy<Option<String>> = Lazy::new(|| env::var("TPL_ZH_HANS_RESET_TEXT").ok());
+static TPL_ZH_HANS_RESET_TEXT: Lazy<Option<String>> =
+    Lazy::new(|| env::var("TPL_ZH_HANS_RESET_TEXT").ok());
 static TPL_ZH_HANS_RESET_CLICK_LINK: Lazy<Option<String>> =
     Lazy::new(|| env::var("TPL_ZH_HANS_RESET_CLICK_LINK").ok());
 static TPL_ZH_HANS_RESET_VALIDITY: Lazy<Option<String>> =
@@ -137,10 +138,12 @@ impl I18nEmailReset<'_> {
             click_link: TPL_ZH_HANS_RESET_CLICK_LINK
                 .as_deref()
                 .unwrap_or("点击下方链接以打开密码重置表单。"),
-            validity: TPL_ZH_HANS_RESET_VALIDITY.as_deref().unwrap_or(
-                "出于安全考虑，此链接仅在短时间内有效。",
-            ),
-            expires: TPL_ZH_HANS_RESET_EXPIRES.as_deref().unwrap_or("链接过期时间"),
+            validity: TPL_ZH_HANS_RESET_VALIDITY
+                .as_deref()
+                .unwrap_or("出于安全考虑，此链接仅在短时间内有效。"),
+            expires: TPL_ZH_HANS_RESET_EXPIRES
+                .as_deref()
+                .unwrap_or("链接过期时间"),
             button_text: TPL_ZH_HANS_RESET_BUTTON.as_deref().unwrap_or("重置密码"),
             footer: TPL_ZH_HANS_RESET_FOOTER.as_deref(),
         }

--- a/src/models/src/i18n/error.rs
+++ b/src/models/src/i18n/error.rs
@@ -79,12 +79,8 @@ impl I18nError<'_> {
 
     fn build_zh_hans(status_code: StatusCode, details_text: Option<Cow<'static, str>>) -> Self {
         let error_text = match status_code {
-            StatusCode::BAD_REQUEST => {
-                "您的请求异常，请参见详情。"
-            }
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                "拒绝访问——您未被允许访问此资源。"
-            }
+            StatusCode::BAD_REQUEST => "您的请求异常，请参见详情。",
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => "拒绝访问——您未被允许访问此资源。",
             StatusCode::INTERNAL_SERVER_ERROR => "内部服务器错误",
             _ => "找不到请求的资源",
         };

--- a/src/models/src/i18n/password_reset.rs
+++ b/src/models/src/i18n/password_reset.rs
@@ -125,8 +125,7 @@ Reset via E-Mail nutzen für den Fall, dass der derzeitige Passkey abhanden komm
             fido_link: "https://fidoalliance.org/fido2/?lang=zh-hans",
             generate: "生成",
             mfa: I18nAccountMfa::build_zh_hans(),
-            new_acc_desc_1:
-                "您可以在无密码账户和传统的密码账户之中选择其一。",
+            new_acc_desc_1: "您可以在无密码账户和传统的密码账户之中选择其一。",
             new_acc_desc_2: r#"无密码账户应被优先考虑，因为其提供更强的安全性。
 您需要至少一个支持FIDO2标准的通行密钥（Yubikey、Apple Touch ID或Windows Hello等）以完成账户创建。
 获取更多信息："#,

--- a/src/models/src/lib.rs
+++ b/src/models/src/lib.rs
@@ -59,6 +59,8 @@ pub enum ListenScheme {
     Http,
     Https,
     HttpHttps,
+    UnixHttp,
+    UnixHttps,
 }
 
 impl Display for ListenScheme {
@@ -67,6 +69,8 @@ impl Display for ListenScheme {
             ListenScheme::Http => write!(f, "http"),
             ListenScheme::Https => write!(f, "https"),
             ListenScheme::HttpHttps => write!(f, "{{http|https}}"),
+            ListenScheme::UnixHttp => write!(f, "unix+http"),
+            ListenScheme::UnixHttps => write!(f, "unix+https"),
         }
     }
 }


### PR DESCRIPTION
This PR adds two `LISTEN_SCHEME` types: `unix_http`, `unix_https`.

They both create a UNIX socket of HTTP. The `http` and `https` are used to clarify the scheme to use for `PUB_URL`.

## Testing

To test the UDS support, please use the following configuration:

```
LISTEN_SCHEME=unix_http
LISTEN_ADDRESS=server.sock
PEER_IP_HEADER_NAME=X-Forwarded-For
PUB_URL=localhost:8080
```

and start a reverse proxy, to turn UDS into TCP, for example, with caddy: `caddy reverse-proxy --from :8080 --to unix/server.sock`, or with socat: `socat UNIX-CLIENT:server.sock TCP-LISTEN:8080`.

Caddy is a real reverse proxy and it sends `X-Forwarded-For` header. socat is just a socket forwarder, so it does not send `X-Forwarded-For`. To use socat, `PEER_IP_HEADER_NAME` should be unset, and all users will be regarded as 192.0.0.8.

## Security

When reverse proxy is configured, visitor IP will be read from `PEER_IP_HEADER_NAME`. The IP of proxy cannot be retrieved so a IPv4 dummy address (192.0.0.8) is assumed. This IP is always regarded as a trust proxy.

When reverse proxy is not configured, it is not recommended. I personally strongly oppose such a usage, unless all users are trusted. In such a setting, all users will be seen as 192.0.0.8, and rate-limiting and IP blacklisting will treat all users as the same person.

If there are multiple users or services running on the same server, it is also recommended to use POSIX ACLs to limit access to Rauthy UDS to the reverse proxy, so other users/compromised services won't be able to bypass the reverse proxy.

The 192.0.0.8 is defined as IPv4 dummy address by [RFC7600](https://www.iana.org/go/rfc7600), this assignment has been acknowledged by IANA. 
192.0.0.8 is in the 192.0.0.0/24 range, and basically all ISPs rejects routes to these addresses. Therefore, nobody can connect to servers with 192.0.0.8 as their source address. If one can, it is a larger security issue (if someone is accepting RPKI-invalid routes, their neighbors can even announce more special-purpose IP addresses and bypass all rate-limiting and IP blacklisting)