### PR TITLE
fix: client default scope cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ Even though this changes the request and response objects on the API, this chang
 a breaking change. API clients are forbidden to modify upstream IdPs for security reasons, which means this change
 should only affect the Rauthy Admin UI.
 
+### Bugfix
+
+- During the deletion of a custom scope, that has been mapped to only a clients default scopes, but not the
+  free ones, the mapping would be skipped during the whole client cleanup and end up being left-over after the
+  deletion, which needed a manual cleanup afterward.
+  [#663](https://github.com/sebadob/rauthy/pull/663)
+
 ## v0.27.2
 
 ### Changes

--- a/src/models/src/entity/clients.rs
+++ b/src/models/src/entity/clients.rs
@@ -1797,5 +1797,13 @@ mod tests {
         client.delete_scope("cust_scope");
         assert_eq!(&client.scopes, "email,openid,groups");
         assert_eq!(&client.default_scopes, "email,openid");
+
+        client.delete_scope("email");
+        assert_eq!(&client.scopes, "openid,groups");
+        assert_eq!(&client.default_scopes, "openid");
+
+        client.delete_scope("groups");
+        assert_eq!(&client.scopes, "openid");
+        assert_eq!(&client.default_scopes, "openid");
     }
 }

--- a/src/models/src/entity/clients.rs
+++ b/src/models/src/entity/clients.rs
@@ -669,51 +669,44 @@ impl Client {
 
     // TODO make a generic 'delete_from_csv' function out of this and re-use it in some other places
     pub fn delete_scope(&mut self, scope: &str) {
+        let len = scope.bytes().len();
+
         // find the scope via index in the string
         // first entry: delete scope + ',' if it exists
         // last entry: delete scope + ',' in front if it exists
         // middle: delete scope + ',' in front if it exists
         // --> 2 cases: first entry or else
-        let i_opt = self.scopes.find(scope);
-        if i_opt.is_none() {
-            return;
-        }
-
-        let i = i_opt.unwrap();
-        let len = scope.bytes().len();
-        if i == 0 {
-            // the scope is the first entry
-            if self.scopes.len() > len {
-                let s = format!("{},", scope);
-                self.scopes = self.scopes.replace(&s, "");
+        if let Some(i) = self.scopes.find(scope) {
+            if i == 0 {
+                // the scope is the first entry
+                if self.scopes.len() > len {
+                    let s = format!("{},", scope);
+                    self.scopes = self.scopes.replace(&s, "");
+                } else {
+                    self.scopes = String::default();
+                }
             } else {
-                self.scopes = String::default();
+                // the scope is at the end or in the middle
+                let s = format!(",{}", scope);
+                self.scopes = self.scopes.replace(&s, "");
             }
-        } else {
-            // the scope is at the end or in the middle
-            let s = format!(",{}", scope);
-            self.scopes = self.scopes.replace(&s, "");
         }
 
         // check if the to-be-deleted scope is in the default scopes
-        let i_opt = self.default_scopes.find(scope);
-        if i_opt.is_none() {
-            return;
-        }
-
-        let i = i_opt.unwrap();
-        if i == 0 {
-            // the scope is the first entry
-            if self.default_scopes.len() > len {
-                let s = format!("{},", scope);
-                self.default_scopes = self.default_scopes.replace(&s, "");
+        if let Some(i) = self.default_scopes.find(scope) {
+            if i == 0 {
+                // the scope is the first entry
+                if self.default_scopes.len() > len {
+                    let s = format!("{},", scope);
+                    self.default_scopes = self.default_scopes.replace(&s, "");
+                } else {
+                    self.default_scopes = String::default();
+                }
             } else {
-                self.default_scopes = String::default();
+                // the scope is at the end or in the middle
+                let s = format!(",{}", scope);
+                self.default_scopes = self.default_scopes.replace(&s, "");
             }
-        } else {
-            // the scope is at the end or in the middle
-            let s = format!(",{}", scope);
-            self.default_scopes = self.default_scopes.replace(&s, "");
         }
     }
 
@@ -1789,5 +1782,20 @@ mod tests {
                 .await
                 .expect("ephemeral client test http server to start") })
         })
+    }
+
+    #[test]
+    fn test_delete_client_custom_scope() {
+        let mut client = Client::default();
+        client.scopes = "email,openid,profile,groups".to_string();
+        client.default_scopes = "email,openid,cust_scope".to_string();
+
+        client.delete_scope("profile");
+        assert_eq!(&client.scopes, "email,openid,groups");
+        assert_eq!(&client.default_scopes, "email,openid,cust_scope");
+
+        client.delete_scope("cust_scope");
+        assert_eq!(&client.scopes, "email,openid,groups");
+        assert_eq!(&client.default_scopes, "email,openid");
     }
 }


### PR DESCRIPTION
Fixes a bug during the deletion of a custom scope.

When you had a custom scope assigned to a client, but only added it to the `default_scopes` without allowing it for `scopes` in general, this mapping would get lost during the cleanup of the client mapping, when the custom scope has been deleted without removing the mapping first.

If this happened, you had to remove the scope mapping from the client manually to fix it.

This was due to a check if the to-be-deleted scope exists at all for this client and exit early if not. However, it is possible that a scope exists in default scopes only, so that the client does not have a choice and it will always be added. This has been fixed and an extra test case for this special case has been added as well.