### PR TITLE
fix: add the default `PUB_URL` for local dev in `rauthy.cfg` again

### DIFF
--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -1084,12 +1084,12 @@ LISTEN_PORT_HTTPS=8443
 # The scheme to use locally, valid values: http | https | http_https | unix_http | unix_https
 # For more details about the UNIX domain socket, check out its documentation page.
 # default: http_https
-LISTEN_SCHEME=http_https
+LISTEN_SCHEME=http
 
 # The Public URL of the whole deployment
 # The LISTEN_SCHEME + PUB_URL must match the HTTP ORIGIN HEADER later on, which is especially important when running
 # rauthy behind a reverse proxy. In case of a non-standard port (80/443), you need to add the port to the PUB_URL
-#PUB_URL=localhost:8443
+PUB_URL=localhost:8080
 
 # default value: number of available physical cores
 HTTP_WORKERS=1


### PR DESCRIPTION
fixes #771