### PR TITLE
Reduce default `POW_DIFFICULTY` from `20` to `19`

### DIFF
--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -1683,9 +1683,9 @@ admin_force_mfa = true
 # This is currently only used for the user registration via UI.
 # The value must be between 10 and 99.
 #
-# default: 20
+# default: 19
 # overwritten by: POW_DIFFICULTY
-#difficulty = 20
+#difficulty = 19
 
 # The expiration duration in seconds for a PoW
 #

--- a/config.toml
+++ b/config.toml
@@ -1710,9 +1710,9 @@ admin_force_mfa = false
 # This is currently only used for the user registration via UI.
 # The value must be between 10 and 99.
 #
-# default: 20
+# default: 19
 # overwritten by: POW_DIFFICULTY
-difficulty = 20
+difficulty = 19
 
 # The expiration duration in seconds for a PoW
 #

--- a/src/models/src/rauthy_config.rs
+++ b/src/models/src/rauthy_config.rs
@@ -469,7 +469,7 @@ impl Default for Vars {
                 admin_force_mfa: true,
             },
             pow: VarsPow {
-                difficulty: 20,
+                difficulty: 19,
                 exp: 30,
             },
             scim: VarsScim {


### PR DESCRIPTION
The default difficulty for PoWs was `20` all the time. However, since PoWs have been added to the Login UI as well, where in case of a password-account, the clients needs to calculate 2 PoWs, the default was a bit too high for slower machines.
Therefore, the default difficulty was reduced to `19`, to compensate for the additional calculation during login.