### PR TITLE
make compilable on windows removing unixsockets if windows

### DIFF
--- a/src/api/src/openapi.rs
+++ b/src/api/src/openapi.rs
@@ -322,6 +322,15 @@ impl ApiDoc {
         // contact.email = Some(ADMIN);
         // doc.info.contact = Some(contact);
 
+        #[cfg(target_os = "windows")]
+        let scheme = if !*PROXY_MODE && app_state.listen_scheme == ListenScheme::Http
+        {
+            "http://"
+        } else {
+            "https://"
+        };
+        
+        #[cfg(not(target_os = "windows"))]
         let scheme = if (!*PROXY_MODE && app_state.listen_scheme == ListenScheme::Http)
             || app_state.listen_scheme == ListenScheme::UnixHttp
         {

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -531,6 +531,7 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
             app = app.service(swagger.clone());
         }
 
+        #[cfg(not(target_os = "windows"))]
         if matches!(
             app_state.listen_scheme,
             ListenScheme::UnixHttp | ListenScheme::UnixHttps
@@ -572,7 +573,8 @@ async fn actix_main(app_state: web::Data<AppState>) -> std::io::Result<()> {
                 .run()
                 .await
         }
-
+        
+        #[cfg(not(target_os = "windows"))]
         ListenScheme::UnixHttp | ListenScheme::UnixHttps => {
             server.bind_uds(listen_addr)?.run().await
         }

--- a/src/models/src/app_state.rs
+++ b/src/models/src/app_state.rs
@@ -67,10 +67,12 @@ impl AppState {
                 info!("Listen URL: {{http|https}}://{}:{}", listen_addr, port);
                 ListenScheme::HttpHttps
             }
+            #[cfg(not(target_os = "windows"))]
             "unix_http" => {
                 info!("Listen URL: unix+http:{}", listen_addr);
                 ListenScheme::UnixHttp
             }
+            #[cfg(not(target_os = "windows"))]
             "unix_https" => {
                 info!("Listen URL: unix+https:{}", listen_addr);
                 ListenScheme::UnixHttps
@@ -109,6 +111,18 @@ impl AppState {
             .parse::<u32>()
             .expect("Could not parse REFRESH_TOKEN_GRACE_TIME");
 
+        #[cfg(target_os = "windows")]
+        let issuer_scheme = if matches!(
+            listen_scheme,
+            ListenScheme::HttpHttps | ListenScheme::Https
+        ) || *PROXY_MODE
+        {
+            "https"
+        } else {
+            "http"
+        };
+
+        #[cfg(not(target_os = "windows"))]
         let issuer_scheme = if matches!(
             listen_scheme,
             ListenScheme::HttpHttps | ListenScheme::Https | ListenScheme::UnixHttps
@@ -118,6 +132,7 @@ impl AppState {
         } else {
             "http"
         };
+        
         let issuer = format!("{}://{}/auth/v1", issuer_scheme, public_url);
         debug!("Issuer: {}", issuer);
 

--- a/src/models/src/entity/clients.rs
+++ b/src/models/src/entity/clients.rs
@@ -1452,7 +1452,9 @@ pub fn is_origin_external<'a>(
             ListenScheme::Http => scheme == "http",
             ListenScheme::Https => scheme == "https",
             ListenScheme::HttpHttps => scheme == "http" || scheme == "https",
+            #[cfg(not(target_os = "windows"))]
             ListenScheme::UnixHttp => scheme == "http",
+            #[cfg(not(target_os = "windows"))]
             ListenScheme::UnixHttps => scheme == "https",
         } || ADDITIONAL_ALLOWED_ORIGIN_SCHEMES
             .iter()

--- a/src/models/src/lib.rs
+++ b/src/models/src/lib.rs
@@ -60,7 +60,9 @@ pub enum ListenScheme {
     Http,
     Https,
     HttpHttps,
+    #[cfg(not(target_os = "windows"))]
     UnixHttp,
+    #[cfg(not(target_os = "windows"))]
     UnixHttps,
 }
 
@@ -70,7 +72,9 @@ impl Display for ListenScheme {
             ListenScheme::Http => write!(f, "http"),
             ListenScheme::Https => write!(f, "https"),
             ListenScheme::HttpHttps => write!(f, "{{http|https}}"),
+            #[cfg(not(target_os = "windows"))]
             ListenScheme::UnixHttp => write!(f, "unix+http"),
+            #[cfg(not(target_os = "windows"))]
             ListenScheme::UnixHttps => write!(f, "unix+https"),
         }
     }


### PR DESCRIPTION
As I have seen you added the fix in hiqlite to make it compatible with windows here:
https://github.com/sebadob/hiqlite/commit/c6113b57b96cae2551fa3c590bc97d11ee0c9e96

I thought maybe you would also add the small fixes in rauthy, as it is not much and would make life for me easier, so that I don't have to patch it ^^

The only thing left is to target the hiqlite branch with the fix currently
`hiqlite = { git = "https://github.com/sebadob/hiqlite.git", features = ["full"], rev = "626c6877c54f4c6bad360d02053853f6d3d4fefc" }`

as the latest commits had a problem that I think will be resolved in future:
`failed to select a version for `libsqlite3-sys``