### PR TITLE
fix: allow nullable `family_name` for the registration form

### DIFF
--- a/frontend/src/routes/users/register/+page.svelte
+++ b/frontend/src/routes/users/register/+page.svelte
@@ -2,7 +2,7 @@
     import * as yup from "yup";
     import {extractFormErrors, getQueryParams} from "../../../utils/helpers.js";
     import Button from "$lib/Button.svelte";
-    import {REGEX_NAME} from "../../../utils/constants.js";
+    import {REGEX_NAME, REGEX_NAME_NULLABLE} from "../../../utils/constants.js";
     import {getPow, registerUser} from "../../../utils/dataFetching.js";
     import {onMount, tick} from "svelte";
     import Input from "$lib/inputs/Input.svelte";
@@ -30,7 +30,7 @@
                 .matches(REGEX_NAME, t.regexName),
             familyName: yup.string()
                 .required(t.required)
-                .matches(REGEX_NAME, t.regexName),
+                .matches(REGEX_NAME_NULLABLE, t.regexName),
         });
     }
 


### PR DESCRIPTION
Tiny bugfix that allows nullable `family_name`s for the user registration form. The `family_name` has been made optional with the `v0.27` release.