### PR TITLE
feat: sanitize SVGs even though only admins can upload them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,6 +1719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "data-url"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
+
+[[package]]
 name = "date_header"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,6 +4225,7 @@ dependencies = [
  "serde_json_path",
  "spow",
  "sqlx",
+ "svg-hush",
  "time",
  "tokio",
  "tokio-test",
@@ -4339,6 +4346,7 @@ dependencies = [
  "spow",
  "sqlx",
  "strum",
+ "svg-hush",
  "time",
  "tokio",
  "tokio-test",
@@ -5804,6 +5812,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "svg-hush"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f755b9992346207ee132274476f9803953c3a9ba287b8cc899aa9aa200c2f4d"
+dependencies = [
+ "base64 0.13.1",
+ "data-url",
+ "once_cell",
+ "quick-error",
+ "url",
+ "xml-rs",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7031,6 +7053,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ serde_with = { version = "3.8.1", features = ["macros"] }
 spow = { version = "0.4", features = ["server"] }
 sqlx = { version = "0.8.2", features = ["macros", "migrate", "postgres", "runtime-tokio", "sqlite", "tls-rustls", "uuid"] }
 strum = { version = "0.26.3", features = ["derive"] }
+svg-hush = "0.9.4"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing", "serde"] }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "tracing"] }

--- a/src/error/Cargo.toml
+++ b/src/error/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { workspace = true }
 serde_json_path = { workspace = true }
 spow = { workspace = true }
 sqlx = { workspace = true }
+svg-hush = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }

--- a/src/error/src/error_impls.rs
+++ b/src/error/src/error_impls.rs
@@ -16,6 +16,7 @@ use serde_json_path::ParseError;
 use spow::pow::PowError;
 use std::borrow::Cow;
 use std::string::FromUtf8Error;
+use svg_hush::FError;
 use time::OffsetDateTime;
 use tracing::{debug, error, trace};
 
@@ -470,6 +471,16 @@ impl From<ruma::client::Error<reqwest::Error, ruma::api::client::Error>> for Err
         ErrorResponse::new(
             ErrorResponseType::Connection,
             format!("matrix error: {:?}", value),
+        )
+    }
+}
+
+impl From<svg_hush::FError> for ErrorResponse {
+    fn from(value: FError) -> Self {
+        trace!("{:?}", value);
+        ErrorResponse::new(
+            ErrorResponseType::BadRequest,
+            format!("svg sanitization error: {:?}", value),
         )
     }
 }

--- a/src/models/Cargo.toml
+++ b/src/models/Cargo.toml
@@ -69,6 +69,7 @@ serde_json_path = { workspace = true }
 serde_with = { workspace = true }
 spow = { workspace = true }
 sqlx = { workspace = true }
+svg-hush = { workspace = true }
 strum = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }

--- a/src/models/src/entity/auth_providers.rs
+++ b/src/models/src/entity/auth_providers.rs
@@ -1077,8 +1077,6 @@ impl AuthProviderCallback {
 pub struct AuthProviderTemplate {
     pub id: String,
     pub name: String,
-    // pub logo: Option<Vec<u8>>,
-    // pub logo_type: Option<String>,
 }
 
 impl AuthProviderTemplate {


### PR DESCRIPTION
Even though only the `rauthy_admin` role can upload SVG images for clients or upstream IdPs, they will from now on be sanitized as an additional defense in depth.