### PR TITLE
fix the ingress name

### DIFF
--- a/book/src/getting_started/k8s.md
+++ b/book/src/getting_started/k8s.md
@@ -477,7 +477,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
-  name: rauthy-https
+  name: rauthy-http
   namespace: rauthy
 spec:
   entryPoints:


### PR DESCRIPTION
The same name for HTTP and HTTPS routes causes them to overwrite each other.