### PR TITLE
rauthy-client: fix URL encoded `redirect_uri`

### DIFF
--- a/rauthy-client/CHANGELOG.md
+++ b/rauthy-client/CHANGELOG.md
@@ -2,8 +2,20 @@
 
 ## UNRELEASED
 
-External dependencies have been bumped, mostly to fix [CWE-770](https://github.com/advisories/GHSA-4p46-pwfr-66x6) for
-`ring`. At the same time, `bindode` has been bumped to `v2` in combination with the MSRV to `1.85.0`
+### Breaking
+
+The function signature for `OidcProviderConfig::setup_from_config()` now expects the `redirect_uri` as a `String`
+instead of `&str`.
+
+### Changes
+
+External dependencies have been bumped and the MSRV to `1.85.0`. `ring`, which is a pretty heavy weight dependency, has
+been dropped in favor of `sha2`. `ring` was used only for S256 PKCE hashes.
+
+### Bugfix
+
+- The `redirect_uri` during the `/token` request has been URL encoded, which should not be the case and could lead to
+  errors like `invalid redirect_uri`
 
 ## v0.6.1
 

--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -39,9 +39,9 @@ rand = "0.9"
 reqwest = { version = "0.12.12", default-features = false, features = [
     "brotli", "json", "rustls-tls", "rustls-tls-webpki-roots"
 ] }
-ring = "0.17.13"
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.100"
+sha2 = "0.10.9"
 thiserror = { version = "2" }
 tokio = "1.34"
 tracing = "0.1.40"

--- a/rauthy-client/examples/actix-web/Cargo.lock
+++ b/rauthy-client/examples/actix-web/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-client"
-version = "0.6.1"
+version = "0.7.0-20240311"
 dependencies = [
  "actix-macros",
  "actix-web",
@@ -1876,9 +1876,9 @@ dependencies = [
  "jwt-simple",
  "rand 0.9.0",
  "reqwest",
- "ring",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.6",
  "tokio",
  "tracing",
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/rauthy-client/examples/actix-web/src/main.rs
+++ b/rauthy-client/examples/actix-web/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
     };
     // The redirect_uri here must match the URI of this application, where we accept and handle
     // the callback after a successful login.
-    OidcProvider::setup_from_config(config, "http://localhost:3000/callback").await?;
+    OidcProvider::setup_from_config(config, "http://localhost:3000/callback".to_string()).await?;
 
     let config = Data::new(Config::new().await?);
     let addr = "127.0.0.1:3000";

--- a/rauthy-client/examples/axum/Cargo.lock
+++ b/rauthy-client/examples/axum/Cargo.lock
@@ -1660,9 +1660,9 @@ dependencies = [
  "jwt-simple",
  "rand 0.9.0",
  "reqwest",
- "ring",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/rauthy-client/examples/axum/src/main.rs
+++ b/rauthy-client/examples/axum/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
     };
     // The redirect_uri here must match the URI of this application, where we accept and handle
     // the callback after a successful login.
-    OidcProvider::setup_from_config(config, "http://localhost:3000/callback").await?;
+    OidcProvider::setup_from_config(config, "http://localhost:3000/callback".to_string()).await?;
 
     let config = Config::new().await?;
 

--- a/rauthy-client/examples/generic/Cargo.lock
+++ b/rauthy-client/examples/generic/Cargo.lock
@@ -1899,9 +1899,9 @@ dependencies = [
  "jwt-simple",
  "rand 0.9.0",
  "reqwest",
- "ring",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.6",
  "tokio",
  "tracing",
@@ -2220,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/rauthy-client/examples/generic/src/main.rs
+++ b/rauthy-client/examples/generic/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
     };
     // The redirect_uri here must match the URI of this application, where we accept and handle
     // the callback after a successful login.
-    OidcProvider::setup_from_config(config, "http://localhost:3000/callback").await?;
+    OidcProvider::setup_from_config(config, "http://localhost:3000/callback".to_string()).await?;
 
     let config = Data::new(Config::new().await?);
     let addr = "127.0.0.1:3000";

--- a/rauthy-client/src/lib.rs
+++ b/rauthy-client/src/lib.rs
@@ -17,13 +17,13 @@
 use crate::provider::OidcProvider;
 use base64::{engine, engine::general_purpose, Engine as _};
 use rand::{distr, Rng};
-use ring::digest;
 use tracing::{error, warn};
 
 use crate::handler::OidcCookieInsecure;
 use crate::jwks::jwks_handler;
 use crate::rauthy_error::RauthyError;
 pub use reqwest::Certificate as RootCertificate;
+use sha2::{Digest, Sha256};
 
 /// Handles the encrypted OIDC state cookie for the login flow
 pub mod cookie_state;
@@ -137,7 +137,9 @@ where
 #[inline]
 pub fn generate_pkce_challenge() -> (String, String) {
     let plain = secure_random(32);
-    let s256 = digest::digest(&digest::SHA256, plain.as_bytes());
+    let mut hasher = Sha256::new();
+    hasher.update(plain.as_bytes());
+    let s256 = hasher.finalize();
     let challenge = base64_url_encode(s256.as_ref());
     (plain, challenge)
 }

--- a/rauthy-client/src/provider.rs
+++ b/rauthy-client/src/provider.rs
@@ -48,8 +48,9 @@ impl OidcProviderConfig {
         JwksMsg::NewJwksUri(provider.jwks_uri.clone()).send()?;
 
         let auth_endpoint = &provider.authorization_endpoint;
+        let redirect_uri_encoded = redirect_uri.replace(':', "%3A").replace('/', "%2F");
         let auth_url_base = format!(
-            "{auth_endpoint}?client_id={client_id}&redirect_uri={redirect_uri}&\
+            "{auth_endpoint}?client_id={client_id}&redirect_uri={redirect_uri_encoded}&\
             response_type=code&code_challenge_method=S256&scope={scope}"
         );
 
@@ -118,12 +119,11 @@ impl OidcProvider {
 
     pub async fn setup_from_config(
         config: RauthyConfig,
-        redirect_uri: &str,
+        redirect_uri: String,
     ) -> Result<(), RauthyError> {
-        let callback = redirect_uri.replace(':', "%3A").replace('/', "%2F");
         let scope = config.scope.join("+");
         let config = OidcProviderConfig::build_from_values(
-            callback,
+            redirect_uri,
             config.iss,
             scope,
             config.client_id,


### PR DESCRIPTION
The `rauthy-client` was URL encoding the `redirect_uri` during the `/token` request, which could lead to invalid `redirect_uri` checks.