### PR TITLE
fix: set correct recipient name in email notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,6 +2398,7 @@ dependencies = [
 [[package]]
 name = "hiqlite"
 version = "0.2.1"
+source = "git+https://github.com/sebadob/hiqlite.git#175fcd53da9d27aab05435633c8095ba0e3b6eb3"
 dependencies = [
  "argon2",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ strip = true
 panic = "abort"
 
 [patch.crates-io]
-#hiqlite = { git = "https://github.com/sebadob/hiqlite.git", package = "hiqlite" }
-hiqlite = { path = "../hiqlite/hiqlite", package = "hiqlite" }
+hiqlite = { git = "https://github.com/sebadob/hiqlite.git", package = "hiqlite" }
+#hiqlite = { path = "../../hiqlite/hiqlite", package = "hiqlite" }
 
 [workspace.dependencies]
 accept-language = "3"

--- a/src/models/src/events/notifier.rs
+++ b/src/models/src/events/notifier.rs
@@ -77,6 +77,7 @@ impl EventNotifier {
             );
 
             let notifier = NotifierEmail {
+                notification_recipient_name: "Rauthy Admin".to_string(),
                 notification_email: email,
                 tx_email,
             };
@@ -174,6 +175,7 @@ impl EventNotifier {
 
 #[derive(Debug)]
 struct NotifierEmail {
+    notification_recipient_name: String,
     notification_email: String,
     tx_email: mpsc::Sender<EMail>,
 }
@@ -182,6 +184,7 @@ struct NotifierEmail {
 impl Notify for NotifierEmail {
     async fn notify(&self, notification: &Notification) -> Result<(), ErrorResponse> {
         email::send_email_notification(
+            self.notification_recipient_name.clone(),
             self.notification_email.clone(),
             &self.tx_email,
             notification,


### PR DESCRIPTION
There was a bug which made Rauthy not set the users actual name in the `to` field when sending out E-Mails, but actually the subject instead. Email sending was fine, because the address itself was correct, but the name was not.