### PR TITLE
rauthy-client: fix `LogoutToken.sub` not being deserialized correctly

### DIFF
--- a/rauthy-client/src/backchannel_logout/logout_token.rs
+++ b/rauthy-client/src/backchannel_logout/logout_token.rs
@@ -62,6 +62,7 @@ impl LogoutToken {
         )?;
 
         let mut lt = claims.custom;
+        lt.sub = claims.subject;
         lt.jti = claims.jwt_id;
 
         Ok(lt)


### PR DESCRIPTION
The `rauthy-client` has not been migrated to our own custom JWT implementation and the `sub` in LogoutTokens was sometimes not correctly deserialized, when there was no `sid`, becaue of the way `jwt-simple` works, which the client still uses.