### PR TITLE
Fix: UI theme overwrite

### DIFF
--- a/frontend/src/css/theme.css
+++ b/frontend/src/css/theme.css
@@ -14,7 +14,7 @@ body {
     --text-high: 200 15% 25%;
     --bg: 34 25% 97%;
     --bg-high: 34 20% 90%;
-    --action: 34 100% 59%;
+    --action: 34 100% 40%;
     --accent: 246 60% 53%;
     --error: 15 100% 37%;
 
@@ -42,6 +42,7 @@ Must be the same as in @media (prefers-color-scheme: dark) -> body
         --text-high: 34 7% 90%;
         --bg: 200 40% 6%;
         --bg-high: 200 20% 17%;
+        --action: 34 100% 59%;
         --btn-text: hsl(var(--bg));
     }
 }
@@ -80,6 +81,7 @@ Must be the same as in @media (prefers-color-scheme: dark) -> body
         --text-high: 200 15% 25%;
         --bg: 34 25% 97%;
         --bg-high: 34 20% 90%;
+        --action: 34 100% 40%;
         --btn-text: white;
     }
 }

--- a/frontend/src/lib/ThemeSwitch.svelte
+++ b/frontend/src/lib/ThemeSwitch.svelte
@@ -13,20 +13,16 @@
     let activeTheme = $derived(theme.isDark() ? 'dark' : 'light');
 
     $effect(() => {
-        const mediaPref = window?.matchMedia?.('(prefers-color-scheme:dark)')?.matches ?? false;
+        const mediaPrefDark = window?.matchMedia?.('(prefers-color-scheme:dark)')?.matches ?? false;
 
         if (theme.isDark() === undefined) {
-            const darkModeSaved = window?.localStorage?.getItem(storageIdx);
-            if (darkModeSaved) {
-                let newValue = "true" === darkModeSaved;
-                if (theme.isDark() === mediaPref) {
-                    localStorage.removeItem(storageIdx);
-                }
-                theme.setIsDark(newValue);
-                // darkMode = newValue;
+            const modeSaved = window?.localStorage?.getItem(storageIdx);
+            if (modeSaved === 'dark') {
+                theme.setIsDark(true);
+            } else if (modeSaved === 'light') {
+                theme.setIsDark(false);
             } else {
-                theme.setIsDark(mediaPref);
-                // darkMode = mediaPref;
+                theme.setIsDark(mediaPrefDark);
             }
         } else if (theme.isDark()) {
             document.body.classList.remove("theme-light");
@@ -36,11 +32,7 @@
             document.body.classList.add("theme-light");
         }
 
-        if (mediaPref === theme.isDark()) {
-            localStorage.removeItem(storageIdx);
-        } else {
-            localStorage.setItem(storageIdx, 'true');
-        }
+        localStorage.setItem(storageIdx, theme.isDark() ? 'dark' : 'light');
     });
 
     function toggle() {


### PR DESCRIPTION
Permanently overwriting the theme in the UI via the theme switcher button was not working as expected under certain conditions. The value has not been persisted correctly in some cases.

This PR fixes the overwriting of otherwise set system prefs and actually persists them between reloads.