### PR TITLE
Fix: logging for invalid `SessionState`

### DIFF
--- a/src/middlewares/src/principal.rs
+++ b/src/middlewares/src/principal.rs
@@ -61,7 +61,10 @@ where
         let service = Rc::clone(&self.service);
 
         Box::pin(async move {
-            // let mut session = None;
+            if req.path().starts_with("/auth/v1/_app/") || req.path() == "/auth/v1/" {
+                return service.call(req).await;
+            }
+
             let mut principal = Principal {
                 session: None,
                 api_key: get_api_key_from_headers(&req).await?,

--- a/src/models/src/entity/sessions.rs
+++ b/src/models/src/entity/sessions.rs
@@ -674,7 +674,7 @@ impl Session {
                     return true;
                 }
 
-                warn!(
+                debug!(
                     "Session in Init state used on invalid path: {:?} -> {}",
                     self, req_path
                 );


### PR DESCRIPTION
Move "invalid state" logs for `SessionState` from `warn` into `debug` level and skip `Principal` extraction for static assets.