### PR TITLE
Cleanup unnecessary `derive`s on different types

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,6 +17,7 @@ container_mailcrab := "rauthy-mailcrab"
 container_postgres := "rauthy-db-postgres"
 container_cargo_registry := "/usr/local/cargo/registry"
 file_test_pid := ".test_pid"
+jemalloc_conf := "JEMALLOC_SYS_WITH_MALLOC_CONF=abort_conf:true,narenas:8,tcache_max:2048,dirty_decay_ms:5000,muzzy_decay_ms:5000"
 postgres := "HIQLITE=false"
 
 [private]
@@ -349,7 +350,8 @@ build-profiling:
     set -euxo pipefail
     clear
     echo "Building a release build with the 'profiling' profile - this will take some time ..."
-    RUSTFLAGS=-g cargo build --profile profiling
+    #RUSTFLAGS=-g cargo build --profile profiling
+    RUSTFLAGS=-g {{ jemalloc_conf }} cargo build --profile profiling --features jemalloc
     echo "You can analyze the application via: heaptrack ./target/profiling/rauthy"
 
 # Build the final container image.

--- a/rauthy.cfg
+++ b/rauthy.cfg
@@ -515,7 +515,7 @@ HQL_LOG_STATEMENTS=true
 # travel through the Raft and have their own dedicated connection.
 #
 # default: 4
-#HQL_READ_POOL_SIZE=4
+HQL_READ_POOL_SIZE=4
 
 # Enables immediate flush + sync to disk after each Log Store Batch.
 # The situations where you would need this are very rare, and you

--- a/src/api/src/openapi.rs
+++ b/src/api/src/openapi.rs
@@ -191,7 +191,6 @@ use utoipa::{OpenApi, openapi};
             ErrorResponseType,
 
             ApiKeyRequest,
-            AuthCodeRequest,
             AuthRequest,
             BackchannelLogoutRequest,
             IpBlacklistRequest,

