### PR TITLE
fix: only migrate `password_policy` from table `config`

### DIFF
--- a/src/models/src/migration/db_migrate.rs
+++ b/src/models/src/migration/db_migrate.rs
@@ -32,9 +32,10 @@ pub async fn migrate_from_sqlite(db_from: sqlx::SqlitePool) -> Result<(), ErrorR
 
     // CONFIG
     debug!("Migrating table: config");
-    let before = sqlx::query_as::<_, ConfigEntity>("SELECT * FROM config")
-        .fetch_all(&db_from)
-        .await?;
+    let before =
+        sqlx::query_as::<_, ConfigEntity>("SELECT * FROM config WHERE id = 'password_policy'")
+            .fetch_all(&db_from)
+            .await?;
     inserts::config(before).await?;
 
     // API KEYS
@@ -227,9 +228,10 @@ pub async fn migrate_from_postgres(db_from: sqlx::PgPool) -> Result<(), ErrorRes
 
     // CONFIG
     debug!("Migrating table: config");
-    let before = sqlx::query_as::<_, ConfigEntity>("SELECT * FROM config")
-        .fetch_all(&db_from)
-        .await?;
+    let before =
+        sqlx::query_as::<_, ConfigEntity>("SELECT * FROM config WHERE id = 'password_policy'")
+            .fetch_all(&db_from)
+            .await?;
     inserts::config(before).await?;
 
     // API KEYS


### PR DESCRIPTION
If you are trying to migrate from an older Rauthy version (pre `cryptr`, ~1 year ago), you could run into a `MIGRATE_DB_FROM` issue because of a very old, not cleaned up temp migration value in the `config` table.

This PR adjusts the migration of the `config` table and only cares about `id = 'password_policy'`, since all other values are automatically managed with each version anyway.

This fixes #669 without manual interaction in the future.