### PR TITLE
Fix: RS256 key modulus

### DIFF
--- a/src/models/src/entity/jwk.rs
+++ b/src/models/src/entity/jwk.rs
@@ -178,7 +178,7 @@ impl JWKS {
         // RSA256
         let jwk_plain = web::block(|| {
             let mut rng = rand_08::thread_rng();
-            rsa::RsaPrivateKey::new(&mut rng, 2028)
+            rsa::RsaPrivateKey::new(&mut rng, 2048)
                 .unwrap()
                 .to_pkcs8_der()
                 .unwrap()


### PR DESCRIPTION
Rauthy accidentially generated 2028 bit keys for RS256 RSA keys instead of 2048.

fixes #1123