### PR TITLE
feat: don't return Ok on `/ready` during the first 5 seconds

### DIFF
--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -213,7 +213,7 @@ https://github.com/sebadob/rauthy/releases/tag/v0.27.0
             warn!(
                 r#"
 
-Error looking up PasswordPolicy - this is most probably a know 0.27.0 bug.
+Error looking up PasswordPolicy - this is most probably a known 0.27.0 bug.
 Inserting default Policy to fix it.
 You should visit the Admin UI -> Config -> Password Policy and adjust it to your needs.
 


### PR DESCRIPTION
To further imrove K8s rolling releases, the `/ready` endpoint will return `HTTP 503` during the first 5 seconds after startup to give the new node enough time to join an existing raft cluster.