### PR TITLE
fix windows build, add cross-env to package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "DEV_MODE=true vite dev",
-    "build": "DEV_MODE=false vite build",
+    "dev": "cross-env DEV_MODE=true vite dev",
+    "build": "cross-env DEV_MODE=false vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -30,7 +30,8 @@
     "vite": "^6.3.4",
     "vite-plugin-top-level-await": "^1.5.0",
     "vite-plugin-wasm": "^3.4.1",
-    "@swc/core": "^1.11.4"
+    "@swc/core": "^1.11.4",
+    "cross-env": "^7.0.3"
   },
   "type": "module"
 }


### PR DESCRIPTION
Because of the addition of setting env vars in front of the build command, it broke compiling under Windows.

https://www.npmjs.com/package/cross-env?activeTab=readme