### PR TITLE
Make code_challenge_methods_supported optional

### DIFF
--- a/src/models/src/entity/auth_providers.rs
+++ b/src/models/src/entity/auth_providers.rs
@@ -131,6 +131,7 @@ pub struct WellKnownLookup {
     pub userinfo_endpoint: String,
     pub jwks_uri: String,
     pub scopes_supported: Vec<String>,
+    #[serde(default)]
     pub code_challenge_methods_supported: Vec<String>,
 }
 


### PR DESCRIPTION
Per RFC 8414 section 2, `code_challenge_methods_supported` is optional. It is missing in many OpenID servers.