### PR TITLE
Feat: Add SCIM types + impl's to `rauthy-client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `v0.29.2`s fix for the HTTP 302 instead of 200 on `/logout` broke the logout from the UI without additional
   `id_token_hint`.
-  [#93ß](https://github.com/sebadob/rauthy/pull/930)
+  [#930](https://github.com/sebadob/rauthy/pull/930)
 - Form validation for Upstream Auth Provider config did not set some fields to required under certain conditions and
   would therefore return the backend validation error instead of a nicer way of handling it.
   [#931](https://github.com/sebadob/rauthy/pull/931)

--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -11,6 +11,10 @@ description = "rauthy-client - Client for the Rauthy OIDC IAM project"
 readme = "README.md"
 repository = "https://github.com/sebadob/rauthy/tree/main/rauthy-client"
 
+[package.metadata.docs.rs]
+features = ["backchannel-logout", "device-code", "scim"]
+rustdoc-args = ["--features backchannel-logout,device-code,scim"]
+
 [features]
 default = []
 actix-web = [

--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/sebadob/rauthy/tree/main/rauthy-client"
 default = []
 actix-web = [
     "dep:actix-web",
-    "dep:http",
     # minimal versions
     "dep:actix-macros",
 ]
@@ -26,6 +25,7 @@ axum = [
 backchannel-logout = []
 device-code = []
 qrcode = ["device-code", "dep:qrcode"]
+scim = []
 userinfo = []
 
 [dependencies]
@@ -35,6 +35,7 @@ bincode = { version = "2", default-features = false, features = ["std", "serde"]
 cached = { version = "0.55.1", features = [] }
 chacha20poly1305 = { version = "0.10.1", features = ["std"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std"] }
+http = "1"
 jwt-simple = { version = "0.12.6", default-features = false, features = ["pure-rust"] }
 rand = "0.9"
 reqwest = { version = "0.12.12", default-features = false, features = [
@@ -49,7 +50,6 @@ tracing = "0.1.40"
 
 # actix-web
 actix-web = { version = "4.4", optional = true, features = [] }
-http = { version = "1.0.0", optional = true }
 
 # axum
 axum = { version = "0.8", optional = true, features = [] }

--- a/rauthy-client/examples/axum/Cargo.lock
+++ b/rauthy-client/examples/axum/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "axum-extra",
  "dotenvy",
  "rauthy-client",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1657,6 +1658,7 @@ dependencies = [
  "cached",
  "chacha20poly1305",
  "chrono",
+ "http",
  "jwt-simple",
  "rand 0.9.0",
  "reqwest",
@@ -1876,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/rauthy-client/examples/axum/Cargo.toml
+++ b/rauthy-client/examples/axum/Cargo.toml
@@ -6,12 +6,13 @@ authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"
 
 [dependencies]
-rauthy-client = { path = "../..", features = ["axum", "backchannel-logout", "userinfo"] }
+rauthy-client = { path = "../..", features = ["axum", "backchannel-logout", "scim", "userinfo"] }
 
 anyhow = "1.0.75"
 axum = { version = "0.8.1", features = ["http2"] }
 axum-extra = { version = "0.10.0", features = ["cookie"] }
 dotenvy = "0.15.7"
+serde_json = "1.0.140"
 tokio = { version = "1.43.1", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["tracing"] }

--- a/rauthy-client/examples/axum/README.md
+++ b/rauthy-client/examples/axum/README.md
@@ -16,3 +16,17 @@ Then you can start the example with `cargo run` and open the UI on `localhost:30
 
 If you have any other setup, keep in mind that in case of Backchannel Logouts, Rauthy needs to be able to reach
 the client directly.
+
+This example also shows a very simple SCIM implementation. You can test SCIM if you naviagte to
+
+```
+http://localhost:3000/data
+```
+
+And then activate SCIM for the `test` client.
+
+The `SCIM Base URI` is `http://localhost:3000/scim/v2`. Rauthy will derive all the other endpoints based on this
+URI like defined in the RFC. The bearer token is `123SuperSafeSCIM` as set for the `RauthyConfig` in `main.rs`.
+
+The simple test page will automatically refresh every 2 seconds and you should see all User / Group data being updated
+in real-time if you have set everything up correctly.

--- a/rauthy-client/examples/axum/src/main.rs
+++ b/rauthy-client/examples/axum/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
                 .route(
                     "/Groups/{id}",
                     get(scim::groups::get_group)
-                        .put(scim::groups::put_group)
+                        .patch(scim::groups::patch_group)
                         .delete(scim::groups::delete_group),
                 ),
         )

--- a/rauthy-client/examples/axum/src/scim/groups.rs
+++ b/rauthy-client/examples/axum/src/scim/groups.rs
@@ -1,0 +1,184 @@
+use axum::extract::Path;
+use rauthy_client::scim::types::{
+    ScimError, ScimFilterBy, ScimGroup, ScimGroupMember, ScimListQuery, ScimListResponse,
+    ScimPatchOp, ScimResource,
+};
+use rauthy_client::secure_random;
+use std::sync::LazyLock;
+use tokio::sync::RwLock;
+
+// Very simple group storage - DO NOT do it like that in production, we just want to keep it simple.
+pub static GROUPS: LazyLock<RwLock<Vec<ScimGroup>>> = LazyLock::new(|| RwLock::new(Vec::new()));
+
+// All SCIM type extractors already validate the proper Content-Type and the SCIM bearer token.
+// This means if you end up in the request handler, the token has already been validated.
+
+/// A request to get "all" users. The `ScimListQuery` basically deinfes pagination and the
+/// expected results. Must always return a `ScimListResponse`.
+///
+/// By RFC, the `ScimListQuery` can include more fields, but Rauthy will only use `start_index` and
+/// `count`.
+pub async fn get_groups(query: ScimListQuery) -> Result<ScimListResponse, ScimError> {
+    // The query index must be stable over time. For a real world implementation, a good idea would
+    // be to use something like a creation timestamp, that never changes.
+    let start_index = query.start_index.unwrap_or(0);
+
+    let resources = find_groups(start_index, &query).await;
+    let len = resources.len() as u32;
+
+    Ok(ScimListResponse {
+        items_per_page: query.count.unwrap_or(len),
+        total_results: len,
+        start_index,
+        resources,
+        ..Default::default()
+    })
+}
+
+pub async fn post_group(group: ScimGroup) -> Result<ScimGroup, ScimError> {
+    save_group(group).await
+}
+
+pub async fn get_group(Path(id): Path<String>) -> Result<ScimGroup, ScimError> {
+    match GROUPS
+        .read()
+        .await
+        .iter()
+        .find(|g| g.id.as_deref() == Some(&id))
+    {
+        Some(group) => Ok(group.clone()),
+        None => Err(ScimError::new(404, Some("Group not found".into()))),
+    }
+}
+
+pub async fn put_group(Path(id): Path<String>, patch_op: ScimPatchOp) -> Result<(), ScimError> {
+    for op in patch_op.operations {
+        // PatchOps can become very complex and super annoying to work with, if you have a
+        // stricly typed language. This example only shows the ones that Rauthy actually sends.
+        // You get the least amount of boilerplate with this way of doing it.
+
+        if let Ok(users) = op.try_as_add_member() {
+            // Add users to a group
+            for group in GROUPS.write().await.iter_mut() {
+                if group.id.as_deref() == Some(&id) {
+                    if group.members.is_none() {
+                        group.members = Some(Vec::with_capacity(users.len()));
+                    }
+                    let members = group.members.as_mut().unwrap();
+
+                    for user in users {
+                        members.push(ScimGroupMember {
+                            value: user.user_id.to_string(),
+                            display: Some(user.user_email.to_string()),
+                        });
+                    }
+
+                    break;
+                }
+            }
+        } else if let Ok(replace) = op.try_as_replace_name() {
+            // Update / Replace the group name / externalId
+            for group in GROUPS.write().await.iter_mut() {
+                if group.id.as_deref() == Some(&id) {
+                    group.external_id = replace.external_id.to_string();
+                    group.display_name = replace.group_name.to_string();
+                    break;
+                }
+            }
+        } else if let Ok(users) = op.try_as_remove_member() {
+            // Remove users from group
+            for group in GROUPS.write().await.iter_mut() {
+                if group.id.as_deref() == Some(&id) {
+                    if group.members.is_none() {
+                        return Ok(());
+                    }
+
+                    let users = users.into_iter().map(|u| u.user_id).collect::<Vec<_>>();
+                    let members = group.members.as_mut().unwrap();
+                    members.retain(|u| !users.contains(&u.value.as_str()));
+                    break;
+                }
+            }
+        } else {
+            return Err(ScimError::new(400, Some("Invalid ScimPatchOp".into())));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn delete_group(Path(id): Path<String>) -> Result<(), ScimError> {
+    GROUPS
+        .write()
+        .await
+        .retain(|g| g.id.as_deref() != Some(&id));
+    Ok(())
+}
+
+async fn find_groups(start_index: u32, query: &ScimListQuery) -> Vec<ScimResource> {
+    // If any filter is given by Rauthy, usually a single result is expected
+    match query.filter_by() {
+        ScimFilterBy::ExternalId(id) => GROUPS
+            .read()
+            .await
+            .iter()
+            .filter_map(|u| {
+                if u.external_id == id {
+                    Some(ScimResource::Group(Box::new(u.clone())))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>(),
+        ScimFilterBy::UserName(_) => {
+            // Cannot happen for groups, only for user resources.
+            // In production, better return an Error instead of panic.
+            unreachable!()
+        }
+        ScimFilterBy::DisplayName(name) => GROUPS
+            .read()
+            .await
+            .iter()
+            .filter_map(|u| {
+                if u.display_name == name {
+                    Some(ScimResource::Group(Box::new(u.clone())))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>(),
+        ScimFilterBy::None => GROUPS
+            .read()
+            .await
+            .iter()
+            .skip(start_index as usize)
+            .take(query.count.unwrap_or(100) as usize)
+            .map(|u| ScimResource::Group(Box::new(u.clone())))
+            .collect::<Vec<_>>(),
+    }
+}
+
+async fn save_group(mut group: ScimGroup) -> Result<ScimGroup, ScimError> {
+    if let Some(id) = &group.id {
+        let mut res = None;
+        for g in GROUPS.write().await.iter_mut() {
+            if g.id.as_deref() == Some(id) {
+                g.external_id = group.external_id;
+                g.display_name = group.display_name;
+                // CAUTION: You MUST NOT update members here -> only doen via PatchOp!
+
+                res = Some(g.clone());
+                break;
+            }
+        }
+        if let Some(group) = res {
+            Ok(group)
+        } else {
+            Err(ScimError::new(404, Some("Group does not exist".into())))
+        }
+    } else {
+        group.id = Some(secure_random(32));
+        GROUPS.write().await.push(group.clone());
+        Ok(group)
+    }
+}

--- a/rauthy-client/examples/axum/src/scim/mod.rs
+++ b/rauthy-client/examples/axum/src/scim/mod.rs
@@ -1,0 +1,31 @@
+use crate::scim::groups::GROUPS;
+use crate::scim::users::USERS;
+use crate::templates::HTML_SCIM_DATA;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::Response;
+use std::fmt::Write;
+
+pub mod groups;
+pub mod users;
+
+pub async fn get_data() -> Response<String> {
+    let mut user_data = String::with_capacity(64);
+    for user in USERS.read().await.iter() {
+        writeln!(user_data, "<p>{:?}</p>", user).unwrap();
+    }
+
+    let mut group_data = String::with_capacity(64);
+    for group in GROUPS.read().await.iter() {
+        writeln!(group_data, "<p>{:?}</p>", group).unwrap();
+    }
+
+    Response::builder()
+        .status(200)
+        .header(CONTENT_TYPE, "text/html")
+        .body(
+            HTML_SCIM_DATA
+                .replace("{{ USERS }}", &user_data)
+                .replace("{{ GROUPS }}", &group_data),
+        )
+        .unwrap()
+}

--- a/rauthy-client/examples/axum/src/scim/users.rs
+++ b/rauthy-client/examples/axum/src/scim/users.rs
@@ -5,6 +5,7 @@ use rauthy_client::scim::types::{
 use rauthy_client::secure_random;
 use std::sync::LazyLock;
 use tokio::sync::RwLock;
+use tracing::info;
 
 // Very simple user storage - DO NOT do it like that in production, we just want to keep it simple.
 pub static USERS: LazyLock<RwLock<Vec<ScimUser>>> = LazyLock::new(|| RwLock::new(Vec::new()));
@@ -35,6 +36,7 @@ pub async fn get_users(query: ScimListQuery) -> Result<ScimListResponse, ScimErr
 }
 
 pub async fn post_user(user: ScimUser) -> Result<ScimUser, ScimError> {
+    info!("Create user {:?}", user);
     save_user(user).await
 }
 
@@ -51,6 +53,8 @@ pub async fn get_user(Path(id): Path<String>) -> Result<ScimUser, ScimError> {
 }
 
 pub async fn put_user(Path(id): Path<String>, mut user: ScimUser) -> Result<ScimUser, ScimError> {
+    info!("Update user {}: {:?}", id, user);
+
     // just overwrite the users id so we can re-use our simple logic
     user.id = Some(id);
     save_user(user).await

--- a/rauthy-client/examples/axum/src/scim/users.rs
+++ b/rauthy-client/examples/axum/src/scim/users.rs
@@ -1,0 +1,140 @@
+use axum::extract::Path;
+use rauthy_client::scim::types::{
+    ScimError, ScimFilterBy, ScimListQuery, ScimListResponse, ScimResource, ScimUser,
+};
+use rauthy_client::secure_random;
+use std::sync::LazyLock;
+use tokio::sync::RwLock;
+
+// Very simple user storage - DO NOT do it like that in production, we just want to keep it simple.
+pub static USERS: LazyLock<RwLock<Vec<ScimUser>>> = LazyLock::new(|| RwLock::new(Vec::new()));
+
+// All SCIM type extractors already validate the proper Content-Type and the SCIM bearer token.
+// This means if you end up in the request handler, the token has already been validated.
+
+/// A request to get "all" users. The `ScimListQuery` basically deinfes pagination and the
+/// expected results. Must always return a `ScimListResponse`.
+///
+/// By RFC, the `ScimListQuery` can include more fields, but Rauthy will only use `start_index` and
+/// `count`.
+pub async fn get_users(query: ScimListQuery) -> Result<ScimListResponse, ScimError> {
+    // The query index must be stable over time. For a real world implementation, a good idea would
+    // be to use something like a creation timestamp, that never changes.
+    let start_index = query.start_index.unwrap_or(0);
+
+    let resources = find_users(start_index, &query).await;
+    let len = resources.len() as u32;
+
+    Ok(ScimListResponse {
+        items_per_page: query.count.unwrap_or(len),
+        total_results: len,
+        start_index,
+        resources,
+        ..Default::default()
+    })
+}
+
+pub async fn post_user(user: ScimUser) -> Result<ScimUser, ScimError> {
+    save_user(user).await
+}
+
+pub async fn get_user(Path(id): Path<String>) -> Result<ScimUser, ScimError> {
+    match USERS
+        .read()
+        .await
+        .iter()
+        .find(|u| u.id.as_deref() == Some(&id))
+    {
+        Some(user) => Ok(user.clone()),
+        None => Err(ScimError::new(404, Some("User not found".into()))),
+    }
+}
+
+pub async fn put_user(Path(id): Path<String>, mut user: ScimUser) -> Result<ScimUser, ScimError> {
+    // just overwrite the users id so we can re-use our simple logic
+    user.id = Some(id);
+    save_user(user).await
+}
+
+pub async fn delete_user(Path(id): Path<String>) -> Result<(), ScimError> {
+    USERS.write().await.retain(|u| u.id.as_deref() != Some(&id));
+    Ok(())
+}
+
+async fn find_users(start_index: u32, query: &ScimListQuery) -> Vec<ScimResource> {
+    // If any filter is given by Rauthy, usually a single result is expected
+    match query.filter_by() {
+        ScimFilterBy::ExternalId(id) => USERS
+            .read()
+            .await
+            .iter()
+            .filter_map(|u| {
+                if u.external_id == id {
+                    Some(ScimResource::User(Box::new(u.clone())))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>(),
+        ScimFilterBy::UserName(name) => USERS
+            .read()
+            .await
+            .iter()
+            .filter_map(|u| {
+                if u.user_name == name {
+                    Some(ScimResource::User(Box::new(u.clone())))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>(),
+        ScimFilterBy::DisplayName(_) => {
+            // Cannot happen for users, only for group resources.
+            // In production, better return an Error instead of panic.
+            unreachable!()
+        }
+        ScimFilterBy::None => USERS
+            .read()
+            .await
+            .iter()
+            .skip(start_index as usize)
+            .take(query.count.unwrap_or(100) as usize)
+            .map(|u| ScimResource::User(Box::new(u.clone())))
+            .collect::<Vec<_>>(),
+    }
+}
+
+async fn save_user(mut user: ScimUser) -> Result<ScimUser, ScimError> {
+    if let Some(id) = &user.id {
+        let mut res = None;
+        for u in USERS.write().await.iter_mut() {
+            if u.id.as_deref() == Some(id) {
+                u.external_id = user.external_id;
+                u.user_name = user.user_name;
+                u.name = user.name;
+                u.display_name = user.display_name;
+                u.preferred_language = user.preferred_language;
+                u.locale = user.locale;
+                u.active = user.active;
+                u.emails = user.emails;
+                u.phone_numbers = user.phone_numbers;
+                u.photos = user.photos;
+                u.addresses = user.addresses;
+                // CAUTION: You MUST NOT upgrade any groups assignments here!
+                u.roles = user.roles;
+
+                res = Some(u.clone());
+                break;
+            }
+        }
+        if let Some(user) = res {
+            Ok(user)
+        } else {
+            Err(ScimError::new(404, Some("User does not exist".into())))
+        }
+    } else {
+        user.id = Some(secure_random(32));
+        USERS.write().await.push(user.clone());
+        Ok(user)
+    }
+}

--- a/rauthy-client/examples/axum/src/templates.rs
+++ b/rauthy-client/examples/axum/src/templates.rs
@@ -92,3 +92,18 @@ pub const HTML_CALLBACK: &str = r#"<!DOCTYPE html>
 </script>
 </html>
 "#;
+
+pub const HTML_SCIM_DATA: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SCIM Data</title>
+    <meta http-equiv="refresh" content="2">
+</head>
+<body>
+<p>This page will refresh every 2 seconds.</p>
+<div>{{ USERS }}</div>
+<div>{{ GROUPS }}</div>
+</body>
+</html>
+"#;

--- a/rauthy-client/examples/generic/Cargo.lock
+++ b/rauthy-client/examples/generic/Cargo.lock
@@ -1896,6 +1896,7 @@ dependencies = [
  "cached",
  "chacha20poly1305",
  "chrono",
+ "http 1.1.0",
  "jwt-simple",
  "rand 0.9.0",
  "reqwest",

--- a/rauthy-client/justfile
+++ b/rauthy-client/justfile
@@ -39,6 +39,7 @@ check: clippy-examples
     cargo minimal-versions check --features axum
     cargo minimal-versions check --features device-code
     cargo minimal-versions check --features userinfo
+    cargo minimal-versions check --features scim,axum
 
 # runs the full set of tests
 test test="":

--- a/rauthy-client/justfile
+++ b/rauthy-client/justfile
@@ -45,7 +45,7 @@ test test="":
     #!/usr/bin/env bash
     set -euxo pipefail
     clear
-    cargo test {{ test }}
+    cargo test --features scim {{ test }}
     echo All tests successful
 
 # builds the code

--- a/rauthy-client/src/backchannel_logout/logout_token.rs
+++ b/rauthy-client/src/backchannel_logout/logout_token.rs
@@ -14,7 +14,7 @@ static LOGOUT_TOKEN_ALLOWED_LIFETIME: u8 = 120;
 static LOGOUT_TOKEN_ALLOW_CLOCK_SKEW: u8 = 5;
 
 /// Logout Token for OIDC backchannel logout specified in
-/// https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken
+/// <https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken>
 #[derive(Debug, Serialize, Deserialize)]
 struct LogoutTokenRaw {
     // default claims
@@ -47,7 +47,7 @@ pub struct LogoutToken {
 
 impl LogoutToken {
     /// Parse and validate the token as specified in
-    /// https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation
+    /// <https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation>
     pub async fn from_str_validated(logout_token: &str) -> Result<Self, RauthyError> {
         let (header, lt_raw) = LogoutTokenRaw::build_from_str(logout_token)?;
         let kid = lt_raw.validate_claims(header)?;

--- a/rauthy-client/src/lib.rs
+++ b/rauthy-client/src/lib.rs
@@ -11,8 +11,16 @@
 //!
 //! # Features
 //!
-//! - `actix-web` will enable actix-web specific extractors and api
-//! - `axum` will enable axum specific extractors and api
+//! - `actix-web` enables actix-web specific extractors and api
+//! - `axum` enables axum specific extractors and api
+//! - `backchannel-logout` adds `LogoutToken` + validation functions for OIDC Backchannel Logout
+//! - `device-code` adds everything oyu need to the device code flow. This will most probably be
+//!   used without default features.
+//! - `qrcode` brings QR Code geneation in combination with the `device-code` feature
+//! - `scim` adds types and helpers to implement the client side of SCIM v2 in a Rauthy-compatible
+//!   way
+//! - `userinfo` adds additional types and helpers to easily fetch the `/userinfo` endpoint and
+//!   actively validate against it.
 
 use crate::provider::OidcProvider;
 use base64::{engine, engine::general_purpose, Engine as _};
@@ -50,6 +58,7 @@ pub mod token_set;
 
 pub mod rauthy_error;
 
+/// SCIM v2 types for full compatibility with Rauthy
 #[cfg(feature = "scim")]
 pub mod scim;
 

--- a/rauthy-client/src/lib.rs
+++ b/rauthy-client/src/lib.rs
@@ -50,6 +50,9 @@ pub mod token_set;
 
 pub mod rauthy_error;
 
+#[cfg(feature = "scim")]
+pub mod scim;
+
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const B64_URL_SAFE_NO_PAD: engine::GeneralPurpose = general_purpose::URL_SAFE_NO_PAD;

--- a/rauthy-client/src/oidc_config.rs
+++ b/rauthy-client/src/oidc_config.rs
@@ -25,6 +25,9 @@ pub struct RauthyConfig {
     /// If set to None, the client will be treated as a public client and not provide any
     /// secret to the /token endpoint after the callback. Set a secret for confidential clients.
     pub secret: Option<String>,
+    /// The Bearer token used for all SCIM operations.
+    #[cfg(feature = "scim")]
+    pub scim_token: String,
 }
 
 /// The claim selector which decides how a claim should be evaluated, based on the roles and groups.

--- a/rauthy-client/src/scim/axum.rs
+++ b/rauthy-client/src/scim/axum.rs
@@ -8,6 +8,7 @@ use axum::response::IntoResponse;
 use axum::response::Response;
 use http::header::CONTENT_TYPE;
 use http::request::Parts;
+use tracing::error;
 
 impl IntoResponse for ScimError {
     #[inline]
@@ -79,10 +80,13 @@ where
                     ))
                 }
             }
-            Err(err) => Err(ScimError::new(
-                400,
-                Some(format!("Cannot extract ScimUser from request body: {:?}", err).into()),
-            )),
+            Err(err) => {
+                error!("Cannot extract ScimUser from request body: {:?}", err);
+                Err(ScimError::new(
+                    400,
+                    Some(format!("Cannot extract ScimUser from request body: {:?}", err).into()),
+                ))
+            }
         }
     }
 }
@@ -109,10 +113,13 @@ where
                     ))
                 }
             }
-            Err(err) => Err(ScimError::new(
-                400,
-                Some(format!("Cannot extract ScimGroup from request body: {:?}", err).into()),
-            )),
+            Err(err) => {
+                error!("Cannot extract ScimGroup from request body: {:?}", err);
+                Err(ScimError::new(
+                    400,
+                    Some(format!("Cannot extract ScimGroup from request body: {:?}", err).into()),
+                ))
+            }
         }
     }
 }
@@ -125,6 +132,8 @@ where
 
     #[inline]
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        println!("in from request for ScimPatchOp");
+
         validate_scim_token(req.headers())?;
         is_content_type_scim(req.headers())?;
 
@@ -139,10 +148,13 @@ where
                     ))
                 }
             }
-            Err(err) => Err(ScimError::new(
-                400,
-                Some(format!("Cannot extract ScimPatchOp from request body: {:?}", err).into()),
-            )),
+            Err(err) => {
+                error!("Cannot extract ScimPatchOp from request body: {:?}", err);
+                Err(ScimError::new(
+                    400,
+                    Some(format!("Cannot extract ScimPatchOp from request body: {:?}", err).into()),
+                ))
+            }
         }
     }
 }

--- a/rauthy-client/src/scim/axum.rs
+++ b/rauthy-client/src/scim/axum.rs
@@ -176,21 +176,3 @@ where
         Ok(params)
     }
 }
-
-// impl<S> FromRequestParts<S> for ScimSearchRequest
-// where
-//     S: Send + Sync,
-// {
-//     type Rejection = ScimError;
-//
-//     #[inline]
-//     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-//         validate_scim_token(&parts.headers)?;
-//
-//         let params = match Query::<ScimSearchRequest>::from_request_parts(parts, state).await {
-//             Ok(params) => params.0,
-//             Err(_) => ScimSearchRequest::default(),
-//         };
-//         Ok(params)
-//     }
-// }

--- a/rauthy-client/src/scim/axum.rs
+++ b/rauthy-client/src/scim/axum.rs
@@ -1,0 +1,184 @@
+use crate::scim::types::{
+    ScimError, ScimGroup, ScimListQuery, ScimListResponse, ScimPatchOp, ScimUser,
+    SCIM_SCHEMA_GROUP, SCIM_SCHEMA_PATCH_OP, SCIM_SCHEMA_USER,
+};
+use crate::scim::{is_content_type_scim, validate_scim_token, CONTENT_TYPE_SCIM};
+use axum::extract::{FromRequest, FromRequestParts, Query, Request};
+use axum::response::IntoResponse;
+use axum::response::Response;
+use http::header::CONTENT_TYPE;
+use http::request::Parts;
+
+impl IntoResponse for ScimError {
+    #[inline]
+    fn into_response(self) -> Response {
+        Response::builder()
+            .status(self.status)
+            .header(CONTENT_TYPE, CONTENT_TYPE_SCIM)
+            .body(serde_json::to_string(&self).unwrap())
+            .unwrap()
+            .into_response()
+    }
+}
+
+impl IntoResponse for ScimListResponse {
+    #[inline]
+    fn into_response(self) -> Response {
+        Response::builder()
+            .status(200)
+            .header(CONTENT_TYPE, CONTENT_TYPE_SCIM)
+            .body(serde_json::to_string(&self).unwrap())
+            .unwrap()
+            .into_response()
+    }
+}
+
+impl IntoResponse for ScimGroup {
+    #[inline]
+    fn into_response(self) -> Response {
+        Response::builder()
+            .status(200)
+            .header(CONTENT_TYPE, CONTENT_TYPE_SCIM)
+            .body(serde_json::to_string(&self).unwrap())
+            .unwrap()
+            .into_response()
+    }
+}
+
+impl IntoResponse for ScimUser {
+    #[inline]
+    fn into_response(self) -> Response {
+        Response::builder()
+            .status(200)
+            .header(CONTENT_TYPE, CONTENT_TYPE_SCIM)
+            .body(serde_json::to_string(&self).unwrap())
+            .unwrap()
+            .into_response()
+    }
+}
+
+impl<S> FromRequest<S> for ScimUser
+where
+    S: Send + Sync,
+{
+    type Rejection = ScimError;
+
+    #[inline]
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        validate_scim_token(req.headers())?;
+        is_content_type_scim(req.headers())?;
+
+        match axum::extract::Json::<ScimUser>::from_request(req, state).await {
+            Ok(user) => {
+                if user.schemas.iter().any(|s| s == SCIM_SCHEMA_USER) {
+                    Ok(user.0)
+                } else {
+                    Err(ScimError::new(
+                        400,
+                        Some("Invalid Schema for ScimUser".into()),
+                    ))
+                }
+            }
+            Err(err) => Err(ScimError::new(
+                400,
+                Some(format!("Cannot extract ScimUser from request body: {:?}", err).into()),
+            )),
+        }
+    }
+}
+
+impl<S> FromRequest<S> for ScimGroup
+where
+    S: Send + Sync,
+{
+    type Rejection = ScimError;
+
+    #[inline]
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        validate_scim_token(req.headers())?;
+        is_content_type_scim(req.headers())?;
+
+        match axum::extract::Json::<ScimGroup>::from_request(req, state).await {
+            Ok(group) => {
+                if group.schemas.iter().any(|s| s == SCIM_SCHEMA_GROUP) {
+                    Ok(group.0)
+                } else {
+                    Err(ScimError::new(
+                        400,
+                        Some("Invalid Schema for ScimGroup".into()),
+                    ))
+                }
+            }
+            Err(err) => Err(ScimError::new(
+                400,
+                Some(format!("Cannot extract ScimGroup from request body: {:?}", err).into()),
+            )),
+        }
+    }
+}
+
+impl<S> FromRequest<S> for ScimPatchOp
+where
+    S: Send + Sync,
+{
+    type Rejection = ScimError;
+
+    #[inline]
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        validate_scim_token(req.headers())?;
+        is_content_type_scim(req.headers())?;
+
+        match axum::extract::Json::<ScimPatchOp>::from_request(req, state).await {
+            Ok(op) => {
+                if op.schemas.iter().any(|s| s == SCIM_SCHEMA_PATCH_OP) {
+                    Ok(op.0)
+                } else {
+                    Err(ScimError::new(
+                        400,
+                        Some("Invalid Schema for ScimPatchOp".into()),
+                    ))
+                }
+            }
+            Err(err) => Err(ScimError::new(
+                400,
+                Some(format!("Cannot extract ScimPatchOp from request body: {:?}", err).into()),
+            )),
+        }
+    }
+}
+
+impl<S> FromRequestParts<S> for ScimListQuery
+where
+    S: Send + Sync,
+{
+    type Rejection = ScimError;
+
+    #[inline]
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        validate_scim_token(&parts.headers)?;
+
+        let params = match Query::<ScimListQuery>::from_request_parts(parts, state).await {
+            Ok(query) => query.0,
+            Err(_) => ScimListQuery::default(),
+        };
+        Ok(params)
+    }
+}
+
+// impl<S> FromRequestParts<S> for ScimSearchRequest
+// where
+//     S: Send + Sync,
+// {
+//     type Rejection = ScimError;
+//
+//     #[inline]
+//     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+//         validate_scim_token(&parts.headers)?;
+//
+//         let params = match Query::<ScimSearchRequest>::from_request_parts(parts, state).await {
+//             Ok(params) => params.0,
+//             Err(_) => ScimSearchRequest::default(),
+//         };
+//         Ok(params)
+//     }
+// }

--- a/rauthy-client/src/scim/mod.rs
+++ b/rauthy-client/src/scim/mod.rs
@@ -2,7 +2,7 @@ use crate::provider::SCIM_TOKEN;
 use crate::scim::types::ScimError;
 use http::header::{AUTHORIZATION, CONTENT_TYPE};
 use http::HeaderMap;
-use tracing::{debug, error};
+use tracing::error;
 
 #[cfg(feature = "axum")]
 pub mod axum;
@@ -21,7 +21,7 @@ fn is_content_type_scim(headers: &HeaderMap) -> Result<(), ScimError> {
     if CONTENT_TYPE_SCIM == ct {
         Ok(())
     } else {
-        debug!("SCIM request with invalid Content-Type: {}", ct);
+        error!("SCIM request with invalid Content-Type: {}", ct);
         Err(ScimError::new(400, Some("Invalid Content-Type".into())))
     }
 }

--- a/rauthy-client/src/scim/mod.rs
+++ b/rauthy-client/src/scim/mod.rs
@@ -1,0 +1,57 @@
+use crate::provider::SCIM_TOKEN;
+use crate::scim::types::ScimError;
+use http::header::{AUTHORIZATION, CONTENT_TYPE};
+use http::HeaderMap;
+use tracing::{debug, error};
+
+#[cfg(feature = "axum")]
+pub mod axum;
+pub mod types;
+
+pub static CONTENT_TYPE_SCIM: &str = "application/scim+json";
+
+#[allow(unused)]
+#[inline]
+fn is_content_type_scim(headers: &HeaderMap) -> Result<(), ScimError> {
+    let Some(ct_val) = headers.get(CONTENT_TYPE) else {
+        return Err(ScimError::new(400, Some("Content-Type missing".into())));
+    };
+
+    let ct = ct_val.to_str().unwrap_or_default();
+    if CONTENT_TYPE_SCIM == ct {
+        Ok(())
+    } else {
+        debug!("SCIM request with invalid Content-Type: {}", ct);
+        Err(ScimError::new(400, Some("Invalid Content-Type".into())))
+    }
+}
+
+#[allow(unused)]
+#[inline]
+fn validate_scim_token(headers: &HeaderMap) -> Result<(), ScimError> {
+    let Some(auth_val) = headers.get(AUTHORIZATION) else {
+        error!("SCIM request no token");
+        return Err(ScimError::new(
+            400,
+            Some("Authorization header missing".into()),
+        ));
+    };
+    let Some(token) = auth_val
+        .to_str()
+        .unwrap_or_default()
+        .strip_prefix("Bearer ")
+    else {
+        error!("SCIM request with invalid Authorization header");
+        return Err(ScimError::new(
+            400,
+            Some("Invalid Authorization Header".into()),
+        ));
+    };
+
+    if token == SCIM_TOKEN.get().expect("OIDC Config not set up") {
+        Ok(())
+    } else {
+        error!("SCIM request with invalid token");
+        Err(ScimError::new(400, Some("Invalid Bearer Token".into())))
+    }
+}

--- a/rauthy-client/src/scim/types.rs
+++ b/rauthy-client/src/scim/types.rs
@@ -1,0 +1,510 @@
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+pub static SCIM_SCHEMA_ERROR: &str = "urn:ietf:params:scim:api:messages:2.0:Error";
+pub static SCIM_SCHEMA_GROUP: &str = "urn:ietf:params:scim:schemas:core:2.0:Group";
+pub static SCIM_SCHEMA_LIST_RESPONSE: &str = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+pub static SCIM_SCHEMA_PATCH_OP: &str = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+pub static SCIM_SCHEMA_USER: &str = "urn:ietf:params:scim:schemas:core:2.0:User";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimName {
+    // Note: We don't even want to send `formatted`, because it's duplicate data and therefore
+    // wasted bandwidth. The `formatted` can be built from all other existing values -> pointless!
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub formatted: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub family_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub given_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimAddress {
+    // Note: We don't even want to send `formatted`, because it's duplicate data and therefore
+    // wasted bandwidth. The `formatted` can be built from all other existing values -> pointless!
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub formatted: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub street_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locality: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub postal_code: Option<String>,
+    /// When specified, the value
+    /// MUST be in ISO 3166-1 "alpha-2" code format [ISO3166]; e.g.,
+    /// the United States and Sweden are "US" and "SE", respectively.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    // #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    // pub _type: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScimGroupValue {
+    /// Our group ID
+    pub value: String,
+    /// `_ref` MUST be the URI of the corresponding "Group"
+    /// resources to which the user belongs, basically the PUT URI.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub _ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ScimValue {
+    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary: Option<bool>,
+}
+
+/// A SCIM v2 User - values that Rauthy does not support are not added at all.
+/// Some implementations like e.g. aws have the following mandatory values:
+///   - `user_name`
+///   - `name.given_name`
+///   - `name.family_name`
+///   - `display_name`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimUser {
+    pub schemas: Vec<Cow<'static, str>>,
+    /// Our ID. Will be `None` for `Create` requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Rauthy's User ID
+    pub external_id: String,
+    pub user_name: String,
+    pub name: Option<ScimName>,
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferred_language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emails: Option<Vec<ScimValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone_numbers: Option<Vec<ScimValue>>,
+    /// For a Photo, the inner `value` should contain the `picture_uri`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub photos: Option<Vec<ScimValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub addresses: Option<Vec<ScimAddress>>,
+    /// `groups` are read-only and changes MUST be applied via the "Group Resource".
+    /// Any given groups via `/Users` requests MUST be ignored!
+    ///
+    /// Provide the current assignment when the User is returned from us though.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<ScimGroupValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roles: Option<Vec<ScimValue>>,
+}
+
+impl Default for ScimUser {
+    fn default() -> Self {
+        Self {
+            schemas: vec![SCIM_SCHEMA_USER.into()],
+            id: None,
+            external_id: String::default(),
+            user_name: String::default(),
+            name: Default::default(),
+            display_name: None,
+            preferred_language: None,
+            locale: None,
+            active: None,
+            emails: None,
+            phone_numbers: None,
+            photos: None,
+            addresses: None,
+            groups: None,
+            roles: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimGroup {
+    pub schemas: Vec<Cow<'static, str>>,
+    /// Our Group ID. Will be `None` for `Create` requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Rauthy's Group ID
+    pub external_id: String,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub members: Option<Vec<ScimGroupMember>>,
+}
+
+impl Default for ScimGroup {
+    fn default() -> Self {
+        ScimGroup {
+            schemas: vec![SCIM_SCHEMA_GROUP.into()],
+            id: None,
+            external_id: String::default(),
+            display_name: String::default(),
+            members: None,
+        }
+    }
+}
+
+/// We only allow Users to be members of groups, and not groups as group members.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimGroupMember {
+    pub value: String,
+    // /// `_ref` MUST be the URI of the corresponding "User"
+    // #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    // pub _ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+}
+
+// #[derive(Debug, Serialize, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// pub struct ScimSearchRequest {
+//     pub schemas: Vec<Cow<'static, str>>,
+//     #[serde(skip_serializing_if = "Option::is_none")]
+//     pub attributes: Option<Vec<String>>,
+//     #[serde(skip_serializing_if = "Option::is_none")]
+//     excluded_attributes: Option<Vec<String>>,
+//     pub filter: String,
+//     pub start_index: u32,
+//     pub count: u32,
+// }
+//
+// impl Default for ScimSearchRequest {
+//     fn default() -> Self {
+//         ScimSearchRequest {
+//             schemas: vec!["urn:ietf:params:scim:api:messages:2.0:SearchRequest".into()],
+//             attributes: None,
+//             excluded_attributes: None,
+//             filter: String::default(),
+//             start_index: 1,
+//             count: 100,
+//         }
+//     }
+// }
+
+#[derive(Debug, PartialEq)]
+pub enum ScimFilterBy<'a> {
+    ExternalId(&'a str),
+    UserName(&'a str),
+    DisplayName(&'a str),
+    None,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimListQuery {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_index: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub attributes: Option<String>,
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub excluded_attributes: Option<String>,
+}
+
+impl Default for ScimListQuery {
+    fn default() -> Self {
+        ScimListQuery {
+            filter: None,
+            start_index: Some(1),
+            count: Some(100),
+            // attributes: None,
+            // excluded_attributes: None,
+        }
+    }
+}
+
+impl ScimListQuery {
+    pub fn filter_by(&self) -> ScimFilterBy {
+        if self.filter.is_none() {
+            ScimFilterBy::None
+        } else {
+            let filter = self.filter.as_ref().map(|f| f.as_str()).unwrap_or_default();
+
+            if let Some(v) = filter.strip_prefix("externalId eq \"") {
+                ScimFilterBy::ExternalId(&v[..v.len() - 1])
+            } else if let Some(v) = filter.strip_prefix("userName eq \"") {
+                let stripped = &v[..v.len() - 1];
+                ScimFilterBy::UserName(stripped)
+            } else if let Some(v) = filter.strip_prefix("displayName eq \"") {
+                let stripped = &v[..v.len() - 1];
+                ScimFilterBy::DisplayName(stripped)
+            } else {
+                panic!("invalid filter type: {}", filter);
+            }
+        }
+    }
+}
+
+// #[derive(Serialize, Deserialize, Debug)]
+// pub struct ScimSchema {
+//     pub id: String,
+//     pub name: String,
+//     pub description: String,
+//     pub attributes: Vec<Attributes>,
+//     pub meta: Meta,
+// }
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum ScimResource {
+    User(Box<ScimUser>),
+    // Schema(Box<ScimSchema>),
+    Group(Box<ScimGroup>),
+    // ResourceType(Box<ScimResourceType>),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScimListResponse {
+    /// `["urn:ietf:params:scim:api:messages:2.0:ListResponse"]`
+    pub schemas: Vec<Cow<'static, str>>,
+    pub items_per_page: u32,
+    pub total_results: u32,
+    pub start_index: u32,
+    #[serde(rename = "Resources")]
+    pub resources: Vec<ScimResource>,
+}
+
+impl Default for ScimListResponse {
+    fn default() -> Self {
+        Self {
+            schemas: vec![SCIM_SCHEMA_LIST_RESPONSE.into()],
+            items_per_page: 0,
+            total_results: 0,
+            start_index: 0,
+            resources: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScimError {
+    /// `["urn:ietf:params:scim:api:messages:2.0:Error"]`
+    pub schemas: Vec<Cow<'static, str>>,
+    pub detail: Option<Cow<'static, str>>,
+    pub status: u16,
+}
+
+impl ScimError {
+    pub fn new(status: u16, detail: Option<Cow<'static, str>>) -> Self {
+        Self {
+            schemas: vec![SCIM_SCHEMA_ERROR.into()],
+            detail,
+            status,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScimPatchOp {
+    /// `urn:ietf:params:scim:api:messages:2.0:PatchOp`
+    pub schemas: Vec<Cow<'static, str>>,
+    #[serde(rename = "Operations")]
+    pub operations: Vec<ScimPatchOperations>,
+}
+
+impl Default for ScimPatchOp {
+    fn default() -> Self {
+        Self {
+            schemas: vec![SCIM_SCHEMA_PATCH_OP.into()],
+            operations: Vec::default(),
+        }
+    }
+}
+
+//
+// #[derive(Debug, Deserialize)]
+// pub struct ScimPatchOpWithPath {
+//     /// `urn:ietf:params:scim:api:messages:2.0:PatchOp`
+//     pub schemas: Vec<Cow<'static, str>>,
+//     #[serde(rename = "Operations")]
+//     pub operations: Vec<ScimPatchOperationsWithPath>,
+// }
+
+// impl Default for ScimPatchOpWithPath {
+//     fn default() -> Self {
+//         Self {
+//             schemas: vec![SCIM_SCHEMA_PATCH_OP.into()],
+//             operations: Vec::default(),
+//         }
+//     }
+// }
+
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ScimOp {
+    Add,
+    Remove,
+    Replace,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScimPatchOperations {
+    pub op: ScimOp,
+    pub path: Cow<'static, str>,
+    pub value: serde_json::Value,
+}
+
+impl ScimPatchOperations {
+    pub fn try_as_add_member(&self) -> Result<Vec<ScimOpAddMember>, ScimError> {
+        if self.op != ScimOp::Add || self.path.as_ref() != "members" {
+            return Err(ScimError::new(
+                400,
+                Some("Invalid input for ScimOp::Add".into()),
+            ));
+        }
+
+        if let serde_json::Value::Array(arr) = &self.value {
+            let mut res = Vec::with_capacity(arr.len());
+            for val in arr {
+                let Some(uid) = val.get("value") else {
+                    return Err(ScimError::new(
+                        400,
+                        Some("Missing `value` for ScimPatchOp".into()),
+                    ));
+                };
+                let Some(email) = val.get("display") else {
+                    return Err(ScimError::new(
+                        400,
+                        Some("Missing `display` for ScimPatchOp".into()),
+                    ));
+                };
+
+                res.push(ScimOpAddMember {
+                    user_id: uid.as_str().unwrap_or_default(),
+                    user_email: email.as_str().unwrap_or_default(),
+                })
+            }
+            return Ok(res);
+        }
+        Err(ScimError::new(
+            400,
+            Some("Cannot deserialize ScimPatchOp".into()),
+        ))
+    }
+
+    pub fn try_as_replace_name(&self) -> Result<ScimOpReplaceName, ScimError> {
+        if self.op != ScimOp::Replace {
+            return Err(ScimError::new(
+                400,
+                Some("Invalid input for ScimOp::Replace".into()),
+            ));
+        }
+
+        if let serde_json::Value::Object(map) = &self.value {
+            let Some(name) = map.get("displayName") else {
+                return Err(ScimError::new(
+                    400,
+                    Some("Missing `displayName` for ScimPatchOp".into()),
+                ));
+            };
+            let Some(ext_id) = map.get("externalId") else {
+                return Err(ScimError::new(
+                    400,
+                    Some("Missing `externalId` for ScimPatchOp".into()),
+                ));
+            };
+
+            return Ok(ScimOpReplaceName {
+                group_name: name.as_str().unwrap_or_default(),
+                external_id: ext_id.as_str().unwrap_or_default(),
+            });
+        }
+        Err(ScimError::new(
+            400,
+            Some("Cannot deserialize ScimPatchOp".into()),
+        ))
+    }
+
+    pub fn try_as_remove_member(&self) -> Result<Vec<ScimOpRemoveMember>, ScimError> {
+        if self.op != ScimOp::Remove || self.path.as_ref() != "members" {
+            return Err(ScimError::new(
+                400,
+                Some("Invalid input for ScimOp::Remove".into()),
+            ));
+        }
+
+        if let serde_json::Value::Array(arr) = &self.value {
+            let mut res = Vec::with_capacity(arr.len());
+            for val in arr {
+                let Some(uid) = val.get("value") else {
+                    return Err(ScimError::new(
+                        400,
+                        Some("Missing `value` for ScimPatchOp".into()),
+                    ));
+                };
+
+                res.push(ScimOpRemoveMember {
+                    user_id: uid.as_str().unwrap_or_default(),
+                })
+            }
+            return Ok(res);
+        }
+        Err(ScimError::new(
+            400,
+            Some("Cannot deserialize ScimPatchOp".into()),
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScimOpAddMember<'a> {
+    pub user_id: &'a str,
+    pub user_email: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScimOpReplaceName<'a> {
+    pub group_name: &'a str,
+    pub external_id: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ScimOpRemoveMember<'a> {
+    pub user_id: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_extract() {
+        let q = ScimListQuery {
+            filter: Some("externalId eq \"id123\"".to_string()),
+            start_index: None,
+            count: None,
+        };
+        assert_eq!(q.filter_by(), ScimFilterBy::ExternalId("id123"));
+
+        let q = ScimListQuery {
+            filter: Some("userName eq \"Batman\"".to_string()),
+            start_index: None,
+            count: None,
+        };
+        assert_eq!(q.filter_by(), ScimFilterBy::UserName("Batman"));
+
+        let q = ScimListQuery {
+            filter: Some("displayName eq \"Alfred\"".to_string()),
+            start_index: None,
+            count: None,
+        };
+        assert_eq!(q.filter_by(), ScimFilterBy::UserName("Alfred"));
+    }
+}

--- a/rauthy-client/src/scim/types.rs
+++ b/rauthy-client/src/scim/types.rs
@@ -168,32 +168,6 @@ pub struct ScimGroupMember {
     pub display: Option<String>,
 }
 
-// #[derive(Debug, Serialize, Deserialize)]
-// #[serde(rename_all = "camelCase")]
-// pub struct ScimSearchRequest {
-//     pub schemas: Vec<Cow<'static, str>>,
-//     #[serde(skip_serializing_if = "Option::is_none")]
-//     pub attributes: Option<Vec<String>>,
-//     #[serde(skip_serializing_if = "Option::is_none")]
-//     excluded_attributes: Option<Vec<String>>,
-//     pub filter: String,
-//     pub start_index: u32,
-//     pub count: u32,
-// }
-//
-// impl Default for ScimSearchRequest {
-//     fn default() -> Self {
-//         ScimSearchRequest {
-//             schemas: vec!["urn:ietf:params:scim:api:messages:2.0:SearchRequest".into()],
-//             attributes: None,
-//             excluded_attributes: None,
-//             filter: String::default(),
-//             start_index: 1,
-//             count: 100,
-//         }
-//     }
-// }
-
 #[derive(Debug, PartialEq)]
 pub enum ScimFilterBy<'a> {
     ExternalId(&'a str),
@@ -250,15 +224,6 @@ impl ScimListQuery {
         }
     }
 }
-
-// #[derive(Serialize, Deserialize, Debug)]
-// pub struct ScimSchema {
-//     pub id: String,
-//     pub name: String,
-//     pub description: String,
-//     pub attributes: Vec<Attributes>,
-//     pub meta: Meta,
-// }
 
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
@@ -327,24 +292,6 @@ impl Default for ScimPatchOp {
         }
     }
 }
-
-//
-// #[derive(Debug, Deserialize)]
-// pub struct ScimPatchOpWithPath {
-//     /// `urn:ietf:params:scim:api:messages:2.0:PatchOp`
-//     pub schemas: Vec<Cow<'static, str>>,
-//     #[serde(rename = "Operations")]
-//     pub operations: Vec<ScimPatchOperationsWithPath>,
-// }
-
-// impl Default for ScimPatchOpWithPath {
-//     fn default() -> Self {
-//         Self {
-//             schemas: vec![SCIM_SCHEMA_PATCH_OP.into()],
-//             operations: Vec::default(),
-//         }
-//     }
-// }
 
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -506,32 +453,5 @@ mod tests {
             count: None,
         };
         assert_eq!(q.filter_by(), ScimFilterBy::UserName("Alfred"));
-    }
-
-    #[test]
-    fn deserialize_patch_op() {
-        let s = r#"
-        {
-          "schemas": [
-            "urn:ietf:params:scim:api:messages:2.0:PatchOp"
-          ],
-          "Operations": [
-            {
-              "op": "add",
-              "path": "members",
-              "value": [
-                {
-                  "value": "BrbGMJJ9mcJnB7YyZVp0tbAtYlLXShZS",
-                  "display": "admin@localhost"
-                }
-              ]
-            }
-          ]
-        }"#;
-
-        let op: ScimPatchOp = serde_json::from_str(s).unwrap();
-        println!("{:?}", op);
-
-        assert_eq!(1, 2);
     }
 }

--- a/rauthy-client/src/scim/types.rs
+++ b/rauthy-client/src/scim/types.rs
@@ -36,7 +36,7 @@ pub struct ScimAddress {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub postal_code: Option<String>,
     /// When specified, the value
-    /// MUST be in ISO 3166-1 "alpha-2" code format [ISO3166]; e.g.,
+    /// MUST be in ISO 3166-1 "alpha-2" code format ISO3166; e.g.,
     /// the United States and Sweden are "US" and "SE", respectively.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub country: Option<String>,

--- a/rauthy-client/src/scim/types.rs
+++ b/rauthy-client/src/scim/types.rs
@@ -357,13 +357,13 @@ pub enum ScimOp {
 #[derive(Debug, Deserialize)]
 pub struct ScimPatchOperations {
     pub op: ScimOp,
-    pub path: Cow<'static, str>,
+    pub path: Option<String>,
     pub value: serde_json::Value,
 }
 
 impl ScimPatchOperations {
     pub fn try_as_add_member(&self) -> Result<Vec<ScimOpAddMember>, ScimError> {
-        if self.op != ScimOp::Add || self.path.as_ref() != "members" {
+        if self.op != ScimOp::Add || self.path.as_deref() != Some("members") {
             return Err(ScimError::new(
                 400,
                 Some("Invalid input for ScimOp::Add".into()),
@@ -433,7 +433,7 @@ impl ScimPatchOperations {
     }
 
     pub fn try_as_remove_member(&self) -> Result<Vec<ScimOpRemoveMember>, ScimError> {
-        if self.op != ScimOp::Remove || self.path.as_ref() != "members" {
+        if self.op != ScimOp::Remove || self.path.as_deref() != Some("members") {
             return Err(ScimError::new(
                 400,
                 Some("Invalid input for ScimOp::Remove".into()),
@@ -506,5 +506,32 @@ mod tests {
             count: None,
         };
         assert_eq!(q.filter_by(), ScimFilterBy::UserName("Alfred"));
+    }
+
+    #[test]
+    fn deserialize_patch_op() {
+        let s = r#"
+        {
+          "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+          ],
+          "Operations": [
+            {
+              "op": "add",
+              "path": "members",
+              "value": [
+                {
+                  "value": "BrbGMJJ9mcJnB7YyZVp0tbAtYlLXShZS",
+                  "display": "admin@localhost"
+                }
+              ]
+            }
+          ]
+        }"#;
+
+        let op: ScimPatchOp = serde_json::from_str(s).unwrap();
+        println!("{:?}", op);
+
+        assert_eq!(1, 2);
     }
 }

--- a/src/models/src/entity/clients_scim.rs
+++ b/src/models/src/entity/clients_scim.rs
@@ -260,7 +260,7 @@ impl ClientScim {
                 let err = res.json::<ScimError>().await?;
                 return Err(ErrorResponse::new(
                     ErrorResponseType::Scim,
-                    format!("SCIM GET /Groups errior: {:?}", err),
+                    format!("SCIM GET /Groups error: {:?}", err),
                 ));
             }
 

--- a/src/models/src/entity/scim_types.rs
+++ b/src/models/src/entity/scim_types.rs
@@ -63,7 +63,7 @@ pub struct ScimValue {
 }
 
 /// A SCIM v2 User - values that Rauthy does not support are not added at all.
-/// Some implementations like e.g. aws have the follwoing mandatory values:
+/// Some implementations like e.g. aws have the following mandatory values:
 ///   - `user_name`
 ///   - `name.given_name`
 ///   - `name.family_name`

--- a/src/models/src/entity/users.rs
+++ b/src/models/src/entity/users.rs
@@ -635,11 +635,6 @@ LIMIT $2"#;
                 .query_raw(sql, params!(last_created_ts, limit))
                 .await?;
             for mut row in rows {
-                let email_verified: bool = row.get("email_verified");
-                if !email_verified {
-                    continue;
-                }
-
                 let user = Self {
                     id: row.get("user_id"),
                     email: row.get("email"),
@@ -649,7 +644,7 @@ LIMIT $2"#;
                     roles: row.get("roles"),
                     groups: row.get("groups"),
                     enabled: row.get("enabled"),
-                    email_verified: true,
+                    email_verified: row.get("email_verified"),
                     password_expires: None,
                     created_at: row.get("created_at"),
                     last_login: None,
@@ -677,11 +672,6 @@ LIMIT $2"#;
             let rows = DB::pg_query_rows(sql, &[&last_created_ts, &(limit as i32)], limit as usize)
                 .await?;
             for row in rows {
-                let email_verified: bool = row.get("email_verified");
-                if !email_verified {
-                    continue;
-                }
-
                 let user = Self {
                     id: row.get("user_id"),
                     email: row.get("email"),
@@ -691,7 +681,7 @@ LIMIT $2"#;
                     roles: row.get("roles"),
                     groups: row.get("groups"),
                     enabled: row.get("enabled"),
-                    email_verified: true,
+                    email_verified: row.get("email_verified"),
                     password_expires: None,
                     created_at: row.get("created_at"),
                     last_login: None,


### PR DESCRIPTION
This PR brings the SCIM client side into the `rauthy-client` for easy usage when activating the new `scim` feature.

This is an incomplete SCIM impl on purpose to keep the complexity down. Only the Operations that Rauthy will use eventually are implemented to make everything work as expected.

For now, only API extractors for `axum` are added behind `scim` + `axum` feature.