### PR TITLE
fix: remove non-existent just migrate call

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,6 @@ setup:
 
     echo "Starting Postgres and Mailcrab containers"
     just backend-start
-    just migrate
 
     cargo build
 


### PR DESCRIPTION
> error: Justfile does not contain recipe `migrate`

Migration is done in `backend-start` -> `postgres-start` -> `migrate-postgres`