### PR TITLE
Feat: mandatory pow on `LoginRequest` + `ProviderLoginRequest`

### DIFF
--- a/frontend/src/api/types/auth_provider.ts
+++ b/frontend/src/api/types/auth_provider.ts
@@ -72,6 +72,8 @@ export interface ProviderLoginRequest {
     provider_id: string,
     /// Validation: PATTERN_URI
     pkce_challenge: string,
+    
+    pow: string,
 }
 
 export interface ProviderLookupRequest {

--- a/frontend/src/api/types/authorize.ts
+++ b/frontend/src/api/types/authorize.ts
@@ -6,6 +6,7 @@ export interface LoginRequest {
     email: string,
     /// Validation: max 256
     password?: string,
+    pow: string,
     /// Validation: PATTERN_CLIENT_ID_EPHEMERAL
     client_id: string,
     /// Validation: PATTERN_URI
@@ -45,13 +46,13 @@ export interface RequestResetRequest {
     redirect_uri?: string,
 }
 
-export interface TokenSet {
-    access_token: string,
-    token_type: JwtTokenType,
-    id_token?: string,
-    expires_in: number,
-    refresh_token?: string,
-}
+// export interface TokenSet {
+//     access_token: string,
+//     token_type: JwtTokenType,
+//     id_token?: string,
+//     expires_in: number,
+//     refresh_token?: string,
+// }
 
 export interface WebauthnLoginResponse {
     code: string,

--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -43,6 +43,7 @@
     import type {SessionInfoResponse} from "$api/types/session.ts";
     import ClientLogo from "$lib5/ClientLogo.svelte";
     import type {ProviderLoginRequest} from "$api/types/auth_provider.ts";
+    import {fetchSolvePow} from "$utils/pow";
 
     const inputWidth = "18rem";
 
@@ -191,14 +192,18 @@
             return;
         }
 
+        let pow = await fetchSolvePow() || '';
+
         const payload: LoginRequest = {
             email,
+            pow,
             client_id: clientId,
             redirect_uri: redirectUri,
             state: stateParam,
             nonce: nonce,
             scopes,
         };
+        console.log(payload);
         if (challenge && challengeMethod && (challengeMethod === 'plain' || challengeMethod === 'S256')) {
             payload.code_challenge = challenge;
             payload.code_challenge_method = challengeMethod;
@@ -247,6 +252,8 @@
             } else {
                 console.error('did not receive a proper WebauthnLoginResponse after HTTP200');
             }
+        } else if (res.status === 400) {
+            err = res.error?.message || '';
         } else if (res.status === 406) {
             // 406 -> client forces MFA while the user has none
             err = t.authorize.clientForceMfa;
@@ -318,6 +325,8 @@
             return;
         }
 
+        let pow = await fetchSolvePow() || '';
+
         let payload: ProviderLoginRequest = {
             email: email || undefined,
             client_id: clientId,
@@ -329,6 +338,7 @@
             code_challenge_method: challengeMethod,
             provider_id: id,
             pkce_challenge,
+            pow,
         };
 
         let res = await fetchPost<string>('/auth/v1/providers/login', payload);

--- a/frontend/src/utils/pow.ts
+++ b/frontend/src/utils/pow.ts
@@ -1,6 +1,6 @@
 import {fetchPost} from "$api/fetch";
 
-export async function fetchSolvePow() {
+export async function fetchSolvePow(): Promise<string | undefined> {
     // spawn the worker in advance so it can async load the wasm already
     let worker = new Worker(new URL("powWorker.ts", import.meta.url));
 

--- a/src/api/src/auth_providers.rs
+++ b/src/api/src/auth_providers.rs
@@ -19,6 +19,7 @@ use rauthy_models::entity::logos::{Logo, LogoType};
 use rauthy_models::entity::theme::ThemeCssFull;
 use rauthy_models::entity::users::User;
 use rauthy_models::html::HtmlCached;
+use spow::pow::Pow;
 use tracing::debug;
 use validator::Validate;
 
@@ -140,6 +141,8 @@ pub async fn post_provider_login(
 ) -> Result<HttpResponse, ErrorResponse> {
     principal.validate_session_auth_or_init()?;
     payload.validate()?;
+
+    Pow::validate(&payload.pow)?;
 
     let (cookie, xsrf_token, location) = AuthProviderCallback::login_start(payload).await?;
 

--- a/src/api/src/oidc.rs
+++ b/src/api/src/oidc.rs
@@ -304,10 +304,11 @@ pub async fn post_authorize_handle(
     principal.validate_session_auth_or_init()?;
     payload.validate()?;
 
-    // TODO refactor login delay to use Instant, which is a bit cleaner
     let start = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
 
     let session = principal.get_session()?;
+
+    Pow::validate(&payload.pow)?;
 
     let mut has_password_been_hashed = false;
     let mut add_login_delay = true;

--- a/src/api_types/src/auth_providers.rs
+++ b/src/api_types/src/auth_providers.rs
@@ -115,6 +115,12 @@ pub struct ProviderLoginRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
     pub code_challenge_method: Option<String>,
+    /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
+    #[validate(regex(
+        path = "*RE_CLIENT_ID_EPHEMERAL",
+        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
+    ))]
+    pub pow: String,
 
     // values for the callback from upstream
     /// Validation: `[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]`

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -121,6 +121,12 @@ pub struct LoginRequest {
         path = "*RE_CLIENT_ID_EPHEMERAL",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
+    pub pow: String,
+    /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
+    #[validate(regex(
+        path = "*RE_CLIENT_ID_EPHEMERAL",
+        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
+    ))]
     pub client_id: String,
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$"))]


### PR DESCRIPTION
To add additional protection against DoS, bots and automated security scanners, the `LoginRequest` + `ProviderLoginReqeust` now require a mandatory PoW. An additional benefit is, that an admin could shift a bit of resources for logins from the backend to the clients, when the `t_cost` for the password hashing (which always will be the bottleneck in terms of resources) is reduced slightly in exchange for a bit higher PoW difficulty.