### PR TITLE
Missing `/providers/{id}/link` doc

### DIFF
--- a/src/api/src/auth_providers.rs
+++ b/src/api/src/auth_providers.rs
@@ -238,7 +238,7 @@ pub async fn delete_provider_link(
     path = "/providers/minimal",
     tag = "providers",
     responses(
-        (status = 200, description = "OK", body = ProviderResponse),
+        (status = 200, description = "OK"),
     ),
 )]
 #[get("/providers/minimal")]
@@ -340,12 +340,7 @@ pub async fn get_provider_delete_safe(
     }
 }
 
-/// PUT upload an image / icon for an auth provider
-///
-/// The image can only be max 10MB in size and will be minified automatically.
-///
-/// **Permissions**
-/// - `rauthy_admin`
+/// GET the uploaded image an auth provider
 #[utoipa::path(
     get,
     path = "/providers/{id}/img",

--- a/src/api/src/openapi.rs
+++ b/src/api/src/openapi.rs
@@ -31,6 +31,7 @@ use utoipa::{openapi, OpenApi};
         auth_providers::post_provider_lookup,
         auth_providers::post_provider_login,
         auth_providers::post_provider_callback,
+        auth_providers::post_provider_link,
         auth_providers::delete_provider_link,
         auth_providers::get_providers_minimal,
         auth_providers::put_provider,


### PR DESCRIPTION
fixes #569