### PR TITLE
Feat: further improve login location checks

### DIFF
--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -1359,6 +1359,7 @@ pub async fn post_webauthn_auth_start(
 #[post("/users/{id}/webauthn/auth/finish")]
 pub async fn post_webauthn_auth_finish(
     id: web::Path<String>,
+    req: HttpRequest,
     Json(payload): Json<WebauthnAuthFinishRequest>,
 ) -> Result<HttpResponse, ErrorResponse> {
     payload.validate()?;
@@ -1370,7 +1371,7 @@ pub async fn post_webauthn_auth_finish(
     // This here will simply fail, if the secret code from the /start does not exist
     // -> indirect validation through exising code.
 
-    let res = webauthn::auth_finish(id, payload).await?;
+    let res = webauthn::auth_finish(id, &req, payload).await?;
     Ok(res.into_response())
 }
 


### PR DESCRIPTION
An additional improvement to Login location checks.

Locations are checked with each successful MFA auth request, even when it's a Test / Service request only. These can only be done with a valid session and they could highlight stolen session information, if for instance a users browser got compromised with all data stolen, and then the additional IP validation has been disabled.

Rauthy now also checks the login location after a password has been successfully compared, even if the account is secure further with MFA, which an attacker might not be able to break. It would not be a full account compromise and technically not a real login from a new location, but it would notify users about stolen passwords, so they can be changed, even if all of their data was untouched because of still working MFA.