### PR TITLE
Fix: change default admin

### DIFF
--- a/book/src/config/bootstrap.md
+++ b/book/src/config/bootstrap.md
@@ -4,7 +4,7 @@ Rauthy supports some basic bootstrapping functionality to make it easier to use 
 
 ## Admin User
 
-By default, the admin user will always be `admin@localhost.de` and the password will be auto-generated and shown
+By default, the admin user will always be `admin@localhost` and the password will be auto-generated and shown
 only once in the logs. This is the easiest way if you want to set up a new instance manually.
 
 However, you can change the default admin username and also provide a bootstrap password for this user, if Rauthy

--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -286,7 +286,7 @@ HQL_S3_SECRET=s3_secret
 
 # If set, the email of the default admin will be changed
 # during the initialization of an empty production database.
-BOOTSTRAP_ADMIN_EMAIL=admin@localhost.de
+BOOTSTRAP_ADMIN_EMAIL=admin@localhost
 
 # If set, this plain text password will be used for the
 # initial admin password instead of generating a random
@@ -657,7 +657,7 @@ HQL_SECRET_API=SuperSecureSecret1337
 
 # This contact information will be added to the `rauthy`client
 # within the anti lockout rule with each new restart.
-RAUTHY_ADMIN_EMAIL="admin@localhost.de"
+RAUTHY_ADMIN_EMAIL="admin@localhost"
 
 # Will be used as the prefix for the E-Mail subject for each E-Mail 
 # that will be sent out to a client.
@@ -816,7 +816,7 @@ MAX_HASH_THREADS=1
 #####################################
 
 # The E-Mail address event notifications should be sent to.
-#EVENT_EMAIL=admin@localhost.de
+#EVENT_EMAIL=admin@localhost
 
 # Matrix variables for event notifications.
 # `EVENT_MATRIX_USER_ID` and `EVENT_MATRIX_ROOM_ID` are mandatory.

--- a/book/src/config/logging.md
+++ b/book/src/config/logging.md
@@ -103,7 +103,7 @@ a working SMTP, you only need to set `EVENT_EMAIL`, that's it.
 
 ```
 # The E-Mail address event notifications should be sent to.
-EVENT_EMAIL=admin@localhost.de
+EVENT_EMAIL=admin@localhost
 ```
 
 #### Matrix

