### PR TITLE
make i18n for `validEmail` more clear

### DIFF
--- a/frontend/src/i18n/common/de.ts
+++ b/frontend/src/i18n/common/de.ts
@@ -135,7 +135,7 @@ export const I18nDe: I18n = {
         requestExpires: "Anfrage läuft ab",
         requestExpired: "Anfrage ist abgelaufen",
         signUp: "Benutzer Registrierung",
-        validEmail: "Gültige E-Mail Adresse",
+        validEmail: "Gültige E-Mail Adresse angeben",
     },
     device: {
         accept: "Akzeptieren",

--- a/frontend/src/i18n/common/en.ts
+++ b/frontend/src/i18n/common/en.ts
@@ -135,7 +135,7 @@ export const I18nEn: I18n = {
         requestExpires: "Request expires",
         requestExpired: "Request has expired",
         signUp: "User Registration",
-        validEmail: "Valid E-Mail Address",
+        validEmail: "Provide valid E-Mail address",
     },
     device: {
         accept: "Accept",


### PR DESCRIPTION
`Valid E-Mail Address` for the `email` input on the login page was a bit confusing and has now been changed to `Provide valid E-Mail address`.