### PR TITLE
Feat: User-Editable custom attributes

### DIFF
--- a/book/src/getting_started/docker.md
+++ b/book/src/getting_started/docker.md
@@ -54,7 +54,7 @@ accounts. It is an account like any other. The only reason it is a Rauthy admin,
 <code>rauthy_admin</code> role.
 
 If you like to test creating new accounts or password reset flows though, you need to have at least a minimal setup that
-is able to send E-Mails. The easiest way (work on localhost only) is the below `docker-compose.yaml`:
+is able to send E-Mails. The easiest way (works on localhost only) is the below `docker-compose.yaml`:
 
 ```
 networks:

--- a/frontend/src/i18n/admin/de.ts
+++ b/frontend/src/i18n/admin/de.ts
@@ -19,6 +19,13 @@ export let I18nAdminDe: I18nAdmin = {
         delete1: "Soll dieses Attribut wirklich gelöscht werden?",
         defaultValue: "Standard Wert",
         desc: "Beschreibung",
+        makeEditable: "Editierbar machen",
+        makeEditableP1: "Dieses Attribut kann durch Benutzer editierbar gemacht werden.",
+        makeEditableP2: `<b>ACHTUNG:</b> Diese Änderung kann niemals rückgängig gemacht werden! Jegliche Angaben durch
+            einen Benutzer direkt sind immer unvalidiert und dürfen NIEMALS für irgengeine Form von Authentifizierung 
+            oder Authorisierung genutzt werden!`,
+        makeEditableP3: `Ein Attribut kann deshalb niemals von editierbar zu nicht-editierbar gewandelt werden, weil
+            für eine gewisse Zeit, unabhängig von der Dauer, unvalidierte Eingaben erlaubt waren.`,
         name: "Attribut Name",
         userEditable: "Durch Benutzer Editierbar",
     },

--- a/frontend/src/i18n/admin/en.ts
+++ b/frontend/src/i18n/admin/en.ts
@@ -19,6 +19,12 @@ export let I18nAdminEn: I18nAdmin = {
         delete1: "Are you sure you want to delete this attribute?",
         defaultValue: "Default Value",
         desc: "Description",
+        makeEditable: "Make Editable",
+        makeEditableP1: "You can convert this attribute and make it editable by users themselves.",
+        makeEditableP2: `<b>CAUTION:</b> This can never be changed back! All inputs from a user directly are always
+            untrusted data and MUST NEVER be used for any form of authentication or authorization!`,
+        makeEditableP3: `An attribute cannot be changed from editable to non-editable, because it allowed untrusted
+            inputs in the past, no matter for how long this was the case.`,
         name: "Attribute Name",
         userEditable: "User Editable",
     },

--- a/frontend/src/i18n/admin/interface.ts
+++ b/frontend/src/i18n/admin/interface.ts
@@ -22,6 +22,11 @@ export interface I18nAdmin {
         delete1: string,
         defaultValue: string,
         desc: string,
+        makeEditable: string,
+        makeEditableP1: string,
+        // inserted as html
+        makeEditableP2: string,
+        makeEditableP3: string,
         name: string,
         userEditable: string,
     },

--- a/frontend/src/i18n/admin/ko.ts
+++ b/frontend/src/i18n/admin/ko.ts
@@ -17,6 +17,12 @@ export let I18nAdminKo: I18nAdmin = {
         delete1: "이 속성을 삭제하시겠습니까?",
         defaultValue: "Default Value",
         desc: "설명",
+        makeEditable: "Make Editable",
+        makeEditableP1: "You can convert this attribute and make it editable by users themselves.",
+        makeEditableP2: `<b>CAUTION:</b> This can never be changed back! All inputs from a user directly are always
+            untrusted data and MUST NEVER be used for any form of authentication or authorization!`,
+        makeEditableP3: `An attribute cannot be changed from editable to non-editable, because it allowed untrusted
+            inputs in the past, no matter for how long this was the case.`,
         name: "속성 이름",
         userEditable: "User Editable",
     },

--- a/frontend/src/lib/admin/attrs/AttrConfig.svelte
+++ b/frontend/src/lib/admin/attrs/AttrConfig.svelte
@@ -8,7 +8,8 @@
     import Form from "$lib5/form/Form.svelte";
     import type {UserAttrConfigRequest, UserAttrConfigValueResponse} from "$api/types/user_attrs.ts";
     import {PATTERN_ATTR, PATTERN_ATTR_DESC} from "$utils/patterns";
-    import InputCheckbox from "$lib/form/InputCheckbox.svelte";
+    import CheckIcon from "$lib/CheckIcon.svelte";
+    import {slide} from "svelte/transition";
 
     let {
         attr,
@@ -22,6 +23,8 @@
 
     const width = "20rem";
 
+    let refSubmit: undefined | HTMLButtonElement;
+
     let t = useI18n();
     let ta = useI18nAdmin();
 
@@ -33,14 +36,23 @@
     let defaultValue = $state(attr.default_value);
     let userEditable = $state(attr.user_editable || false);
 
+    let showMakeEditable = $state(false);
+
     $effect(() => {
         if (attr.name) {
             name = attr.name;
             desc = attr.desc;
             defaultValue = attr.default_value;
             userEditable = attr.user_editable || false;
+
+            showMakeEditable = false;
         }
     });
+
+    async function submitMakeEditable() {
+        userEditable = true;
+        refSubmit?.click();
+    }
 
     async function onSubmit(form: HTMLFormElement, params: URLSearchParams) {
         err = '';
@@ -92,19 +104,51 @@
             bind:value={defaultValue}
             autocomplete="off"
             label={ta.attrs.defaultValue}
-            placeholder="JSON Value"
+            placeholder={ta.attrs.defaultValue}
             {width}
     />
-    <!--    TODO this is not yet respected in the backend, but CRUD works-->
-    <!--    <InputCheckbox-->
-    <!--            ariaLabel={ta.attrs.userEditable}-->
-    <!--            bind:checked={userEditable}-->
-    <!--    >-->
-    <!--        {ta.attrs.userEditable}-->
-    <!--    </InputCheckbox>-->
+
+    <div class="editableRow">
+        <div class="flex gap-05">
+            {ta.attrs.userEditable}
+            <CheckIcon checked={userEditable}/>
+        </div>
+
+        {#if !userEditable}
+            <div class="editable">
+                <Button
+                        ariaLabel={ta.attrs.makeEditable}
+                        level={showMakeEditable ? 3 : 2}
+                        onclick={() => showMakeEditable = !showMakeEditable}
+                >
+                    {ta.attrs.makeEditable}
+                </Button>
+            </div>
+        {/if}
+    </div>
+
+    {#if !userEditable}
+        <div class="editable">
+            {#if showMakeEditable}
+                <div transition:slide={{ duration: 150 }}>
+                    <p>{ta.attrs.makeEditableP1}</p>
+                    <p class="err">{@html ta.attrs.makeEditableP2}</p>
+                    <p class="err">{ta.attrs.makeEditableP3}</p>
+
+                    <Button
+                            ariaLabel={ta.attrs.makeEditable}
+                            level={-1}
+                            onclick={submitMakeEditable}
+                    >
+                        {ta.attrs.makeEditable}
+                    </Button>
+                </div>
+            {/if}
+        </div>
+    {/if}
 
     <div class="btn">
-        <Button type="submit">
+        <Button type="submit" level={showMakeEditable ? 2 : 1} bind:ref={refSubmit}>
             {t.common.save}
         </Button>
 
@@ -126,5 +170,19 @@
         display: flex;
         gap: .5rem;
         align-items: center;
+    }
+
+    .editable {
+        margin-top: .5rem;
+    }
+
+    .editableRow {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+
+    .editableRow > .editable {
+        margin: .2rem 0 0 .5rem;
     }
 </style>

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -264,8 +264,13 @@ pub async fn put_cust_attr(
         .validate_api_key_or_admin_session(AccessGroup::UserAttributes, AccessRights::Update)?;
     payload.validate()?;
 
+    // Note: Even though in the Admin UI, a change from user-editable back to non-editable is
+    // not allowed at all, we do not check this condition here on purpose. The only reason is that
+    // we want to have at least the possibility to do this via an API call. The reason we only leave
+    // this option for direct API calls is that it should only be done with intention and not easily
+    // by clicking a button without thinking twice about the risks and implications.
+
     let entity = UserAttrConfigEntity::update(path.into_inner(), payload).await?;
-    debug!("entity after update: {:?}", entity);
 
     let clients_scim = ClientScim::find_with_attr_mapping(&entity.name).await?;
     if !clients_scim.is_empty() {


### PR DESCRIPTION
This PR will make it possible to make custom attributes optionally user-editable for self-service via the account dashboard.