### PR TITLE
Fix cleanup of static files in `build-ui` target

### DIFF
--- a/justfile
+++ b/justfile
@@ -290,6 +290,8 @@ build-ui:
     #!/usr/bin/env bash
     set -euxo pipefail
 
+    cd frontend
+
     # cleanup old files
     rm -rf static/v1/*
     rm -rf templates/html/*
@@ -306,7 +308,6 @@ build-ui:
     done
 
     # build the frontend
-    cd frontend
     {{ npm }} run build
     cd ..
 


### PR DESCRIPTION
The static files cleanup in the `justfile` doesn't do anything: it runs in the wrong directory.

https://github.com/sebadob/rauthy/blob/20e447c6a2dbe68689a47b8538d79b0aa0380cc1/justfile#L294

This runs in the root of the `rauthy-0.27.3` extracted files, not in the `frontend` dir.