### PR TITLE
[Book] fix link to config

### DIFF
--- a/book/src/config/production_config.md
+++ b/book/src/config/production_config.md
@@ -2,7 +2,7 @@
 
 If you want to go into production, the configuration from the Getting Started section is most probably not enough.
 
-The best thing you could do is just taking a look at the [Reference Config](/config/config.html) and reading through
+The best thing you could do is just taking a look at the [Reference Config](config/config.html) and reading through
 all the possible options.
 
 However, this section will give you a head start with the minimum you should set up. Depending on if you started


### PR DESCRIPTION
the link to the "Reference Config" is not correct here:
https://sebadob.github.io/rauthy/config/production_config.html

leads to:
https://sebadob.github.io/config/config.html

should:
https://sebadob.github.io/rauthy/config/config.html

