### PR TITLE
Fix: change the way to allow vault insecure connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,18 +205,46 @@ a 2-minute window that allows modifications for MFA keys, like adding new ones a
 The ability to load the config file from a Vault source has been added. To do this, you need to provide the ENV var
 `USE_VAULT_CONFIG=true` and a `vault.toml` file, that contains the necessary information on how to connect and/or
 override the settings with ENV vars.
-If testing with unsecure connections (i.e. http://) one has to set this ENV var: `DEV_MODE=true`.
-
-`vault.toml` file:
 
 ```toml
 [vault]
-addr = 'http://127.0.0.1:8200'
-token = 'hvs....'
-mount = 'secret'
-path = 'rauthy_config'
-config_key = 'config.toml'
-kv_version = '2'
+
+# The full address to your vault including scheme and port
+#
+# default: <empty>
+# overwritten by: VAULT_ADDR
+addr = ''
+
+# The token that rauthy uses to access the secret
+#
+# default: <empty>
+# overwritten by: VAULT_TOKEN
+token = ''
+
+# Secret engine mount point
+#
+# default: <empty>
+# overwritten by: VAULT_MOUNT
+mount = ''
+
+# Path within the mount point containing the secret
+#
+# default: <empty>
+# overwritten by: VAULT_PATH
+path = ''
+
+# The key (name) of the secret
+#
+# default: <empty>
+# overwritten by: VAULT_CONFIG_KEY
+config_key = ''
+
+# KV Version that the secret engine uses.
+# Valid values are '1' or '2'.
+#
+# default: '2'
+# overwritten by: VAULT_KV_VERSION
+kv_version = ''
 
 # You can provide a root certificate bundle, if you
 # are running servers / clients Rauthy needs to connect
@@ -228,10 +256,16 @@ kv_version = '2'
 #-----BEGIN CERTIFICATE-----
 #...
 #-----END CERTIFICATE-----
-#-----BEGIN CERTIFICATE-----
-#....
-#-----END CERTIFICATE-----
 #"""
+
+# If you are testing locally with insecure connections,
+# you can set the following var to make it work.
+#
+# Note: This must be an ENV var and cannot be
+# given as a normal TOML value. It only exists here
+# for completeness / documentation.
+#
+#DANGER_VAULT_INSECURE=true
 ```
 
 [#1051](https://github.com/sebadob/rauthy/pull/1051)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,7 @@ kv_version = ''
 ```
 
 [#1051](https://github.com/sebadob/rauthy/pull/1051)
+[#1090](https://github.com/sebadob/rauthy/pull/1090)
 
 #### Bluesky / AT Protocol
 

--- a/src/models/src/vault_config.rs
+++ b/src/models/src/vault_config.rs
@@ -246,12 +246,7 @@ impl VaultSource {
     }
 
     fn http_client(&self) -> Result<Client, Box<dyn std::error::Error>> {
-        let mut dev_mode = false;
-        if let Ok(v) = env::var("DEV_MODE") {
-            if v == "true" {
-                dev_mode = true;
-            };
-        }
+        let insecure = env::var("DANGER_VAULT_INSECURE").as_deref() == Ok("true");
 
         let http_client = {
             let mut builder = reqwest::Client::builder()
@@ -259,8 +254,8 @@ impl VaultSource {
                 .timeout(Duration::from_secs(10))
                 .min_tls_version(tls::Version::TLS_1_2)
                 .user_agent(format!("Rauthy Client v{RAUTHY_VERSION}"))
-                .https_only(!dev_mode)
-                .danger_accept_invalid_certs(dev_mode)
+                .https_only(!insecure)
+                .danger_accept_invalid_certs(insecure)
                 .use_rustls_tls();
 
             if let Some(bundle) = self.root_ca_bundle.clone() {

--- a/vault.toml
+++ b/vault.toml
@@ -2,40 +2,39 @@
 
 # The full address to your vault including scheme and port
 #
+# default: <empty>
 # overwritten by: VAULT_ADDR
-# default: String::default
 addr = ''
 
 # The token that rauthy uses to access the secret
 #
+# default: <empty>
 # overwritten by: VAULT_TOKEN
-# default: String::default
 token = ''
 
 # Secret engine mount point
 #
+# default: <empty>
 # overwritten by: VAULT_MOUNT
-# default: String::default
 mount = ''
 
 # Path within the mount point containing the secret
 #
+# default: <empty>
 # overwritten by: VAULT_PATH
-# default: String::default
 path = ''
 
 # The key (name) of the secret
 #
+# default: <empty>
 # overwritten by: VAULT_CONFIG_KEY
-# default: String::default
 config_key = ''
 
 # KV Version that the secret engine uses.
 # Valid values are '1' or '2'.
 #
-# overwritten by: VAULT_KV_VERSION
 # default: '2'
-# example: kv_version='2'
+# overwritten by: VAULT_KV_VERSION
 kv_version = ''
 
 # You can provide a root certificate bundle, if you
@@ -48,7 +47,13 @@ kv_version = ''
 #-----BEGIN CERTIFICATE-----
 #...
 #-----END CERTIFICATE-----
-#-----BEGIN CERTIFICATE-----
-#....
-#-----END CERTIFICATE-----
 #"""
+
+# If you are testing locally with insecure connections,
+# you can set the following var to make it work.
+#
+# Note: This must be an ENV var and cannot be
+# given as a normal TOML value. It only exists here
+# for completeness / documentation.
+#
+#DANGER_VAULT_INSECURE=true


### PR DESCRIPTION
An end-user should never care about `DEV_MODE` env var to do anything. The value you need to set to allow insecure vault connections is now `DANGER_VAULT_INSECURE` to make it a lot clearer that this is dangerous and should never be used in production.