### PR TITLE
Fix: encoding for EdDSA public key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-web",
  "actix-web-prom",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-api-types"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-web",
  "openssl",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-common"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-web",
  "argon2",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-error"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-handlers"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-jwt"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "chrono",
  "openssl",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-middlewares"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-models"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "accept-language",
  "actix-multipart",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-notify"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "async-trait",
  "openssl",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-schedulers"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-web",
  "chrono",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-service"
-version = "0.30.0"
+version = "0.30.1-20250612"
 dependencies = [
  "actix-web",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["src/*"]
 exclude = ["rauthy-client"]
 
 [workspace.package]
-version = "0.30.0"
+version = "0.30.1-20250612"
 edition = "2024"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/src/models/src/entity/jwk.rs
+++ b/src/models/src/entity/jwk.rs
@@ -386,7 +386,7 @@ impl JWKSPublicKey {
             }
             JwkKeyPairAlg::EdDSA => {
                 let key = ed25519_compact::SecretKey::from_der(&key_pair.bytes)?;
-                let x = base64_url_encode(&key.public_key().to_der());
+                let x = base64_url_encode(&key.public_key().as_slice());
                 Self {
                     kty: JwkKeyPairType::OKP,
                     alg: Some(key_pair.typ.clone()),


### PR DESCRIPTION
Small bugfix for the public JWKS.

After the recent rework of the whole JWT setup, the EdDSA public keys have been exposed incorrectly. They were base64 encoded DER format, when it should have been base64 encoded raw bytes. This made decoding the public keys in a client fail of course.