### PR TITLE
Fix: add DB migration to drop a possibly left-over legacy rauthy logo

### DIFF
--- a/migrations/hiqlite/13_remove_legacy_logo.sql
+++ b/migrations/hiqlite/13_remove_legacy_logo.sql
@@ -1,0 +1,8 @@
+-- Removes the left-over legacy rauthy logo for new deployments.
+-- This has been taken care of with version migrations programmatically,
+-- but has been forgotten for new deployments.
+DELETE
+FROM client_logos
+WHERE client_id = 'rauthy'
+  AND content_type = 'image/svg+xml'
+  AND data LIKE '%viewBox="0 0 512 138"%';


### PR DESCRIPTION
The old Rauthy logo is showing up for new deployments using Hiqlite and `v0.29`. The old logo has been delt with programmatically back then, when the new Logo was added with `0.28`, but a DB migration has been forgotten for later deployments like `0.29` now, when this temporary programmatic query does not exist anymore.

This adds a DB migration which will drop the logo. It may be the case, that users need to re-upload a custom logo, if they had a custom SVG now.

Merging this PR will be postponed until `0.30` to not have a breaking change now before any possible patch releases.