### PR TITLE
short pre-shutdown delay to smooth out rolling releases

### DIFF
--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -151,6 +151,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         server::server_without_metrics().await?;
     }
 
+    time::sleep(Duration::from_secs(3)).await;
     DB::hql().shutdown().await.unwrap();
 
     Ok(())


### PR DESCRIPTION
Short pre-shutdown delay to smooth out rolling releases inside K8s and give the replication a bit more safety margin during these.