--- a/src/api_types/src/api_keys.rs
+++ b/src/api_types/src/api_keys.rs
@@ -33,7 +33,8 @@ pub struct ApiKeyAccess {
     pub access_rights: Vec<AccessRights>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ApiKeyRequest {
     /// Validation: `^[a-zA-Z0-9_-/]{2,24}$`
     #[validate(regex(path = "*RE_API_KEY", code = "^[a-zA-Z0-9_-/]{2,24}$"))]

--- a/src/api_types/src/api_keys.rs
+++ b/src/api_types/src/api_keys.rs
@@ -47,12 +47,12 @@ pub struct ApiKeyRequest {
     pub access: Vec<ApiKeyAccess>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct ApiKeysResponse {
     pub keys: Vec<ApiKeyResponse>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct ApiKeyResponse {
     pub name: String,
     /// Unix timestamp in seconds

--- a/src/api_types/src/auth_providers.rs
+++ b/src/api_types/src/auth_providers.rs
@@ -15,7 +15,7 @@ pub enum AuthProviderType {
     OIDC,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct ProviderRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\s]{2,128}]`
     #[validate(regex(path = "*RE_CLIENT_NAME", code = "[a-zA-Z0-9À-ɏ-\\s]{2,128}"))]
@@ -69,7 +69,7 @@ pub struct ProviderRequest {
     pub mfa_claim_value: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ProviderCallbackRequest {
     /// Validation: `[a-zA-Z0-9]`
@@ -86,7 +86,7 @@ pub struct ProviderCallbackRequest {
     pub pkce_verifier: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ProviderLoginRequest {
     // values for the downstream client
@@ -133,7 +133,7 @@ pub struct ProviderLoginRequest {
     pub pkce_challenge: String,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct ProviderLookupRequest {
     /// Validation: `[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]`
     #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]"))]
@@ -143,7 +143,7 @@ pub struct ProviderLookupRequest {
     pub metadata_url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct ProviderResponse {
     pub id: String,
     pub name: String,
@@ -170,7 +170,7 @@ pub struct ProviderResponse {
     pub client_secret_post: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct ProviderLinkedUserResponse {
     pub id: String,
     pub email: String,
@@ -185,7 +185,7 @@ impl From<tokio_postgres::Row> for ProviderLinkedUserResponse {
     }
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct ProviderLookupResponse {
     pub issuer: String,
     pub authorization_endpoint: String,

--- a/src/api_types/src/auth_providers.rs
+++ b/src/api_types/src/auth_providers.rs
@@ -69,7 +69,8 @@ pub struct ProviderRequest {
     pub mfa_claim_value: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ProviderCallbackRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
@@ -85,7 +86,8 @@ pub struct ProviderCallbackRequest {
     pub pkce_verifier: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ProviderLoginRequest {
     // values for the downstream client
     /// Validation: `email`

--- a/src/api_types/src/blacklist.rs
+++ b/src/api_types/src/blacklist.rs
@@ -3,7 +3,8 @@ use std::net::Ipv4Addr;
 use utoipa::ToSchema;
 use validator::Validate;
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct IpBlacklistRequest {
     /// Validation: Ipv4Addr
     #[schema(value_type = str)]

--- a/src/api_types/src/blacklist.rs
+++ b/src/api_types/src/blacklist.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 use utoipa::ToSchema;
 use validator::Validate;
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct IpBlacklistRequest {
     /// Validation: Ipv4Addr
@@ -16,12 +16,12 @@ pub struct IpBlacklistRequest {
     pub exp: i64,
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct BlacklistResponse {
     pub ips: Vec<BlacklistedIp>,
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct BlacklistedIp {
     pub ip: String,
     /// Unix timestamp in seconds

--- a/src/api_types/src/clients.rs
+++ b/src/api_types/src/clients.rs
@@ -9,7 +9,8 @@ use utoipa::ToSchema;
 use validator::Validate;
 
 // https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
-#[derive(Debug, Validate, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Validate, Deserialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct DynamicClientRequest {
     /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$>`
     #[validate(custom(function = "validate_vec_uri"))]
@@ -114,7 +115,8 @@ pub struct EphemeralClientRequest {
     pub id_token_signed_response_alg: Option<JwkKeyPairAlg>,
 }
 
-#[derive(Debug, Validate, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Validate, Deserialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewClientRequest {
     /// Validation: `^[a-z0-9-_/]{2,128}$`
     #[validate(regex(path = "*RE_LOWERCASE", code = "^[a-z0-9-_/]{2,128}$"))]
@@ -135,7 +137,8 @@ pub struct NewClientRequest {
     pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UpdateClientRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$`
     #[validate(regex(
@@ -196,7 +199,7 @@ pub struct UpdateClientRequest {
 }
 
 #[derive(Debug, Default, Validate, Deserialize, ToSchema)]
-#[cfg_attr(debug_assertions, derive(serde::Serialize))]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ClientSecretRequest {
     /// Validation: Value between 1 and 24
     #[validate(range(min = 1, max = 24))]
@@ -217,7 +220,8 @@ pub struct ScimClientRequestResponse {
     pub group_sync_prefix: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct ClientResponse {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -251,14 +255,16 @@ pub struct ClientResponse {
     pub scim: Option<ScimClientRequestResponse>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct ClientSecretResponse {
     pub id: String,
     pub confidential: bool,
     pub secret: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, PartialEq, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct DynamicClientResponse {
     pub client_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/api_types/src/clients.rs
+++ b/src/api_types/src/clients.rs
@@ -9,7 +9,7 @@ use utoipa::ToSchema;
 use validator::Validate;
 
 // https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
-#[derive(Debug, Validate, Deserialize, ToSchema)]
+#[derive(Validate, Deserialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct DynamicClientRequest {
     /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$>`
@@ -75,7 +75,7 @@ pub struct DynamicClientRequest {
 }
 
 /// This request is used for ephemeral clients, which are needed for Solid OIDC for instance.
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Serialize, Deserialize, Validate, ToSchema)]
 pub struct EphemeralClientRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$`
     #[validate(regex(
@@ -115,7 +115,7 @@ pub struct EphemeralClientRequest {
     pub id_token_signed_response_alg: Option<JwkKeyPairAlg>,
 }
 
-#[derive(Debug, Validate, Deserialize, ToSchema)]
+#[derive(Validate, Deserialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewClientRequest {
     /// Validation: `^[a-z0-9-_/]{2,128}$`
@@ -137,7 +137,7 @@ pub struct NewClientRequest {
     pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UpdateClientRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$`
@@ -198,7 +198,7 @@ pub struct UpdateClientRequest {
     pub scim: Option<ScimClientRequestResponse>,
 }
 
-#[derive(Debug, Default, Validate, Deserialize, ToSchema)]
+#[derive(Default, Validate, Deserialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ClientSecretRequest {
     /// Validation: Value between 1 and 24
@@ -206,7 +206,8 @@ pub struct ClientSecretRequest {
     pub cache_current_hours: Option<u8>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema, Validate)]
+#[derive(Serialize, Deserialize, ToSchema, Validate)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct ScimClientRequestResponse {
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$"))]
@@ -220,8 +221,8 @@ pub struct ScimClientRequestResponse {
     pub group_sync_prefix: Option<String>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
-#[cfg_attr(debug_assertions, derive(Deserialize))]
+#[derive(Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Debug, Deserialize))]
 pub struct ClientResponse {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -255,7 +256,7 @@ pub struct ClientResponse {
     pub scim: Option<ScimClientRequestResponse>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct ClientSecretResponse {
     pub id: String,
@@ -263,8 +264,8 @@ pub struct ClientSecretResponse {
     pub secret: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Serialize, ToSchema)]
-#[cfg_attr(debug_assertions, derive(Deserialize))]
+#[derive(PartialEq, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Debug, Deserialize))]
 pub struct DynamicClientResponse {
     pub client_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -288,7 +289,7 @@ pub struct DynamicClientResponse {
     pub post_logout_redirect_uri: Option<String>,
 
     // only Some(_) after new token has been issued
-    // TODO rotate on PUT
+    // TODO rotate on PUT?
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registration_access_token: Option<String>,
     // This is the uri for PUT requests from Self -> only provide if `registration_access_token`

--- a/src/api_types/src/cust_validation.rs
+++ b/src/api_types/src/cust_validation.rs
@@ -4,6 +4,7 @@ use rauthy_common::regex::{
 };
 use validator::ValidationError;
 
+#[inline]
 pub fn validate_vec_attr(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
 
@@ -23,6 +24,7 @@ pub fn validate_vec_attr(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_challenge(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
 
@@ -42,6 +44,7 @@ pub fn validate_vec_challenge(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_contact(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
@@ -55,6 +58,7 @@ pub fn validate_vec_contact(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_grant_types(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
 
@@ -74,6 +78,7 @@ pub fn validate_vec_grant_types(value: &[String]) -> Result<(), ValidationError>
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_origin(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
@@ -87,6 +92,7 @@ pub fn validate_vec_origin(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_uri(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
@@ -100,6 +106,7 @@ pub fn validate_vec_uri(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_grant_type(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
@@ -116,6 +123,7 @@ pub fn validate_vec_grant_type(value: &[String]) -> Result<(), ValidationError> 
 // validate_vec_groups, _roles and _scopes do the same thing but are 3 functions just to
 // be clear in the validation fields above that it does not create confusion, even if they
 // all use the same `RE_GROUPS` regex.
+#[inline]
 pub fn validate_vec_groups(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
@@ -129,6 +137,7 @@ pub fn validate_vec_groups(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_roles(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {
@@ -142,6 +151,7 @@ pub fn validate_vec_roles(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+#[inline]
 pub fn validate_vec_scopes(value: &[String]) -> Result<(), ValidationError> {
     let mut err = None;
     value.iter().for_each(|v| {

--- a/src/api_types/src/events.rs
+++ b/src/api_types/src/events.rs
@@ -32,7 +32,7 @@ pub enum EventType {
     ScimTaskFailed,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema, IntoParams)]
+#[derive(Deserialize, Validate, ToSchema, IntoParams)]
 pub struct EventsListenParams {
     /// Validation: `0 <= latest <= 1000`
     #[validate(range(min = 0, max = 1000))]
@@ -40,7 +40,7 @@ pub struct EventsListenParams {
     pub level: Option<EventLevel>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct EventsRequest {
     /// Unix timestamp in seconds
     #[validate(range(min = 1719784800))]
@@ -52,7 +52,7 @@ pub struct EventsRequest {
     pub typ: Option<EventType>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct EventResponse {
     pub id: String,
     pub timestamp: i64,

--- a/src/api_types/src/fed_cm.rs
+++ b/src/api_types/src/fed_cm.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct FedCMAssertionRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
@@ -25,7 +25,7 @@ pub struct FedCMAssertionRequest {
     pub disclosure_text_shown: bool,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema, IntoParams)]
+#[derive(Deserialize, Validate, ToSchema, IntoParams)]
 pub struct FedCMClientMetadataRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(

--- a/src/api_types/src/generic.rs
+++ b/src/api_types/src/generic.rs
@@ -4,20 +4,20 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
-#[derive(Debug, Deserialize, Validate, ToSchema, IntoParams)]
+#[derive(Deserialize, Validate, ToSchema, IntoParams)]
 pub struct EncKeyMigrateRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
     pub key_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(PartialEq, Eq, Deserialize)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct I18nRequest {
     pub content: I18nContent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(PartialEq, Eq, Deserialize)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 #[serde(rename_all = "camelCase")]
 pub enum I18nContent {
@@ -32,7 +32,7 @@ pub enum I18nContent {
     Register,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     En,
@@ -41,12 +41,12 @@ pub enum Language {
     Ko,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema, IntoParams)]
+#[derive(Deserialize, Validate, ToSchema, IntoParams)]
 pub struct LogoParams {
     pub updated: Option<i64>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema, IntoParams)]
+#[derive(Deserialize, Validate, ToSchema, IntoParams)]
 pub struct PaginationParams {
     pub page_size: Option<u16>,
     pub offset: Option<u16>,
@@ -58,7 +58,7 @@ pub struct PaginationParams {
     pub session_state: Option<SessionState>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasswordHashTimesRequest {
     #[validate(range(min = 500))]
@@ -69,7 +69,7 @@ pub struct PasswordHashTimesRequest {
     pub p_cost: Option<u32>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasswordPolicyRequest {
     /// Validation: `8 <= length_min <= 128`
@@ -98,7 +98,7 @@ pub struct PasswordPolicyRequest {
     pub not_recently_used: Option<i32>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct SearchParams {
     /// Data type
     pub ty: SearchParamsType,
@@ -110,7 +110,7 @@ pub struct SearchParams {
     pub limit: Option<u16>,
 }
 
-#[derive(Debug, PartialEq, Deserialize, ToSchema)]
+#[derive(PartialEq, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum SearchParamsIdx {
     // user params
@@ -122,14 +122,14 @@ pub enum SearchParamsIdx {
     Ip,
 }
 
-#[derive(Debug, PartialEq, Deserialize, ToSchema)]
+#[derive(PartialEq, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum SearchParamsType {
     User,
     Session,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct AppVersionResponse {
     pub current: String,
     pub last_check: Option<i64>,
@@ -138,33 +138,33 @@ pub struct AppVersionResponse {
     pub update_available: bool,
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct Argon2ParamsResponse {
     pub m_cost: u32,
     pub t_cost: u32,
     pub p_cost: u32,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct EncKeysResponse<'a> {
     pub active: &'a str,
     pub keys: Vec<&'a str>,
 }
 
-#[derive(Debug, Default, Serialize, ToSchema)]
+#[derive(Default, Serialize, ToSchema)]
 pub struct HealthResponse {
     pub db_healthy: bool,
     pub cache_healthy: bool,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct I18nConfigResponse {
     pub common: Vec<Language>,
     pub admin: Vec<Language>,
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct LoginTimeResponse {
     pub argon2_params: Argon2ParamsResponse,
     pub login_time: u32,

--- a/src/api_types/src/generic.rs
+++ b/src/api_types/src/generic.rs
@@ -11,12 +11,14 @@ pub struct EncKeyMigrateRequest {
     pub key_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct I18nRequest {
     pub content: I18nContent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 #[serde(rename_all = "camelCase")]
 pub enum I18nContent {
     Account,
@@ -56,7 +58,8 @@ pub struct PaginationParams {
     pub session_state: Option<SessionState>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasswordHashTimesRequest {
     #[validate(range(min = 500))]
     pub target_time: u32,
@@ -66,7 +69,8 @@ pub struct PasswordHashTimesRequest {
     pub p_cost: Option<u32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasswordPolicyRequest {
     /// Validation: `8 <= length_min <= 128`
     #[validate(range(min = 8, max = 128))]
@@ -141,7 +145,8 @@ pub struct Argon2ParamsResponse {
     pub p_cost: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct EncKeysResponse<'a> {
     pub active: &'a str,
     pub keys: Vec<&'a str>,
@@ -166,7 +171,8 @@ pub struct LoginTimeResponse {
     pub num_cpus: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct PasswordPolicyResponse {
     pub length_min: i32,
     pub length_max: i32,

--- a/src/api_types/src/groups.rs
+++ b/src/api_types/src/groups.rs
@@ -1,9 +1,10 @@
 use rauthy_common::regex::RE_GROUPS_ROLES_SCOPES;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use utoipa::ToSchema;
 use validator::Validate;
 
-#[derive(Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(serde::Serialize))]
 pub struct GroupRequest {
     /// Validation: `^[a-z0-9-_/,:*]{2,64}$`
     #[validate(regex(path = "*RE_GROUPS_ROLES_SCOPES", code = "^[a-z0-9-_/,:*]{2,64}$"))]

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -16,7 +16,7 @@ use time::OffsetDateTime;
 use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct AddressClaim {
     pub formatted: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,7 +30,7 @@ pub struct AddressClaim {
     pub country: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema, IntoParams)]
+#[derive(Deserialize, Validate, ToSchema, IntoParams)]
 pub struct AuthRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
@@ -69,19 +69,19 @@ fn default_scope() -> String {
     String::from("openid")
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Serialize, Deserialize, Validate, ToSchema)]
 pub struct BackchannelLogoutRequest {
     #[validate(regex(path = "*RE_BASE64"))]
     pub logout_token: String,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct PasswordResetResponse {
     pub csrf_token: String,
     pub password_policy: PasswordPolicyResponse,
 }
 
-#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[derive(Deserialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 #[serde(rename_all = "lowercase")]
 pub enum DeviceAcceptedRequest {
@@ -90,8 +90,8 @@ pub enum DeviceAcceptedRequest {
     Pending,
 }
 
-#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
-#[cfg_attr(debug_assertions, derive(Serialize))]
+#[derive(Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Clone, Serialize))]
 pub struct LoginRequest {
     /// Validation: `email`
     #[validate(email)]
@@ -131,7 +131,7 @@ pub struct LoginRequest {
     pub code_challenge_method: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct LoginRefreshRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
@@ -159,7 +159,7 @@ pub struct LoginRefreshRequest {
     pub code_challenge_method: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize, Validate, ToSchema, IntoParams)]
+#[derive(Default, Deserialize, Validate, ToSchema, IntoParams)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct LogoutRequest {
     /// Valid `id_token` issued by Rauthy to do an RP Initiated Logout.
@@ -182,7 +182,7 @@ pub struct LogoutRequest {
     pub logout_token: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct DeviceGrantRequest {
     /// Validation: `[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$`
@@ -196,7 +196,7 @@ pub struct DeviceGrantRequest {
     pub scope: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct DeviceVerifyRequest {
     /// Validation: `[a-zA-Z0-9]`
@@ -211,7 +211,7 @@ pub struct DeviceVerifyRequest {
     pub device_accepted: DeviceAcceptedRequest,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct TokenRequest {
     /// Validation: `^(authorization_code|client_credentials|urn:ietf:params:oauth:grant-type:device_code|password|refresh_token)$`
@@ -295,7 +295,7 @@ pub struct TokenValidationRequest {
     pub token: String,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct DeviceCodeResponse<'a> {
     pub device_code: &'a str,
     pub user_code: &'a str,
@@ -307,18 +307,19 @@ pub struct DeviceCodeResponse<'a> {
     pub interval: Option<u8>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct DeviceVerifyResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scopes: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct JktClaim<'a> {
     pub jkt: &'a str,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(PartialEq, Serialize, Deserialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub enum JwkKeyPairAlg {
     RS256,
     RS384,
@@ -344,7 +345,7 @@ impl Display for JwkKeyPairAlg {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub enum JwkKeyPairType {
     RSA,
     OKP,
@@ -356,7 +357,7 @@ impl Default for JwkKeyPairType {
     }
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct JWKSPublicKeyCerts {
     pub kty: JwkKeyPairType,
     pub alg: JwkKeyPairAlg,
@@ -372,19 +373,19 @@ pub struct JWKSPublicKeyCerts {
     pub x: Option<String>, // OKP
 }
 
-#[derive(Debug, Default, Serialize, ToSchema)]
+#[derive(Default, Serialize, ToSchema)]
 pub struct JWKSCerts {
     pub keys: Vec<JWKSPublicKeyCerts>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct OAuth2ErrorResponse<'a> {
     pub error: OAuth2ErrorTypeResponse,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_description: Option<Cow<'a, str>>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum OAuth2ErrorTypeResponse {
     InvalidRequest,
@@ -400,7 +401,7 @@ pub enum OAuth2ErrorTypeResponse {
     ExpiredToken,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct SessionInfoResponse<'a> {
     pub id: Cow<'a, str>,
@@ -423,7 +424,7 @@ pub struct SessionInfoResponse<'a> {
     pub state: SessionState,
 }
 
-#[derive(Debug, Default, Serialize, ToSchema)]
+#[derive(Default, Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct TokenInfo<'a> {
     pub active: bool,

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -64,28 +64,9 @@ pub struct AuthRequest {
     pub prompt: Option<String>,
 }
 
+#[inline]
 fn default_scope() -> String {
     String::from("openid")
-}
-
-// TODO is this not being used anymore? -> check!
-#[derive(Debug, Deserialize, Validate, ToSchema)]
-pub struct AuthCodeRequest {
-    /// Validation: `^[a-z0-9-_/]{2,128}$`
-    #[validate(regex(path = "*RE_LOWERCASE", code = "^[a-z0-9-_/]{2,128}$"))]
-    pub grant_type: String,
-    /// Validation: `[a-zA-Z0-9]`
-    #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
-    pub code: String,
-    /// Validation: `^[a-z0-9-_/]{2,128}$`
-    #[validate(regex(path = "*RE_LOWERCASE", code = "^[a-z0-9-_/]{2,128}$"))]
-    pub client_id: String,
-    /// Validation: `[a-zA-Z0-9]`
-    #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
-    pub client_secret: Option<String>,
-    /// Validation: `[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$`
-    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$"))]
-    pub redirect_uri: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
@@ -100,7 +81,8 @@ pub struct PasswordResetResponse {
     pub password_policy: PasswordPolicyResponse,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 #[serde(rename_all = "lowercase")]
 pub enum DeviceAcceptedRequest {
     Accept,
@@ -108,7 +90,8 @@ pub enum DeviceAcceptedRequest {
     Pending,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct LoginRequest {
     /// Validation: `email`
     #[validate(email)]
@@ -177,7 +160,7 @@ pub struct LoginRefreshRequest {
 }
 
 #[derive(Debug, Default, Deserialize, Validate, ToSchema, IntoParams)]
-#[cfg_attr(debug_assertions, derive(serde::Serialize))]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct LogoutRequest {
     /// Valid `id_token` issued by Rauthy to do an RP Initiated Logout.
     /// https://openid.net/specs/openid-connect-rpinitiated-1_0.html
@@ -199,7 +182,8 @@ pub struct LogoutRequest {
     pub logout_token: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct DeviceGrantRequest {
     /// Validation: `[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$"))]
@@ -212,7 +196,8 @@ pub struct DeviceGrantRequest {
     pub scope: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct DeviceVerifyRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
@@ -226,7 +211,8 @@ pub struct DeviceVerifyRequest {
     pub device_accepted: DeviceAcceptedRequest,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct TokenRequest {
     /// Validation: `^(authorization_code|client_credentials|urn:ietf:params:oauth:grant-type:device_code|password|refresh_token)$`
     #[validate(regex(
@@ -301,7 +287,8 @@ impl TokenRequest {
     }
 }
 
-#[derive(Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct TokenValidationRequest {
     /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%]+$"))]
@@ -413,7 +400,8 @@ pub enum OAuth2ErrorTypeResponse {
     ExpiredToken,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct SessionInfoResponse<'a> {
     pub id: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -435,7 +423,8 @@ pub struct SessionInfoResponse<'a> {
     pub state: SessionState,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Default, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct TokenInfo<'a> {
     pub active: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/api_types/src/roles.rs
+++ b/src/api_types/src/roles.rs
@@ -1,9 +1,10 @@
 use rauthy_common::regex::RE_GROUPS_ROLES_SCOPES;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use utoipa::ToSchema;
 use validator::Validate;
 
-#[derive(Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(serde::Serialize))]
 pub struct RoleRequest {
     /// Validation: `^[a-z0-9-_/,:*]{2,64}$`
     #[validate(regex(path = "*RE_GROUPS_ROLES_SCOPES", code = "^[a-z0-9-_/,:*]{2,64}$"))]

--- a/src/api_types/src/scopes.rs
+++ b/src/api_types/src/scopes.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
 
-#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ScopeRequest {
     /// Validation: `^[a-z0-9-_/,:*]{2,64}$`
@@ -18,7 +18,7 @@ pub struct ScopeRequest {
     pub attr_include_id: Option<Vec<String>>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct ScopeResponse {
     pub id: String,

--- a/src/api_types/src/scopes.rs
+++ b/src/api_types/src/scopes.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct ScopeRequest {
     /// Validation: `^[a-z0-9-_/,:*]{2,64}$`
     #[validate(regex(path = "*RE_GROUPS_ROLES_SCOPES", code = "^[a-z0-9-_/,:*]{2,64}$"))]
@@ -17,7 +18,8 @@ pub struct ScopeRequest {
     pub attr_include_id: Option<Vec<String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct ScopeResponse {
     pub id: String,
     pub name: String,

--- a/src/api_types/src/sessions.rs
+++ b/src/api_types/src/sessions.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(PartialEq, Serialize, Deserialize, ToSchema)]
 pub enum SessionState {
     Init,
     Auth,
@@ -9,7 +9,7 @@ pub enum SessionState {
     Unknown,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct SessionResponse<'a> {
     pub id: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/api_types/src/themes.rs
+++ b/src/api_types/src/themes.rs
@@ -3,7 +3,7 @@ use rauthy_error::{ErrorResponse, ErrorResponseType};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct ThemeCss {
     /// Validation: 3 HSL values: deg, sat, lum
     pub text: [u16; 3],
@@ -66,7 +66,7 @@ impl ThemeCss {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct ThemeRequestResponse {
     pub client_id: String,
     pub light: ThemeCss,

--- a/src/api_types/src/users.rs
+++ b/src/api_types/src/users.rs
@@ -9,13 +9,13 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct UserPictureConfig {
     pub upload_allowed: bool,
     pub content_len_limit: u32,
 }
 
-#[derive(Debug, Clone, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 pub struct DeviceRequest {
     /// Validation: `[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$`
     #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$"))]
@@ -35,7 +35,7 @@ pub struct MfaAwaitRequest {
     pub req_id: String,
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, ToSchema)]
+#[derive(PartialEq, Eq, Deserialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub enum MfaPurpose {
     Login(String),
@@ -44,7 +44,7 @@ pub enum MfaPurpose {
     Test,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewUserRequest {
     /// Validation: `email`
@@ -70,7 +70,7 @@ pub struct NewUserRequest {
     pub user_expires: Option<i64>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewUserRegistrationRequest {
     #[validate(email)]
@@ -89,7 +89,7 @@ pub struct NewUserRegistrationRequest {
     pub redirect_uri: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasskeyRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{1,32}`
@@ -97,7 +97,7 @@ pub struct PasskeyRequest {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasswordResetRequest {
     /// Validation: `[a-zA-Z0-9]{64}`
@@ -111,7 +111,7 @@ pub struct PasswordResetRequest {
     pub mfa_code: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct RequestResetRequest {
     /// Validation: `email`
@@ -122,7 +122,7 @@ pub struct RequestResetRequest {
     pub redirect_uri: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UpdateUserRequest {
     /// Validation: `email`
@@ -155,7 +155,7 @@ pub struct UpdateUserRequest {
     pub user_values: Option<UserValuesRequest>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UpdateUserSelfRequest {
     /// Validation: `email`
@@ -178,7 +178,7 @@ pub struct UpdateUserSelfRequest {
     pub user_values: Option<UserValuesRequest>,
 }
 
-#[derive(Debug, Default, PartialEq, Deserialize, Validate, ToSchema)]
+#[derive(Default, PartialEq, Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UserValuesRequest {
     /// Validation: `[0-9]{4}-[0-9]{2}-[0-9]{2}`
@@ -200,7 +200,7 @@ pub struct UserValuesRequest {
     pub country: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UserAttrConfigRequest {
     /// Validation: `^[a-zA-Z0-9-_/]{2,32}$`
@@ -211,7 +211,7 @@ pub struct UserAttrConfigRequest {
     pub desc: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UserAttrValueRequest {
     /// Validation: `^[a-zA-Z0-9-_/]{2,32}$`
@@ -220,20 +220,20 @@ pub struct UserAttrValueRequest {
     pub value: serde_json::Value,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UserAttrValuesUpdateRequest {
     #[validate(nested)]
     pub values: Vec<UserAttrValueRequest>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnAuthStartRequest {
     pub purpose: MfaPurpose,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnAuthFinishRequest {
     /// Validation: `[a-zA-Z0-9]{48}`
@@ -244,7 +244,7 @@ pub struct WebauthnAuthFinishRequest {
     pub data: webauthn_rs::prelude::PublicKeyCredential,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnRegStartRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{1,32}`
@@ -255,7 +255,7 @@ pub struct WebauthnRegStartRequest {
     pub magic_link_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnRegFinishRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{1,32}`
@@ -269,14 +269,14 @@ pub struct WebauthnRegFinishRequest {
     pub magic_link_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebIdRequest {
     pub custom_triples: Option<String>,
     pub expose_email: bool,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct DeviceResponse {
     pub id: String,
     pub client_id: String,
@@ -293,7 +293,7 @@ pub struct DeviceResponse {
     pub name: String,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct PasskeyResponse {
     pub name: String,
@@ -304,33 +304,33 @@ pub struct PasskeyResponse {
     pub user_verified: Option<bool>,
 }
 
-#[derive(Clone, Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrConfigValueResponse {
     pub name: String,
     pub desc: Option<String>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrConfigResponse {
     pub values: Vec<UserAttrConfigValueResponse>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrValueResponse {
     pub key: String,
     pub value: serde_json::Value,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrValuesResponse {
     pub values: Vec<UserAttrValueResponse>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct Userinfo {
     pub id: String,
@@ -374,7 +374,7 @@ pub struct Userinfo {
     pub webid: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 #[serde(rename_all = "snake_case")]
 pub enum UserAccountTypeResponse {
@@ -386,7 +386,7 @@ pub enum UserAccountTypeResponse {
     FederatedPassword,
 }
 
-#[derive(Clone, Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserResponse {
     pub id: String,
@@ -422,7 +422,7 @@ pub struct UserResponse {
     pub picture_id: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct UserResponseSimple {
     pub id: String,
     pub email: String,
@@ -447,7 +447,7 @@ impl From<tokio_postgres::Row> for UserResponseSimple {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, ToSchema)]
+#[derive(Default, Serialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserValuesResponse {
     pub birthdate: Option<String>,
@@ -458,14 +458,14 @@ pub struct UserValuesResponse {
     pub country: Option<String>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct WebId {
     pub user_id: String,
     pub expose_email: bool,
     pub custom_triples: Option<String>,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct WebIdResponse {
     pub webid: WebId,
     pub issuer: String,
@@ -475,7 +475,7 @@ pub struct WebIdResponse {
     pub language: Language,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct WebauthnAuthStartResponse {
     pub code: String,
     #[schema(value_type = str)]
@@ -484,12 +484,12 @@ pub struct WebauthnAuthStartResponse {
     pub exp: u64,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct WebauthnLoginFinishResponse {
     pub loc: String,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Serialize, ToSchema)]
 pub struct WebauthnLoginResponse {
     pub code: String,
     pub user_id: String,

--- a/src/api_types/src/users.rs
+++ b/src/api_types/src/users.rs
@@ -35,7 +35,8 @@ pub struct MfaAwaitRequest {
     pub req_id: String,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, PartialEq, Eq, Deserialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub enum MfaPurpose {
     Login(String),
     PasswordNew,
@@ -43,7 +44,8 @@ pub enum MfaPurpose {
     Test,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewUserRequest {
     /// Validation: `email`
     #[validate(email)]
@@ -68,7 +70,8 @@ pub struct NewUserRequest {
     pub user_expires: Option<i64>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewUserRegistrationRequest {
     #[validate(email)]
     pub email: String,
@@ -86,14 +89,16 @@ pub struct NewUserRegistrationRequest {
     pub redirect_uri: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasskeyRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{1,32}`
     #[validate(regex(path = "*RE_USER_NAME", code = "[a-zA-Z0-9À-ɏ-\\s]{1,32}"))]
     pub name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct PasswordResetRequest {
     /// Validation: `[a-zA-Z0-9]{64}`
     #[validate(regex(path = "*RE_ALNUM_64", code = "[a-zA-Z0-9]{64}"))]
@@ -106,7 +111,8 @@ pub struct PasswordResetRequest {
     pub mfa_code: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct RequestResetRequest {
     /// Validation: `email`
     #[validate(email)]
@@ -116,7 +122,8 @@ pub struct RequestResetRequest {
     pub redirect_uri: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UpdateUserRequest {
     /// Validation: `email`
     #[validate(email)]
@@ -193,7 +200,8 @@ pub struct UserValuesRequest {
     pub country: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UserAttrConfigRequest {
     /// Validation: `^[a-zA-Z0-9-_/]{2,32}$`
     #[validate(regex(path = "*RE_ATTR", code = "^[a-z0-9-_/]{2,32}$"))]
@@ -203,7 +211,8 @@ pub struct UserAttrConfigRequest {
     pub desc: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UserAttrValueRequest {
     /// Validation: `^[a-zA-Z0-9-_/]{2,32}$`
     #[validate(regex(path = "*RE_ATTR", code = "^[a-z0-9-_/]{2,32}$"))]
@@ -211,18 +220,21 @@ pub struct UserAttrValueRequest {
     pub value: serde_json::Value,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UserAttrValuesUpdateRequest {
     #[validate(nested)]
     pub values: Vec<UserAttrValueRequest>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnAuthStartRequest {
     pub purpose: MfaPurpose,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnAuthFinishRequest {
     /// Validation: `[a-zA-Z0-9]{48}`
     #[validate(regex(path = "*RE_ALNUM_48", code = "[a-zA-Z0-9]{48}"))]
@@ -232,7 +244,8 @@ pub struct WebauthnAuthFinishRequest {
     pub data: webauthn_rs::prelude::PublicKeyCredential,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnRegStartRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{1,32}`
     #[validate(regex(path = "*RE_USER_NAME", code = "[a-zA-Z0-9À-ɏ-\\s]{1,32}"))]
@@ -242,7 +255,8 @@ pub struct WebauthnRegStartRequest {
     pub magic_link_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebauthnRegFinishRequest {
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{1,32}`
     #[validate(regex(path = "*RE_USER_NAME", code = "[a-zA-Z0-9À-ɏ-\\s]{1,32}"))]
@@ -255,7 +269,8 @@ pub struct WebauthnRegFinishRequest {
     pub magic_link_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct WebIdRequest {
     pub custom_triples: Option<String>,
     pub expose_email: bool,
@@ -278,7 +293,8 @@ pub struct DeviceResponse {
     pub name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct PasskeyResponse {
     pub name: String,
     /// Unix timestamp in seconds
@@ -288,24 +304,28 @@ pub struct PasskeyResponse {
     pub user_verified: Option<bool>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrConfigValueResponse {
     pub name: String,
     pub desc: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrConfigResponse {
     pub values: Vec<UserAttrConfigValueResponse>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrValueResponse {
     pub key: String,
     pub value: serde_json::Value,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserAttrValuesResponse {
     pub values: Vec<UserAttrValueResponse>,
 }
@@ -354,7 +374,8 @@ pub struct Userinfo {
     pub webid: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 #[serde(rename_all = "snake_case")]
 pub enum UserAccountTypeResponse {
     New,
@@ -365,7 +386,8 @@ pub enum UserAccountTypeResponse {
     FederatedPassword,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Clone, Debug, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserResponse {
     pub id: String,
     pub email: String,
@@ -425,7 +447,8 @@ impl From<tokio_postgres::Row> for UserResponseSimple {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Default, Serialize, ToSchema)]
+#[cfg_attr(debug_assertions, derive(Deserialize))]
 pub struct UserValuesResponse {
     pub birthdate: Option<String>,
     pub phone: Option<String>,

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -99,7 +99,7 @@ pub static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     builder.build().unwrap()
 });
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub enum DbType {
     Postgres,
     Hiqlite,

--- a/src/models/src/entity/scopes.rs
+++ b/src/models/src/entity/scopes.rs
@@ -272,7 +272,6 @@ VALUES ($1, $2, $3, $4)"#,
         };
         let is_name_update = clients.is_some();
 
-        debug!("scope_req: {:?}", scope_req);
         // check configured custom attributes and clean them up
         let attrs = UserAttrConfigEntity::find_all_as_set().await?;
         let attr_include_access = Self::clean_up_attrs(scope_req.attr_include_access, &attrs);


### PR DESCRIPTION
#836

Clean up unnecessary `derive` impls and split into prod / dev to reduce release binary size.