--- a/book/src/getting_started/first_start.md
+++ b/book/src/getting_started/first_start.md
@@ -32,15 +32,15 @@ If this is the case, you can delete the database / volume and just restart rauth
 ```
 
 The log message contains a link to the accounts page, where you then should log in to immediately set a new password.
-Follow the link, use as the default admin `admin@localhost.de` and as password the copied value from the log.
+Follow the link, use as the default admin `admin@localhost` and as password the copied value from the log.
 
 - When logged into the account, click `EDIT` and `CHANGE PASSWORD` to set a new password
 - Log out of the account and try to log in to the admin ui with the new password
 
 ## Custom rauthy admin user
 
-It is a good idea, to either keep the `admin@localhost.de` as a fallback user with just a very long password, or
-disable it, after a custom admin has been added.
+It is a good idea, to either keep the `admin@localhost` and rename it (to never have a default admin, which would be an
+attack vector) as a fallback user with just a very long password, or disable it, after a custom admin has been added.
 
 When logged in to the admin UI, you can add a new user. When the `SMTP` settings are correctly configured in the config,
 which we can test right now, you will receive an E-Mail with the very first password reset.
@@ -54,7 +54,7 @@ To debug this, you can set `LOG_LEVEL=debug` in the config and then watch the lo
 ### `rauthy_admin` user role
 
 The role, which allows a user to access the admin UI, is the `rauthy_admin`.  
-If the user has this role assigned, he will be seen as an admin.  
+If the user has this role assigned, he will be seen as an admin.
 
 Under the hood, rauthy itself uses the OIDC roles and groups in the same way, as all clients would do. This means you
 should not neither delete the `rauthy` default client, nor the `rauthy_admin` role. There are mechanisms to prevents

--- a/book/src/work/custom_scopes_attributes.md
+++ b/book/src/work/custom_scopes_attributes.md
@@ -94,7 +94,7 @@ I used the `rauthy` client in this example (which you should not mess with when 
   ],
   "auth_time": 1721722389,
   "at_hash": "Hd5ugcSzxwl1epF7Il3pEpq0gznnqs2SnSVZCdNw0EI",
-  "preferred_username": "admin@localhost.de",
+  "preferred_username": "admin@localhost",
   "roles": [
     "rauthy_admin",
     "admin"

--- a/migrations/hiqlite/11_change_default_admin.sql
+++ b/migrations/hiqlite/11_change_default_admin.sql
@@ -1,0 +1,14 @@
+UPDATE users
+SET email = 'admin@localhost'
+WHERE email = 'admin@localhost.de';
+
+-- These are just for internal integration tests.
+-- They will be removed in any case when doing a production setup
+-- and are changed only for consistency.
+UPDATE users
+SET email = 'init_admin@localhost'
+WHERE email = 'init_admin@localhost.de';
+
+UPDATE users
+SET email = 'test_admin@localhost'
+WHERE email = 'test_admin@localhost.de';

--- a/migrations/postgres/V7__change_default_admin.sql
+++ b/migrations/postgres/V7__change_default_admin.sql
@@ -1,0 +1,14 @@
+UPDATE users
+SET email = 'admin@localhost'
+WHERE email = 'admin@localhost.de';
+
+-- These are just for internal integration tests.
+-- They will be removed in any case when doing a production setup
+-- and are changed only for consistency.
+UPDATE users
+SET email = 'init_admin@localhost'
+WHERE email = 'init_admin@localhost.de';
+
+UPDATE users
+SET email = 'test_admin@localhost'
+WHERE email = 'test_admin@localhost.de';

--- a/rauthy-test.cfg
+++ b/rauthy-test.cfg
@@ -14,7 +14,7 @@ AUTH_HEADERS_ENABLE=true
 
 PASSWORD_RESET_COOKIE_BINDING=true
 
-RAUTHY_ADMIN_EMAIL="admin@localhost.de"
+RAUTHY_ADMIN_EMAIL="admin@localhost"
 
 # Limits the maximum amount of parallel password hashes at the exact same time to never exceed system memory while
 # still allowing a good amount of memory for the argon2id algorithm (default: 2)

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -3,7 +3,7 @@
 #####################################
 
 # If 'true', the data store will be initialized with DEV values.
-# The default password for 'admin@localhost.de' is '123SuperSafe'
+# The default password for 'admin@localhost' is '123SuperSafe'
 # default: false
 # !!! DO NOT USE IN PRODUCTION !!!
 DEV_MODE=true
@@ -720,7 +720,7 @@ DYN_CLIENT_REG_TOKEN="123SuperSafe"
 
 # This contact information will be added to the `rauthy`client
 # within the anti lockout rule with each new restart.
-RAUTHY_ADMIN_EMAIL="admin@localhost.de"
+RAUTHY_ADMIN_EMAIL="admin@localhost"
 
 # Will be used as the prefix for the E-Mail subject for each E-Mail
 # that will be sent out to a client.
@@ -870,7 +870,7 @@ EPHEMERAL_CLIENTS_CACHE_LIFETIME=3600
 #####################################
 
 # The E-Mail address event notifications should be sent to.
-EVENT_EMAIL=admin@localhost.de
+EVENT_EMAIL=admin@localhost
 
 # Matrix variables for event notifications.
 # `EVENT_MATRIX_USER_ID` and `EVENT_MATRIX_ROOM_ID` are mandatory.

--- a/src/bin/src/version_migration.rs
+++ b/src/bin/src/version_migration.rs
@@ -1,8 +1,19 @@
 use rauthy_error::ErrorResponse;
+use tracing::warn;
 
 /// If it's necessary to apply manual migrations between major versions, which are
 /// not handled automatically by database migrations, put them here. This function
 /// will be executed at startup after DB init and before the API start.
 pub async fn manual_version_migrations() -> Result<(), ErrorResponse> {
+    warn!(
+        r#"
+
+    CAUTION: If you have been using the default admin 'admin@localhost.de',
+    it will no longer exist with this email. Rauthy v0.29 changes the
+    default admin to 'admin@localhost', which you should use, if you are
+    migrating from an older version with a still existing 'admin@localhost.de'.
+"#
+    );
+
     Ok(())
 }

--- a/src/bin/tests/common.rs
+++ b/src/bin/tests/common.rs
@@ -23,7 +23,7 @@ static SESSION_HEADERS: OnceLock<HeaderMap> = OnceLock::new();
 
 pub const CLIENT_ID: &str = "init_client";
 pub const CLIENT_SECRET: &str = "LjERi0WSEz1E9OY9KFJaMjlwV1Uf3nuIuOUnJnoJQNm2i7YMjTDMy4PbAKnYRgFy";
-pub const USERNAME: &str = "init_admin@localhost.de";
+pub const USERNAME: &str = "init_admin@localhost";
 pub const PASSWORD: &str = "123SuperSafe";
 
 #[allow(dead_code)]

--- a/src/bin/tests/handler_pwd_reset.rs
+++ b/src/bin/tests/handler_pwd_reset.rs
@@ -15,7 +15,7 @@ mod common;
 async fn test_get_pwd_reset_form() -> Result<(), Box<dyn Error>> {
     let backend_url = get_backend_url();
     let user_id = "2PYV3STNz3MN7VnPjJVcPQap".to_string(); // test_admin
-    let username = "test_admin@localhost.de";
+    let username = "test_admin@localhost";
     let reset_id = "2qqdUOcXECQeypBNTs7Pnp7A2zAwr0VzynyzJiIjNR1Ua9KA95dTewM56JaPIoyj";
     let url_get = format!("{backend_url}/users/{user_id}/reset/{reset_id}");
 

--- a/src/bin/tests/handler_users.rs
+++ b/src/bin/tests/handler_users.rs
@@ -131,7 +131,7 @@ async fn test_password_reset_always_ok() -> Result<(), Box<dyn Error>> {
 
     // get password reset for an existing user
     let mut payload = RequestResetRequest {
-        email: "admin@localhost.de".to_string(),
+        email: "admin@localhost".to_string(),
         redirect_uri: None,
     };
     let url = format!("{}/users/request_reset", get_backend_url());
@@ -193,13 +193,13 @@ async fn test_user_picture() -> Result<(), Box<dyn Error>> {
     let users = res.json::<Vec<UserResponseSimple>>().await?;
     let user_id_admin = users
         .iter()
-        .find(|u| u.email == "admin@localhost.de")
+        .find(|u| u.email == "admin@localhost")
         .unwrap()
         .id
         .clone();
     let user_id = users
         .into_iter()
-        .find(|u| u.email == "init_admin@localhost.de")
+        .find(|u| u.email == "init_admin@localhost")
         .unwrap()
         .id;
     eprintln!("user id for picture tests: {}", user_id);

--- a/src/models/src/entity/clients_scim.rs
+++ b/src/models/src/entity/clients_scim.rs
@@ -1195,7 +1195,7 @@ impl ClientScim {
 
                 //                 let pre = r#"{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
                 // "Operations":[{"op":"add","path":"members","value":[{"value":"9eb2bd20-c70c-48fb-a0fb-ff1daccfa23f",
-                // "display":"test_admin@localhost.de"}]}]}"#;
+                // "display":"test_admin@localhost"}]}]}"#;
 
                 // Same situation as for group patching. This "ugly" way of json creation is a pretty
                 // big efficiency gain, and we avoid many unnecessary allocations, since we have a

--- a/src/models/src/entity/magic_links.rs
+++ b/src/models/src/entity/magic_links.rs
@@ -371,7 +371,7 @@ mod tests {
         let ml_from = MagicLinkUsage::try_from(&s).unwrap();
         assert_eq!(ml, ml_from);
 
-        let ml = MagicLinkUsage::EmailChange("admin@localhost.de".to_string());
+        let ml = MagicLinkUsage::EmailChange("admin@localhost".to_string());
         let s = ml.to_string();
         let ml_from = MagicLinkUsage::try_from(&s).unwrap();
         assert_eq!(ml, ml_from);

--- a/src/models/src/entity/users.rs
+++ b/src/models/src/entity/users.rs
@@ -1757,7 +1757,7 @@ mod tests {
     fn test_session_impl() {
         let mut user = User {
             id: "123".to_string(),
-            email: "admin@localhost.de".to_string(),
+            email: "admin@localhost".to_string(),
             given_name: "Admin".to_string(),
             family_name: Some("Rauthy".to_string()),
             password: Some("SoSafeNOTHash".to_string()),
@@ -1820,7 +1820,7 @@ mod tests {
     fn test_user_impl() -> Result<(), ErrorResponse> {
         let mut user =  User {
             id: "123".to_string(),
-            email: "admin@localhost.de".to_string(),
+            email: "admin@localhost".to_string(),
             given_name: "Admin".to_string(),
             family_name: Some("Rauthy".to_string()),
             password: Some("$argon2id$v=19$m=16384,t=3,p=2$l8F0ar1wSQsce+OdPgYbhg$I2XrvC/XRW+22eI2ptBg5GQp3SHjgSQXsfstuTZne1I".to_string()),

--- a/src/models/src/migration/init_prod.rs
+++ b/src/models/src/migration/init_prod.rs
@@ -52,7 +52,7 @@ pub async fn migrate_init_prod(argon2_params: Params, issuer: &str) -> Result<()
 
         // check if we should use manually provided bootstrap values
         let email =
-            env::var("BOOTSTRAP_ADMIN_EMAIL").unwrap_or_else(|_| "admin@localhost.de".to_string());
+            env::var("BOOTSTRAP_ADMIN_EMAIL").unwrap_or_else(|_| "admin@localhost".to_string());
         let hash = match env::var("BOOTSTRAP_ADMIN_PASSWORD_ARGON2ID") {
             Ok(hash) => {
                 info!(
@@ -106,7 +106,7 @@ pub async fn migrate_init_prod(argon2_params: Params, issuer: &str) -> Result<()
             }
         };
 
-        let sql = "UPDATE users SET email = $1, password = $2 WHERE email = 'admin@localhost.de'";
+        let sql = "UPDATE users SET email = $1, password = $2 WHERE email = 'admin@localhost'";
         if is_hiqlite() {
             // TODO we could grab a possibly existing `RAUTHY_ADMIN_EMAIL` and initialize a custom
             // admin


### PR DESCRIPTION
To avoid potential conflicts with the default admin `admin@localhost.de`, it has been changed to `admin@localhost`.

The reason is, that `localhost.de` is a valid domain with an existing TLD. The reason it had the `.de` appended in the first place, is because the early validation for the username / email was very strict and required a TLD. This is not the case anymore and therefore made this change possible.

fixes #697 