### PR TITLE
fix: tiny display fix for `User.created_at` in admin ui

### DIFF
--- a/frontend/src/components/admin/users/UserInfo.svelte
+++ b/frontend/src/components/admin/users/UserInfo.svelte
@@ -357,16 +357,12 @@
             CREATED
         </div>
         <div class="value">
-            {#if user.created_at}
-                {formatDateFromTs(user.created_at)}
-            {:else}
-                Never
-            {/if}
+            {formatDateFromTs(user.created_at)}
         </div>
     </div>
 
     <!-- Last Login-->
-    <div class="unit" style:margin-top="12px">
+    <div class="unit">
         <div class="label font-label">
             LAST LOGIN
         </div>


### PR DESCRIPTION
Addition for #627

Fix the `margin-top` and remove the `if` check for `User.created_At` -> this will value will always exist.

