### PR TITLE
feat: additional safeguards and fixes for `MIGRATE_DB_FROM`

### DIFF
--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -476,7 +476,7 @@ DATABASE_URL=postgresql://rauthy:123SuperSafe@localhost:5432/rauthy
 # !!! USE WITH CARE !!!
 #
 #MIGRATE_DB_FROM=sqlite:data/state_machine/db/hiqlite.db
-#MIGRATE_DB_FROM=postgresql://postgres:123SuperSafe@localhost:5432/rauthy
+#MIGRATE_DB_FROM=postgresql://rauthy:123SuperSafe@localhost:5432/rauthy
 
 # Hiqlite is the default database for Rauthy.
 # You can opt-out and use Postgres instead by setting the proper

--- a/src/models/src/entity/failed_backchannel_logout.rs
+++ b/src/models/src/entity/failed_backchannel_logout.rs
@@ -4,7 +4,7 @@ use rauthy_common::is_hiqlite;
 use rauthy_error::ErrorResponse;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, sqlx::FromRow)]
 pub struct FailedBackchannelLogout {
     pub client_id: String,
     // both `sub` and `sid` may be empty but cannot be NULL because Postgres requires

--- a/src/models/src/entity/user_login_states.rs
+++ b/src/models/src/entity/user_login_states.rs
@@ -5,7 +5,7 @@ use rauthy_common::is_hiqlite;
 use rauthy_error::ErrorResponse;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, sqlx::FromRow)]
 pub struct UserLoginState {
     // Unix Timestamp in Millis - used inside PK
     pub timestamp: i64,


### PR DESCRIPTION
Adds an additional safeguard for `MIGRATE_DB_FROM` that will panic if the feature is being used between different major / minor versions, which is not guaranteed to be stable all the time.

Also fixes some missing newer columns and tables and add them to the migration logic.