### PR TITLE
unwrap the `Argon2Params` in `AppState`

### DIFF
--- a/src/api/src/generic.rs
+++ b/src/api/src/generic.rs
@@ -385,9 +385,9 @@ pub async fn get_login_time(
         .unwrap_or(2000);
 
     let argon2_params = Argon2ParamsResponse {
-        m_cost: data.argon2_params.params.m_cost(),
-        t_cost: data.argon2_params.params.t_cost(),
-        p_cost: data.argon2_params.params.p_cost(),
+        m_cost: data.argon2_params.m_cost(),
+        t_cost: data.argon2_params.t_cost(),
+        p_cost: data.argon2_params.p_cost(),
     };
     let resp = LoginTimeResponse {
         argon2_params,

--- a/src/models/src/app_state.rs
+++ b/src/models/src/app_state.rs
@@ -17,7 +17,7 @@ pub type DbTxn<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub public_url: String,
-    pub argon2_params: Argon2Params,
+    pub argon2_params: argon2::Params,
     pub issuer: String,
     pub listen_addr: String,
     pub listen_scheme: ListenScheme,
@@ -97,13 +97,12 @@ impl AppState {
             .unwrap_or_else(|_| String::from("8"))
             .parse::<u32>()
             .expect("Could not parse ARGON2_P_COST value");
-        let params = argon2::Params::new(argon2_m_cost, argon2_t_cost, argon2_p_cost, None)
+        let argon2_params = argon2::Params::new(argon2_m_cost, argon2_t_cost, argon2_p_cost, None)
             .expect("Unable to build Argon2id params");
         debug!(
             "Argon2id Params: m_cost: {}, t_cost: {}, p_cost: {}",
             argon2_m_cost, argon2_t_cost, argon2_p_cost
         );
-        let argon2_params = Argon2Params { params };
 
         let refresh_grace_time = env::var("REFRESH_TOKEN_GRACE_TIME")
             .unwrap_or_else(|_| String::from('5'))
@@ -248,13 +247,4 @@ impl AppState {
     //
     //     Ok(pool)
     // }
-}
-
-/// Holds the `argon2::Params` for the application.
-///
-/// This has been simplified a lot by now and it may be unwrapped and inserted into the
-/// [AppState](AppState) directly later on. Needs some refactoring though.
-#[derive(Debug, Clone)]
-pub struct Argon2Params {
-    pub params: argon2::Params,
 }

--- a/src/models/src/database.rs
+++ b/src/models/src/database.rs
@@ -168,7 +168,7 @@ impl DB {
 
         // migrate dynamic DB data
         if !*DEV_MODE {
-            init_prod::migrate_init_prod(app_state.argon2_params.params.clone(), &app_state.issuer)
+            init_prod::migrate_init_prod(app_state.argon2_params.clone(), &app_state.issuer)
                 .await?;
         }
 


### PR DESCRIPTION
This will just make the `AppState.params` a bit simpler and better to read.