### PR TITLE
Rework the way the `origin` header is being checked 

### DIFF
--- a/src/api/src/dev_only/dev_handler.rs
+++ b/src/api/src/dev_only/dev_handler.rs
@@ -97,7 +97,7 @@ pub async fn post_dev_only_endpoints(
         "providers_callback" => {
             let payload = serde_json::from_slice::<ProviderCallbackRequest>(bytes)?;
             let principal = web::ReqData::<Principal>::extract(&req).await?;
-            auth_providers::post_provider_callback_handle(data, req, payload, principal).await
+            auth_providers::post_provider_callback_handle(req, payload, principal).await
         }
         "register" => {
             let payload = serde_json::from_slice::<NewUserRegistrationRequest>(bytes)?;

--- a/src/models/src/entity/auth_providers.rs
+++ b/src/models/src/entity/auth_providers.rs
@@ -1,5 +1,4 @@
 use crate::api_cookie::ApiCookie;
-use crate::app_state::AppState;
 use crate::database::{Cache, DB};
 use crate::entity::auth_codes::AuthCode;
 use crate::entity::auth_provider_cust_impl;
@@ -11,10 +10,10 @@ use crate::entity::users_values::UserValues;
 use crate::entity::webauthn::WebauthnLoginReq;
 use crate::language::Language;
 use crate::{AuthStep, AuthStepAwaitWebauthn, AuthStepLoggedIn};
+use actix_web::HttpRequest;
 use actix_web::cookie::Cookie;
 use actix_web::http::header;
 use actix_web::http::header::HeaderValue;
-use actix_web::{HttpRequest, web};
 use cryptr::EncValue;
 use cryptr::utils::secure_random_alnum;
 use hiqlite::{Param, Row, params};
@@ -877,7 +876,6 @@ impl AuthProviderCallback {
 
     /// In case of any error, the callback code will be fully deleted for security reasons.
     pub async fn login_finish<'a>(
-        data: &'a web::Data<AppState>,
         req: &'a HttpRequest,
         payload: &'a ProviderCallbackRequest,
         mut session: Session,
@@ -1078,7 +1076,7 @@ impl AuthProviderCallback {
         }
         client.validate_redirect_uri(&slf.req_redirect_uri)?;
         client.validate_code_challenge(&slf.req_code_challenge, &slf.req_code_challenge_method)?;
-        let header_origin = client.validate_origin(req, &data.listen_scheme, &data.public_url)?;
+        let header_origin = client.get_validated_origin_header(req)?;
 
         // ######################################
         // all good, we can generate an auth code

--- a/src/service/src/oidc/authorize.rs
+++ b/src/service/src/oidc/authorize.rs
@@ -105,7 +105,7 @@ pub async fn post_authorize(
     })?;
     client.validate_redirect_uri(&req_data.redirect_uri)?;
     client.validate_code_challenge(&req_data.code_challenge, &req_data.code_challenge_method)?;
-    let header_origin = client.validate_origin(req, &data.listen_scheme, &data.public_url)?;
+    let header_origin = client.get_validated_origin_header(req)?;
 
     // build authorization code
     let code_lifetime = if user.has_webauthn_enabled() {

--- a/src/service/src/oidc/grant_types/authorization_code.rs
+++ b/src/service/src/oidc/grant_types/authorization_code.rs
@@ -55,7 +55,7 @@ pub async fn grant_type_authorization_code(
                 format!("Client '{}' not found", client_id),
             )
         })?;
-    let header_origin = client.validate_origin(&req, &data.listen_scheme, &data.public_url)?;
+    let header_origin = client.get_validated_origin_header(&req)?;
     if client.confidential {
         let secret = client_secret.ok_or_else(|| {
             warn!("'client_secret' is missing");

--- a/src/service/src/oidc/grant_types/client_credentials.rs
+++ b/src/service/src/oidc/grant_types/client_credentials.rs
@@ -42,7 +42,7 @@ pub async fn grant_type_credentials(
     })?;
     client.validate_secret(&secret, &req)?;
     client.validate_flow("client_credentials")?;
-    let header_origin = client.validate_origin(&req, &data.listen_scheme, &data.public_url)?;
+    let header_origin = client.get_validated_origin_header(&req)?;
 
     let mut headers = Vec::new();
     let dpop_fingerprint =

--- a/src/service/src/oidc/grant_types/password.rs
+++ b/src/service/src/oidc/grant_types/password.rs
@@ -40,7 +40,7 @@ pub async fn grant_type_password(
     let password = req_data.password.unwrap();
 
     let client = Client::find(client_id).await?;
-    let header_origin = client.validate_origin(&req, &data.listen_scheme, &data.public_url)?;
+    let header_origin = client.get_validated_origin_header(&req)?;
     if client.confidential {
         let secret = client_secret.ok_or_else(|| {
             ErrorResponse::new(ErrorResponseType::BadRequest, "Missing 'client_secret'")

--- a/src/service/src/oidc/grant_types/refresh_token.rs
+++ b/src/service/src/oidc/grant_types/refresh_token.rs
@@ -24,7 +24,7 @@ pub async fn grant_type_refresh(
     let (client_id, client_secret) = req_data.try_get_client_id_secret(&req)?;
     let client = Client::find_maybe_ephemeral(client_id).await?;
 
-    let header_origin = client.validate_origin(&req, &data.listen_scheme, &data.public_url)?;
+    let header_origin = client.get_validated_origin_header(&req)?;
 
     if client.confidential {
         let secret = client_secret.ok_or_else(|| {

--- a/src/service/src/oidc/validation.rs
+++ b/src/service/src/oidc/validation.rs
@@ -22,7 +22,6 @@ use tracing::debug;
 
 /// Validates request parameters for the authorization and refresh endpoints
 pub async fn validate_auth_req_param(
-    data: &web::Data<AppState>,
     req: &HttpRequest,
     client_id: &str,
     redirect_uri: &str,
@@ -33,7 +32,7 @@ pub async fn validate_auth_req_param(
     let client = Client::find_maybe_ephemeral(String::from(client_id)).await?;
 
     // allowed origin
-    let header = client.validate_origin(req, &data.listen_scheme, &data.public_url)?;
+    let header = client.get_validated_origin_header(req)?;
 
     // allowed redirect uris
     client.validate_redirect_uri(redirect_uri)?;
@@ -135,7 +134,7 @@ pub async fn validate_refresh_token(
             "Invalid 'azp'",
         ));
     }
-    let header_origin = client.validate_origin(req, &data.listen_scheme, &data.public_url)?;
+    let header_origin = client.get_validated_origin_header(req)?;
 
     // validate DPoP proof
     let (dpop_fingerprint, dpop_nonce) = if let Some(cnf) = claims.custom.cnf {


### PR DESCRIPTION
Rework the way the `origin` header is being checked and include `ADDITIONAL_ALLOWED_ORIGIN_SCHEMES` in tests to make sure it works as expected, as a preparation to add / fix CORS headers in some places.