### PR TITLE
feat: disallow open redirect for `redirect_uri` with open user registration

### DIFF
--- a/dev_notes.md
+++ b/dev_notes.md
@@ -5,6 +5,7 @@
 ## Documentation TODO
 
 - breaking: only a single container from now on
+- breaking: add `USER_REG_OPEN_REDIRECT` to the book
 - `HealthResponse` response has been changed with Hiqlite -> breaking change
 - database backup config has been changed slightly
 - restore from backup has changed slightly

--- a/migrations/hiqlite/1_init_schema.sql
+++ b/migrations/hiqlite/1_init_schema.sql
@@ -79,6 +79,9 @@ CREATE TABLE clients
     contacts                  TEXT
 ) STRICT;
 
+CREATE INDEX clients_client_uri_index
+    ON clients (client_uri);
+
 CREATE TABLE client_logos
 (
     client_id    TEXT NOT NULL

--- a/migrations/postgres/27_idx_client_uris.sql
+++ b/migrations/postgres/27_idx_client_uris.sql
@@ -1,0 +1,3 @@
+CREATE INDEX clients_client_uri_index
+    ON clients (client_uri);
+

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -15,7 +15,7 @@ DEV_MODE=true
 # with SSR.
 # You only need this value, if you want to work with the auth
 # provider login while running the UI in dev mode. Point it to the
-# full address, where ever your UI is running.
+#full address, where ever your UI is running.
 # This will only be respected when `DEV_MODE == true` as well.
 #DEV_MODE_PROVIDER_CALLBACK_URL="localhost:5173"
 
@@ -69,6 +69,23 @@ USERINFO_STRICT=true
 #example.com
 #evil.net
 #"
+
+# If set to `true`, any validation of the `redirect_uri` provided during
+# a user registration will be disabled.
+# Clients can use this feature to redirect the user back to their application
+# after a successful registration, so instead of ending up in the user
+# dashboard, they come back to the client app that initiated the registration.
+#
+# The given `redirect_uri` will be compared against all registered
+# `client_uri`s and will be silently removed, if there is no match. However,
+# this check will prevent ephemeral clients from using this feature. Only
+# if you need this feature in combination with ephemeral clients, you should
+# set this option to `true`. Otherwise it is advised to set the correct
+# Client URI in the admin UI. The `redirect_uri` will be allowed if it starts
+# with any registered `client_uri`.
+#
+# default: false
+#USER_REG_OPEN_REDIRECT=true
 
 # If set to true, a violation inside the CSRF protection middleware based
 # on Sec-* headers will block invalid requests. Usually you always want this

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -77,9 +77,9 @@ USERINFO_STRICT=true
 # dashboard, they come back to the client app that initiated the registration.
 #
 # The given `redirect_uri` will be compared against all registered
-# `client_uri`s and will be silently removed, if there is no match. However,
+# `client_uri`s and will throw an error, if there is no match. However,
 # this check will prevent ephemeral clients from using this feature. Only
-# if you need this feature in combination with ephemeral clients, you should
+# if you need it in combination with ephemeral clients, you should
 # set this option to `true`. Otherwise it is advised to set the correct
 # Client URI in the admin UI. The `redirect_uri` will be allowed if it starts
 # with any registered `client_uri`.

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -389,6 +389,10 @@ lazy_static! {
             })
             .collect()
         );
+    pub static ref USER_REG_OPEN_REDIRECT: bool = env::var("USER_REG_DOMAIN_BLACKLIST")
+        .unwrap_or_else(|_| "false".to_string())
+        .parse::<bool>()
+        .expect("Cannot parse USER_REG_OPEN_REDIRECT to bool");
 
     pub static ref PEER_IP_HEADER_NAME: Option<String> = env::var("PEER_IP_HEADER_NAME").ok();
 

--- a/src/schedulers/src/passwords.rs
+++ b/src/schedulers/src/passwords.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error};
 pub async fn password_expiry_checker(data: web::Data<AppState>) {
     // sec min hour day_of_month month day_of_week year
     // TODO convert to interval that runs multiple times a day + keep track of sent warnings?
+    // -> would require persisting sent emails and other things though
     let schedule = cron::Schedule::from_str("0 30 4 * * * *").unwrap();
 
     loop {
@@ -57,7 +58,6 @@ pub async fn password_expiry_checker(data: web::Data<AppState>) {
         };
 
         match expiring_users {
-            // match User::find_all().await {
             Ok(users_to_notify) => {
                 for user in users_to_notify {
                     send_pwd_reset_info(&data, &user).await;


### PR DESCRIPTION
Follow-up for [#318](https://github.com/sebadob/rauthy/issues/318#issuecomment-2469259813)

A new config var will make it possible to restirect the possibilities of the `redirect_uri` param for the open user registration:

```
# If set to `true`, any validation of the `redirect_uri` provided during
# a user registration will be disabled.
# Clients can use this feature to redirect the user back to their application
# after a successful registration, so instead of ending up in the user
# dashboard, they come back to the client app that initiated the registration.
#
# The given `redirect_uri` will be compared against all registered
# `client_uri`s and will throw an error, if there is no match. However,
# this check will prevent ephemeral clients from using this feature. Only
# if you need it in combination with ephemeral clients, you should
# set this option to `true`. Otherwise it is advised to set the correct
# Client URI in the admin UI. The `redirect_uri` will be allowed if it starts
# with any registered `client_uri`.
#
# default: false
#USER_REG_OPEN_REDIRECT=true
```