### PR TITLE
fix: bump `openssl` + `openssl-sys` to fix CVE-2025-24898

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -3752,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ mime_guess = "2"
 num_cpus = "1"
 num-traits = "0.2.19"
 once_cell = "1.19.0"
-openssl = { version = "0.10.64", features = ["vendored"] }
-openssl-sys = { version = "0.9.102", features = ["vendored"] }
+openssl = { version = "0.10.70", features = ["vendored"] }
+openssl-sys = { version = "0.9.105", features = ["vendored"] }
 oxiri = "0.2.2"
 prometheus = "0.13.3"
 rand = "0.8"


### PR DESCRIPTION
Even though the vulnerable code was not used, this fixes [CVE-2025-24898](https://nvd.nist.gov/vuln/detail/CVE-2025-24898)