### PR TITLE
Feat: add `jemalloc` feature flag

### DIFF
--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[features]
+jemalloc = ["dep:tikv-jemallocator"]
+
 [dependencies]
 rauthy-common = { path = "../common" }
 rauthy-error = { path = "../error" }
@@ -37,7 +40,7 @@ tokio = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 rauthy-api-types = { path = "../api_types" }

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -23,9 +23,9 @@ use tokio::sync::mpsc;
 use tokio::time;
 use tracing::{debug, error, info};
 
-// #[cfg(not(target_env = "msvc"))]
-// #[global_allocator]
-// static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod dummy_data;
 mod logging;


### PR DESCRIPTION
Adds optional support for `jemalloc`.

For most use cases, the default `malloc` is more memory efficient than `jemalloc`. However, for instances with many users, it may be beneficial to custom compile Rauthy with the `jemalloc` feature enabled. This will use `jemalloc` as the global memory allocator. It uses more memory in idle or with low user counts (probably below 1000 users). However, depending on the scenario, I have seen up to 25% performance gains with `jemalloc`. This is especially true when allocating a lot of memory, which would happen for lots of concurrent requests.

This feature is disabled by default for now. `jemalloc` will not work on Windows MSVC targets.