### PR TITLE
fix: build new nightly with increased cache shutdown timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -918,7 +918,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.17",
@@ -1208,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "byteorder"
@@ -2107,7 +2107,7 @@ dependencies = [
  "bytes",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "hyper-util",
  "pin-project",
  "rand",
@@ -2385,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "hiqlite"
 version = "0.3.0-20241115"
-source = "git+https://github.com/sebadob/hiqlite.git#43c109ee2bc0335c36b787f522f19fde9948385c"
+source = "git+https://github.com/sebadob/hiqlite.git#603ff6b758bb64dc18de8891b09257822d29578e"
 dependencies = [
  "argon2",
  "axum",
@@ -2489,7 +2489,7 @@ dependencies = [
  "hex",
  "hostname",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "hyper-util",
  "lazy_static",
  "log",
@@ -2687,14 +2687,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
+ "h2 0.4.7",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -2730,7 +2730,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "hyper-util",
  "rustls 0.23.17",
  "rustls-pki-types",
@@ -2763,7 +2763,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
 
 [[package]]
 name = "jobserver"
@@ -4753,11 +4753,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.6",
+ "h2 0.4.7",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.5.1",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -6588,9 +6588,9 @@ checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -17,14 +17,14 @@
 
 ## Stage 2 - features - do before v1.0.0
 
+- "known host cookie" with connection between accounts and IPs to send out warnings in case
+  of a login on a new device
+- credential stuffing detection
 - on the long term, get rid of `actix-web-validator` as it often blocked `validator` updates already
-- events view wide -> button height 30px -> error with overflow
-- input validation in account view broken for first / last name -> backend requests 2 chars +
-- find a nice way to simply always expose the swagger UI for rauthy admins only without config
+- find a nice way to always expose the swagger UI for rauthy admins only without config
   current issue: when the session cookie is a non-host cookie with path restriction -> not working
   probably move from `/docs/v1` to `/auth/v1/docs`
 - prettify the UI
-- update the book with all the new features
 - maybe get a nicer logo
 
 ### `rauthy-client` TODO's


### PR DESCRIPTION
This will (hopefully) fix an annoying error that may come up in some situations when doing a rolling release of a Rauthy HA deployment inside K8s using Postgres.

This situation is a bit special, because the Raft cluster for the caching layer has no state persistence. This is usally no issue (and even wanted for an in-memory cache), but sometimes one node can get stuck because of race conditions.

I increased the shutdown wait delay inside Hiqlite from 5 to 10 seconds to see if this solves the issue (it should).
This is not the nicest solution, and I am working on a more robust and cleaner one, but this is very time consuming, because tests can only be done manually in real-world scenarios, not in integration tests.