### PR TITLE
Rework and simplify session handling

### DIFF
--- a/frontend/src/api/types/session.ts
+++ b/frontend/src/api/types/session.ts
@@ -1,4 +1,4 @@
-export type SessionState = 'Open' | 'Init' | 'Auth' | 'LoggedOut' | 'Unknown';
+export type SessionState = 'Init' | 'Auth' | 'LoggedOut' | 'Unknown';
 
 export interface SessionResponse {
     id: string,

--- a/frontend/src/lib/admin/blacklist/Blacklist.svelte
+++ b/frontend/src/lib/admin/blacklist/Blacklist.svelte
@@ -199,7 +199,7 @@
                 pageSize={30}
         />
     {/if}
-</ContentAdmin>
+</ContentAdmin>w
 
 <style>
     .addNew {

--- a/src/api_types/src/sessions.rs
+++ b/src/api_types/src/sessions.rs
@@ -3,7 +3,6 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub enum SessionState {
-    Open,
     Init,
     Auth,
     LoggedOut,

--- a/src/models/src/entity/sessions.rs
+++ b/src/models/src/entity/sessions.rs
@@ -76,7 +76,6 @@ impl From<tokio_postgres::Row> for Session {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SessionState {
-    Open,
     Init,
     Auth,
     LoggedOut,
@@ -88,7 +87,6 @@ impl FromStr for SessionState {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let res = match s {
-            "open" => SessionState::Open,
             "init" => SessionState::Init,
             "auth" => SessionState::Auth,
             "logged_out" => SessionState::LoggedOut,
@@ -101,7 +99,6 @@ impl FromStr for SessionState {
 impl From<rauthy_api_types::sessions::SessionState> for SessionState {
     fn from(value: rauthy_api_types::sessions::SessionState) -> Self {
         match value {
-            rauthy_api_types::sessions::SessionState::Open => Self::Open,
             rauthy_api_types::sessions::SessionState::Init => Self::Init,
             rauthy_api_types::sessions::SessionState::Auth => Self::Auth,
             rauthy_api_types::sessions::SessionState::LoggedOut => Self::LoggedOut,
@@ -113,7 +110,6 @@ impl From<rauthy_api_types::sessions::SessionState> for SessionState {
 impl From<SessionState> for rauthy_api_types::sessions::SessionState {
     fn from(value: SessionState) -> Self {
         match value {
-            SessionState::Open => Self::Open,
             SessionState::Init => Self::Init,
             SessionState::Auth => Self::Auth,
             SessionState::LoggedOut => Self::LoggedOut,
@@ -125,7 +121,6 @@ impl From<SessionState> for rauthy_api_types::sessions::SessionState {
 impl SessionState {
     pub fn as_str(&self) -> &str {
         match self {
-            SessionState::Open => "open",
             SessionState::Init => "init",
             SessionState::Auth => "auth",
             SessionState::LoggedOut => "logged_out",
@@ -615,9 +610,7 @@ impl Session {
             return false;
         }
         if let Some(ip) = remote_ip {
-            if (state == SessionState::Open || state == SessionState::Auth)
-                && self.remote_ip != Some(ip.to_string())
-            {
+            if state == SessionState::Auth && self.remote_ip != Some(ip.to_string()) {
                 let session_ip = self.remote_ip.as_deref().unwrap_or("UNKNOWN");
                 warn!(
                     "Invalid access for session {} / {} with different IP: {}",


### PR DESCRIPTION
The internal session handling can be simplified a bit and made more safe in terms of user errors.

The different states a session may be in can be reduced (`SessionState::Open` is not used anymore). Also, it makes sense to pay a tiny bit extra and do double checks that the session is actually in `SessionState::Auth`. In the end, it's just a duplicate simple `bool` check but it would catch cases in which a devloper forgets to explicitly check `Auth` state in an endpoint.

Where `SessionState::Init` would be allowed should be defined via a static list of endpoint.

This is just an additional safety-net and makes future maintenance easier.