### PR TITLE
use `jemalloc` on non-MSVC platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-web",
  "actix-web-prom",
@@ -3971,6 +3971,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spow",
+ "tikv-jemallocator",
  "tokio",
  "tokio-test",
  "tracing",
@@ -3980,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-api-types"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-web",
  "openssl",
@@ -3998,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-common"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-web",
  "argon2",
@@ -4026,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-error"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -4061,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-handlers"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -4092,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-middlewares"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4108,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-models"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "accept-language",
  "actix-multipart",
@@ -4180,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-notify"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "async-trait",
  "openssl",
@@ -4196,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-schedulers"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4216,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-service"
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 dependencies = [
  "actix-web",
  "chrono",
@@ -5436,6 +5437,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["src/*"]
 exclude = ["rauthy-client"]
 
 [workspace.package]
-version = "0.29.3"
+version = "0.29.4-20250514-jemalloc"
 edition = "2024"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"
@@ -108,6 +108,7 @@ serde_urlencoded = "0.7.1"
 spow = { version = "0.6", features = ["server"] }
 strum = { version = "0.27", features = ["derive"] }
 svg-hush = "0.9.4"
+tikv-jemallocator = "0.6"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing", "serde"] }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "tracing"] }
@@ -122,3 +123,5 @@ webauthn-rs = { version = "0.5", features = [
 ] }
 webauthn-rs-proto = "0.5"
 webpki-roots = "1"
+
+

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -34,6 +34,9 @@ tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }
+
 [dev-dependencies]
 rauthy-api-types = { path = "../api_types" }
 

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -23,6 +23,10 @@ use tokio::sync::mpsc;
 use tokio::time;
 use tracing::{debug, error, info};
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod dummy_data;
 mod logging;
 mod server;


### PR DESCRIPTION
After having done tests with different memory allocators, Rauthy will be changed to use `jemalloc` on all non-MSVC platforms.

I tested both `jemalloc` and `mimalloc` against the default `malloc`. `jemalloc` has been significantly faster then `malloc` while having slightly higher memory usage spikes, but with less heap memory used overall because of less memory fragmentation. `mimalloc` was even a tiny bit faster than `jemalloc`, but with way higher memory spikes, so the best option is `jemalloc`.

I will build a nightly image with `jemalloc` and do some real world tests. Local memory profiling during development does not show the whole story.