### PR TITLE
Feat: TLS hot reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1876,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -2558,6 +2579,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2739,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,6 +2853,17 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -3027,6 +3099,31 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.9.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3796,11 +3893,13 @@ version = "0.30.3-20250619-fwd-auth-1"
 dependencies = [
  "actix-web",
  "actix-web-prom",
+ "arc-swap",
  "chrono",
  "dotenvy",
  "ed25519-compact",
  "flume",
  "josekit",
+ "notify",
  "num_cpus",
  "openssl",
  "openssl-sys",
@@ -3815,6 +3914,7 @@ dependencies = [
  "rauthy-models",
  "rauthy-schedulers",
  "rauthy-service",
+ "rauthy-tls",
  "regex",
  "reqwest",
  "ring",
@@ -4108,6 +4208,19 @@ dependencies = [
  "tokio",
  "tracing",
  "utoipa",
+]
+
+[[package]]
+name = "rauthy-tls"
+version = "0.30.3-20250619-fwd-auth-1"
+dependencies = [
+ "arc-swap",
+ "notify",
+ "rauthy-error",
+ "rustls",
+ "rustls-pemfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ actix-multipart = "0.7.2"
 actix-web = { version = "4", features = ["rustls-0_23"] }
 actix-web-lab = "0.24"
 actix-web-prom = "0.10"
+arc-swap = "1.7.1"
 askama = "0.14"
 argon2 = { version = "0.5", features = ["std", "zeroize"] }
 async-trait = "0.1.74"
@@ -74,6 +75,7 @@ lettre = { version = "0.11", default-features = false, features = [
 libflate = "2.1.0"
 mime = "0.3.17"
 mime_guess = "2"
+notify = "8.0.0"
 num_cpus = "1"
 openssl = { version = "0.10.72", features = ["vendored"] }
 openssl-sys = { version = "0.9.105", features = ["vendored"] }

--- a/config-local-test.toml
+++ b/config-local-test.toml
@@ -46,7 +46,7 @@ port_https = 8443
 scheme = 'https'
 pub_url = 'localhost:8443'
 http_workers = 1
-metrics_enable = true
+metrics_enable = false
 swagger_ui_enable = true
 
 [tls]

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -18,12 +18,15 @@ rauthy-middlewares = { path = "../middlewares" }
 rauthy-models = { path = "../models" }
 rauthy-schedulers = { path = "../schedulers" }
 rauthy-service = { path = "../service" }
+rauthy-tls = { path = "../tls" }
 
 actix-web = { workspace = true }
 actix-web-prom = { workspace = true }
+arc-swap = { workspace = true }
 chrono = { workspace = true }
 dotenvy = { workspace = true }
 flume = { workspace = true }
+notify = { workspace = true }
 num_cpus = { workspace = true }
 openssl = { workspace = true }
 openssl-sys = { workspace = true }

--- a/src/bin/src/tls.rs
+++ b/src/bin/src/tls.rs
@@ -1,54 +1,19 @@
 use rauthy_models::rauthy_config::RauthyConfig;
-use rustls_pemfile::Item;
-use rustls_pki_types::PrivateKeyDer;
-use std::io::BufReader;
-use std::iter;
-use tokio::fs;
-use tracing::error;
 
 /// Loads TLS key and cert file from disk and returns a `rustls::ServerConfig`
 pub async fn load_tls() -> rustls::ServerConfig {
     let paths = &RauthyConfig::get().vars.tls;
 
-    let key_path = paths.key_path.as_deref().unwrap_or("tls/tls.key");
-    let cert_path = paths.cert_path.as_deref().unwrap_or("tls/tls.crt");
+    let key_path = paths
+        .key_path
+        .as_deref()
+        .unwrap_or("tls/tls.key")
+        .to_string();
+    let cert_path = paths
+        .cert_path
+        .as_deref()
+        .unwrap_or("tls/tls.crt")
+        .to_string();
 
-    let key_file = fs::read(key_path)
-        .await
-        .expect("Cannot read TLS private key");
-    let key = if key_path.ends_with(".der") {
-        PrivateKeyDer::try_from(key_file).expect("TLS private key to be valid")
-    } else {
-        let mut reader = BufReader::new(key_file.as_slice());
-        let mut key = None;
-        for item in iter::from_fn(|| rustls_pemfile::read_one(&mut reader).transpose()).take(1) {
-            match item.unwrap() {
-                Item::Pkcs1Key(k) => {
-                    key = Some(PrivateKeyDer::Pkcs1(k));
-                }
-                Item::Pkcs8Key(k) => {
-                    key = Some(PrivateKeyDer::Pkcs8(k));
-                }
-                Item::Sec1Key(k) => {
-                    key = Some(PrivateKeyDer::Sec1(k));
-                }
-                _ => panic!("Expected a private PEM key in {}", key_path),
-            }
-        }
-        key.expect("no valid TLS private key found")
-    };
-
-    let certs_file = fs::read(cert_path)
-        .await
-        .expect("Cannot read TLS certificate");
-    let mut certs_reader = BufReader::new(certs_file.as_slice());
-    let cert_chain = rustls_pemfile::certs(&mut certs_reader)
-        .map(|cert| cert.expect("Invalid TLS certificate file"))
-        .collect();
-
-    rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .map_err(|err| error!("Error building rustls ServerConfig: {}", err))
-        .expect("bad certificate/key")
+    rauthy_tls::load_server_config(key_path, cert_path).await
 }

--- a/src/tls/Cargo.toml
+++ b/src/tls/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rauthy-tls"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+rauthy-error = { path = "../error" }
+
+arc-swap = { workspace = true }
+notify = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/src/tls/src/certified_key.rs
+++ b/src/tls/src/certified_key.rs
@@ -1,0 +1,174 @@
+use arc_swap::ArcSwap;
+use notify::event::CreateKind;
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use rauthy_error::{ErrorResponse, ErrorResponseType};
+use rustls::crypto::CryptoProvider;
+use rustls::pki_types::PrivateKeyDer;
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use rustls_pemfile::Item;
+use std::io::BufReader;
+use std::path::Path;
+use std::sync::Arc;
+use std::{fs, iter};
+use tokio::sync::Mutex;
+use tokio::task;
+use tracing::{error, info};
+
+#[derive(Debug)]
+pub struct CertifiedKeyWatched {
+    key_path: String,
+    cert_path: String,
+    cert_key: ArcSwap<CertifiedKey>,
+    watcher: Mutex<Option<RecommendedWatcher>>,
+}
+
+impl ResolvesServerCert for CertifiedKeyWatched {
+    fn resolve(&self, _: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        Some(self.cert_key.load_full())
+    }
+}
+
+impl CertifiedKeyWatched {
+    pub async fn new(key_path: String, cert_path: String) -> Result<Arc<Self>, ErrorResponse> {
+        let kp_cloned = key_path.clone();
+        let cp_cloned = cert_path.clone();
+        let cert_key = task::spawn_blocking(move || Self::try_load(&kp_cloned, &cp_cloned))
+            .await
+            .map_err(|err| ErrorResponse::new(ErrorResponseType::Internal, err.to_string()))??;
+
+        let slf = Arc::new(Self {
+            key_path,
+            cert_path,
+            cert_key: ArcSwap::new(cert_key),
+            watcher: Mutex::new(None),
+        });
+
+        let watcher = Self::watch_files(slf.clone())?;
+        *slf.watcher.lock().await = Some(watcher);
+
+        Ok(slf)
+    }
+
+    fn try_load(key_path: &str, cert_path: &str) -> Result<Arc<CertifiedKey>, ErrorResponse> {
+        let key_file = fs::read(key_path)?;
+        let key = if key_path.ends_with(".der") {
+            PrivateKeyDer::try_from(key_file).map_err(|err| {
+                ErrorResponse::new(
+                    ErrorResponseType::Internal,
+                    format!("Cannot load TLS key: {}", err),
+                )
+            })?
+        } else {
+            let mut reader = BufReader::new(key_file.as_slice());
+            let mut key = None;
+            for item in iter::from_fn(|| rustls_pemfile::read_one(&mut reader).transpose()).take(1)
+            {
+                match item? {
+                    Item::Pkcs1Key(k) => {
+                        key = Some(PrivateKeyDer::Pkcs1(k));
+                    }
+                    Item::Pkcs8Key(k) => {
+                        key = Some(PrivateKeyDer::Pkcs8(k));
+                    }
+                    Item::Sec1Key(k) => {
+                        key = Some(PrivateKeyDer::Sec1(k));
+                    }
+                    _ => panic!("Expected a private PEM key in {}", key_path),
+                }
+            }
+            match key {
+                None => {
+                    return Err(ErrorResponse::new(
+                        ErrorResponseType::Internal,
+                        "No TLS key found",
+                    ));
+                }
+                Some(k) => k,
+            }
+        };
+
+        let certs_file = fs::read(cert_path)?;
+        let mut certs_reader = BufReader::new(certs_file.as_slice());
+        let cert_chain = rustls_pemfile::certs(&mut certs_reader)
+            .filter_map(|res| match res {
+                Ok(cert) => Some(cert),
+                Err(err) => {
+                    error!("Error parsing certificate data: {:?}", err);
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let provider = CryptoProvider::get_default().expect("rustls CryptoProvider not installed");
+        let ck = CertifiedKey::from_der(cert_chain, key, provider).map_err(|err| {
+            ErrorResponse::new(
+                ErrorResponseType::Internal,
+                format!("Cannot build TLS CertifiedKey from Key + Cert: {:?}", err),
+            )
+        })?;
+        ck.keys_match().map_err(|err| {
+            ErrorResponse::new(
+                ErrorResponseType::Internal,
+                format!("TLS Key and Certificate don't match: {:?}", err),
+            )
+        })?;
+
+        Ok(Arc::new(ck))
+    }
+
+    fn watch_files(slf: Arc<Self>) -> Result<RecommendedWatcher, ErrorResponse> {
+        let key_path = slf.key_path.clone();
+        let cert_path = slf.cert_path.clone();
+
+        let mut watcher =
+            notify::recommended_watcher(move |res: notify::Result<notify::Event>| match res {
+                Ok(ev) => {
+                    let should_reload = matches!(
+                        ev.kind,
+                        EventKind::Create(CreateKind::File) | EventKind::Modify(_)
+                    );
+
+                    if should_reload {
+                        match Self::try_load(&slf.key_path, &slf.cert_path) {
+                            Ok(ck) => {
+                                info!("Reloading TLS Key + Certificates");
+                                slf.cert_key.store(ck);
+                            }
+                            Err(err) => {
+                                error!("Error loading TLS after file watch event: {:?}", err);
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!("File watch error: {:?}", err);
+                }
+            })
+            .map_err(|err| {
+                ErrorResponse::new(
+                    ErrorResponseType::Internal,
+                    format!("Cannot start File Watcher: {:?}", err),
+                )
+            })?;
+
+        watcher
+            .watch(Path::new(&key_path), RecursiveMode::NonRecursive)
+            .map_err(|err| {
+                ErrorResponse::new(
+                    ErrorResponseType::Internal,
+                    format!("Cannot watch path {}: {:?}", key_path, err),
+                )
+            })?;
+        watcher
+            .watch(Path::new(&cert_path), RecursiveMode::NonRecursive)
+            .map_err(|err| {
+                ErrorResponse::new(
+                    ErrorResponseType::Internal,
+                    format!("Cannot watch path {}: {:?}", cert_path, err),
+                )
+            })?;
+
+        Ok(watcher)
+    }
+}

--- a/src/tls/src/lib.rs
+++ b/src/tls/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright 2025 Sebastian Dobe <sebastiandobe@mailbox.org>
+
+#![forbid(unsafe_code)]
+
+use crate::certified_key::CertifiedKeyWatched;
+
+pub mod certified_key;
+
+/// Creates a `rustls::ServerConfig` with automatic hot-reloading of TLS certificates whenever
+/// the given `key_path` / `cert_path` are updated.
+pub async fn load_server_config(key_path: String, cert_path: String) -> rustls::ServerConfig {
+    let ck = match CertifiedKeyWatched::new(key_path, cert_path).await {
+        Ok(ck) => ck,
+        Err(err) => {
+            panic!("Cannot load TLS certificates: {:?}", err)
+        }
+    };
+
+    rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_cert_resolver(ck)
+}


### PR DESCRIPTION
fixes #1050 

Some crates already exist for TLS hot reloading `rustls` certificates, but I didn't like their design. All active projects I saw so far used locking and static variables. So, I built a better solution. It has a very slight overhead compared to statis TLS certificates which cannot be reloaded without a complete server restart and this solution does not use any locks when new connections requests come in. Only a single `Mutex` is used in one place, and that is only for convenience to not need any `static` variables or tricks like `mem::forget` for the file watching, because of a chicken-and-egg problem. The `Mutex` now only makes sure that we can actually drop the file watchers without needing to stop the process. This is unneeded for Rauthy, but I may just release this tiny hot-reload implemenation as an independent crate, since it will work with any `rustls` configuration.