### PR TITLE
fix: set `used = true` during `MagicLink::invalidate()`

### DIFF
--- a/src/models/src/entity/magic_links.rs
+++ b/src/models/src/entity/magic_links.rs
@@ -266,8 +266,10 @@ VALUES ($1, $2, $3, $4, $5, $6)"#,
 }
 
 impl MagicLink {
+    /// Sets the magic link as being expired and used.
     pub async fn invalidate(&mut self) -> Result<(), ErrorResponse> {
         self.exp = OffsetDateTime::now_utc().unix_timestamp() - 10;
+        self.used = true;
         self.save().await
     }
 
@@ -346,7 +348,7 @@ impl MagicLink {
         if self.used {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
-                "The requested passwort reset link was already used",
+                "The requested link has been used already",
             ));
         }
 


### PR DESCRIPTION
To provide better debugging and error messages for improved UX, we will now always set `used = true` if `MagicLink::invalidate()` is being called. This also additionally prevents some weird situations we could get into with the expiry checker scheduler.

#796