### PR TITLE
add an index for `(signatures, created_at)` on the `jwks` table

### DIFF
--- a/dev_notes.md
+++ b/dev_notes.md
@@ -7,8 +7,6 @@
 ### After finished Hiqlite migration
 
 - check changed session invalidation functions
-- fix `DbType::from_str`
-- add an index (signature, created_at) to `jwks`
 
 ## Documentation TODO
 

--- a/migrations/hiqlite/1_init_schema.sql
+++ b/migrations/hiqlite/1_init_schema.sql
@@ -163,6 +163,9 @@ CREATE TABLE jwks
     jwk        BLOB    NOT NULL
 ) STRICT;
 
+CREATE INDEX jwks_signature_created_at_index
+    ON jwks (signature, created_at);
+
 CREATE TABLE roles
 (
     id   TEXT NOT NULL

--- a/migrations/postgres/26_jwks_sig_ts_index.sql
+++ b/migrations/postgres/26_jwks_sig_ts_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX jwks_signature_created_at_index
+    ON jwks (signature, created_at);


### PR DESCRIPTION
Very tiny improvement for single JWK lookup (the table with will very small all the time), but it is basically for free.