### PR TITLE
docs: fix typo in unix domain sockets

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,7 +20,7 @@
     - [Forward Authentication](config/forward_auth.md)
     - [Bootstrapping](config/bootstrap.md)
     - [Database Migrations](config/db_migration.md)
-    - [UNIX Doamin Sockets](config/unix_socket.md)
+    - [UNIX Domain Sockets](config/unix_socket.md)
 
 - [Authentication Providers](auth_providers/index.md)
     - [Github](./auth_providers/github.md)

--- a/docs/config/unix_socket.html
+++ b/docs/config/unix_socket.html
@@ -3,7 +3,7 @@
     <head>
         <!-- Book generated using mdBook -->
         <meta charset="UTF-8">
-        <title>UNIX Doamin Sockets - Rauthy Documentation</title>
+        <title>UNIX Domain Sockets - Rauthy Documentation</title>
 
 
         <!-- Custom HTML head -->


### PR DESCRIPTION
Fix tiny typo in "domain sockets"