### PR TITLE
Fix: Suspicious Request Catch + Block

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1770,7 +1770,7 @@ swagger_ui_enable = true
 #
 # default: 1440
 # overwritten by: SUSPICIOUS_REQUESTS_BLACKLIST
-blacklist = 1440
+blacklist = 5
 
 # Will emit a log with level of warning if a request to `/` has
 # been made that has not been caught by any of the usual routes

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -89,11 +89,11 @@ pub async fn server_with_metrics() -> std::io::Result<()> {
             .wrap(metrics_collector.clone())
             .service(oidc::get_well_known)
             .service(fed_cm::get_fed_cm_well_known)
-            .service(generic::catch_all)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first
             .wrap(RauthyIpBlacklistMiddleware)
-            .service(api_services());
+            .service(api_services())
+            .service(generic::catch_all);
 
         #[cfg(not(target_os = "windows"))]
         if matches!(
@@ -173,11 +173,11 @@ pub async fn server_without_metrics() -> std::io::Result<()> {
             .wrap(default_headers())
             .service(oidc::get_well_known)
             .service(fed_cm::get_fed_cm_well_known)
-            .service(generic::catch_all)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first
             .wrap(RauthyIpBlacklistMiddleware)
-            .service(api_services());
+            .service(api_services())
+            .service(generic::catch_all);
 
         #[cfg(not(target_os = "windows"))]
         if matches!(

--- a/src/service/src/suspicious_request_block.rs
+++ b/src/service/src/suspicious_request_block.rs
@@ -1,14 +1,14 @@
 const START_WITH_TARGETS: [&str; 10] = [
-    "../",
-    ".aws/",
-    ".env",
-    ".git/",
-    ".kube/",
-    ".ssh/",
-    "docker-compose",
-    "etc/",
-    "http",
-    "wp-",
+    "/../",
+    "/.aws/",
+    "/.env",
+    "/.git/",
+    "/.kube/",
+    "/.ssh/",
+    "/docker-compose",
+    "/etc/",
+    "/http",
+    "/wp",
 ];
 
 const ENDS_WITH_TARGETS: [&str; 8] = [


### PR DESCRIPTION
After the API layout and the whole internal config rework, the suspicious requests catch all handler stopped working. It simply did not catch the requests as expected.

This PR fixes this and adjusts everything to the new setting.