### PR TITLE
Add an MVP Helm chart for using Rauthy in k8s.

### DIFF
--- a/charts/rauthy/Chart.yaml
+++ b/charts/rauthy/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: rauthy
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "latest"

--- a/charts/rauthy/templates/NOTES.txt
+++ b/charts/rauthy/templates/NOTES.txt
@@ -1,0 +1,28 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "rauthy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "rauthy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "rauthy.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "rauthy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{ if .Release.IsInstall }}
+Extract your secrets from the "{{ (include "rauthy.fullname" .) }}-config" secret in the "{{.Release.Namespace}}" namespace to extract secrets.
+
+$ (kubectl get -n "{{.Release.Namespace}}" secret "{{ (include "rauthy.fullname" .) }}-config" \
+  --output=template --template='{{`{{`}} index .data "config.toml" {{`}}`}}' \
+  | base64 -d && echo )
+
+{{- end }}

--- a/charts/rauthy/templates/_config_helpers.tpl
+++ b/charts/rauthy/templates/_config_helpers.tpl
@@ -1,0 +1,10 @@
+{{- define "rauthy.hostnameByIndex" }}
+{{- $ := (index . 0) }}
+{{- $i := (index . 1) }}
+{{- printf "%s-%d.%s-headless.%s" (include "rauthy.fullname" $) ($i) (include "rauthy.fullname" $) ($.Release.Namespace) }}
+{{- end }}
+
+{{- define "rauthy.hostRaftSyncPortsByIndex" }}
+{{- $ := (index . 0) }}
+{{- include "rauthy.hostnameByIndex" . }}:{{ $.Values.service.hiqliteRaftPort }} {{ include "rauthy.hostnameByIndex" . }}:{{ $.Values.service.hiqliteAPIPort }}
+{{- end }}

--- a/charts/rauthy/templates/_helpers.tpl
+++ b/charts/rauthy/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rauthy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rauthy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rauthy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rauthy.labels" -}}
+helm.sh/chart: {{ include "rauthy.chart" . }}
+{{ include "rauthy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Config secret name
+*/}}
+{{- define "rauthy.configSecretName" -}}
+{{- if .Values.configSecretNameOverride }}
+{{ .Values.configSecretNameOverride }}
+{{- else }}
+{{- default (include "rauthy.fullname" .) .Values.serviceAccount.name }}-config
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rauthy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rauthy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rauthy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rauthy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/rauthy/templates/configsecret.yaml
+++ b/charts/rauthy/templates/configsecret.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.config.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rauthy.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  config.toml: |-
+    {{ with .Values.config.bootstrap -}}
+    [bootstrap]
+      admin_email="{{ $.Values.adminEmail }}"
+      password_plain="{{ .password_plain }}"
+    {{ end -}}
+    
+    [cluster]
+      node_id_from="k8s"
+      node_id=1
+      nodes= [
+    {{- range $i := (until (.Values.replicaCount | int)) }}
+        "{{ add $i  1}} {{ include "rauthy.hostRaftSyncPortsByIndex" (list $ $i) }}",
+    {{- end }}
+      ]
+      secret_raft=
+      {{- with .Values.config.cluster.secret_raft -}}
+        "{{ . }}"
+      {{- else -}}
+        "{{ randAlphaNum 48 }}"
+      {{- end }}
+      secret_api=
+      {{- with .Values.config.cluster.secret_api -}}
+        "{{ . }}"
+      {{- else -}}
+        "{{ randAlphaNum 48 }}"
+      {{- end }}
+    
+    [email]
+      rauthy_admin_email="{{ .Values.adminEmail }}"
+      smtp_url="{{ .Values.config.email.smtp_host }}"
+      smtp_port={{ .Values.config.email.smtp_port }}
+      danger_insecure={{ .Values.config.email.danger_insecure }}
+    
+    [encryption]
+    {{- with .Values.config.encryption.keys }}
+    {{- range . }}
+      keys=[
+        "{{ . }}",
+      ]
+      key_active="{{ $.Values.config.encryption.key_active }}"
+    {{- end }}
+    {{- else }}
+    {{- $key_id := ( printf "Auto%s" ( now | date "20060102T150405" ) ) }}
+      keys=[
+        "{{ $key_id }}/{{ randBytes 32 }}",
+      ]
+      key_active="{{ $key_id }}"
+    {{- end }}
+    
+    [hashing]
+      argon2_m_cost=131072
+      argon2_t_cost=4
+      argon2_p_cost=8
+      max_hash_threads=2
+    
+    [mfa]
+      admin_force_mfa = false
+    
+    [server]
+      port_http={{ .Values.config.server.port_http }}
+      port_https={{ .Values.config.server.port_https }}
+    {{- if .Values.config.server.port_https }}
+      scheme="http_https"
+    {{- else }}
+      scheme="http"
+    {{- end }}
+    {{- with index .Values.ingress.hosts }}
+      pub_url="{{ (first .).host }}"
+    {{- end }}
+      proxy_mode=true
+      trusted_proxies=[
+    {{- range .Values.config.server.trusted_proxies }}
+        "{{ . }}",
+    {{- end }}
+      ]
+      swagger_ui_enable={{ .Values.config.server.swagger_enable }}
+    
+    [[templates]]
+      lang="en"
+      typ="password_new"
+    
+    [tls]
+      cert_path="tls/cert-chain.pem"
+      key_path="tls/key.pem"
+    
+    [webauthn]
+      rp_id="{{ .Values.webauthn.rp_id }}"
+      rp_origin="{{ .Values.webauthn.rp_origin }}"
+{{- end }}

--- a/charts/rauthy/templates/hpa.yaml
+++ b/charts/rauthy/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "rauthy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/rauthy/templates/ingress.yaml
+++ b/charts/rauthy/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.hosts }}
+  tls:
+    {{- range .Values.ingress.hosts }}
+    - hosts:
+        - {{ .host | quote }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "rauthy.fullname" $ }}
+                port:
+                  name: http
+    {{- end }}
+{{- end }}

--- a/charts/rauthy/templates/service.yaml
+++ b/charts/rauthy/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.config.server.port_http }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.config.server.port_https }}
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    {{- include "rauthy.selectorLabels" . | nindent 4 }}

--- a/charts/rauthy/templates/serviceaccount.yaml
+++ b/charts/rauthy/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rauthy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/rauthy/templates/statefulset.yaml
+++ b/charts/rauthy/templates/statefulset.yaml
@@ -1,0 +1,169 @@
+# The headless service is used for the Raft Cluster setup, so Nodes 
+# can connect to each other without any load balancer in between.
+# {{ .Values.blah }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rauthy.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  sessionAffinity: None
+  selector:
+    {{- include "rauthy.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: hiqlite-raft
+      protocol: TCP
+      port: 8100
+      targetPort: hiqlite-raft
+    - name: hiqlite-api
+      protocol: TCP
+      port: 8200
+      targetPort: hiqlite-api
+---
+# The PDB is only necessary for a HA deployment. You can take it out for a single instance.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "rauthy.selectorLabels" . | nindent 6 }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "rauthy.fullname" . }}-headless
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "rauthy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "rauthy.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - rauthy
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: {{ include "rauthy.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            allowPrivilegeEscalation: false
+          ports:
+            # Hiqlite internal ports
+            - name: hiqlite-raft
+              protocol: TCP
+              containerPort: {{ .Values.service.hiqliteRaftPort }}
+            - name: hiqlite-api
+              protocol: TCP
+              containerPort: {{ .Values.service.hiqliteAPIPort }}
+            {{- with .Values.service.httpPort }}
+            - name: http
+              protocol: TCP
+              containerPort: {{ . }}
+            {{- end }}
+            {{- with .Values.service.httpsPort }}
+            - name: https
+              protocol: TCP
+              containerPort: {{ . }}
+            {{- end }}
+          env:
+            {{- if .Values.localTestMode }}
+            - name: LOCAL_TEST
+              value: "true"
+            {{- end }}
+            {{- with .Values.bootstrapConfig }}
+            - name: BOOTSTRAP_ADMIN_EMAIL
+              value: "{{ .adminEmail }}"
+            - name: BOOTSTRAP_ADMIN_PASSWORD_PLAIN
+              value: "{{ .adminPassword }}"
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              # You may need to adjust this, if you decide to start in https only
+              # mode or use another port
+              {{- if .Values.service.httpsPort }}
+              scheme: HTTPS
+              port: https
+              {{- else }}
+              scheme: HTTP
+              port: http
+              {{- end }}
+              path: /auth/v1/health
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              # adjust if you change the Raft API port
+              port: hiqlite-api
+              path: /ping
+            initialDelaySeconds: 5
+            periodSeconds: 1
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ include "rauthy.fullname" . }}-data
+              mountPath: /app/data
+              readOnly: false
+            - name: config
+              mountPath: /app/config.toml
+              readOnly: true
+              subPath: config.toml
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "rauthy.configSecretName" . }}
+        
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "rauthy.fullname" . }}-data
+      spec: 
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 128Mi

--- a/charts/rauthy/templates/tests/test-connection.yaml
+++ b/charts/rauthy/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "rauthy.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: docker.io/busybox
+      command: ['wget', 'http://{{ include "rauthy.fullname" . }}:{{ .Values.service.httpPort }}']
+  restartPolicy: Never

--- a/charts/rauthy/values.yaml
+++ b/charts/rauthy/values.yaml
@@ -1,0 +1,151 @@
+# Default values for rauthy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/sebadob/rauthy
+  # This sets the pull policy for images.
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# Turn on Rauthy's local test mode.
+localTestMode: false
+
+adminEmail: "admin@localhost"
+
+config:
+  enable: true
+  # Define this section if you want to configure bootstrap.
+  bootstrap: {}
+  #  password_plain: "admin"
+  cluster: {}
+  #  secret_raft: SuperSecureSecret1337
+  #  secret_api: SuperSecureSecret1337
+  encryption: {}
+  #  keys:
+  #    - 20250710T0136/6666666666666666666666666666666666666666666=
+  #  key_active: 20250710T0136
+  # This is configured to use mailcrab to make it easy to test
+  email:
+    smtp_host: mailcrab.default.svc
+    smtp_port: 1025
+    danger_insecure: true
+  server:
+    port_http: 8080
+    port_https: 8443
+    trusted_proxies:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+    swagger_enable: true
+
+# This will set the replicaset count more information can be found here:
+#   https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+#
+# If you start a fresh cluster without a bootstrapped Admin password, it is
+# highly suggested to start a single replica for the first setup + login.
+# It will work with 3 replicas directly, but if you are not quick enough and
+# your logs buffer size is small, you might miss the auto-generated password
+# in Pod `rauthy-0` because of many logs.
+replicaCount: 1
+
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This secret should exist in the same target namespace before installing
+# the chart. This secret is the full contents of a Rauthy config file.
+# By default, ${service_name}-secret
+# configSecretNameOverride: rauthy-secret
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  hiqliteRaftPort: 8100
+  hiqliteAPIPort: 8200
+
+
+
+webauthn:
+  rp_id: localhost
+  rp_origin: https://localhost:443
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts: []
+#    - host: auth.staging.example.com
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  requests: {}
+    # Tune the memory requests value carefully. Make sure, that the
+    # pods request at least:
+    # `ARGON2_M_COST` / 1024 * `MAX_HASH_THREADS` Mi + idle memory
+    # The actual usage also heavily depends on the Memory Allocator
+    # tuning. You can find more information in the Tuning section
+    # in this book.
+    # memory: 64Mi
+    # The CPU needs to be adjusted during runtime. This heavily
+    # depends on your use case.
+    # cpu: 100m
+  limits: {}
+  # Be careful with the memory limit. You must make sure, that the
+  # (very costly) password hashing has enough memory available. If not,
+  # the application will crash. You do not really need a memory limit,
+  # since Rust is not a garbage collected language. Better take a close
+  # look at what the container actually needs during
+  # prime time and set the requested resources above properly.
+  #memory:
+  # A CPU limit may make sense in case of DDoS attacks or something
+  # like this, if you do not have external rate limiting or other
+  # mechanisms. Otherwise, `MAX_HASH_THREADS` is the main mechanism 
+  # to limit resources.
+  #cpu: 1000m
+
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []


### PR DESCRIPTION
This chart is meant to be a starting point. This chart will fully fire up an instance of Rauthy in a k8s cluster. However, you will need some form of smtp since rauthy crashes without it. This chart assumes the use of mailcrab, which is a test smtp server that receives mail and present a them in a web UI for testing.

The chart does not require a custom values yaml to launch and is configured for testing. Any serious deployment would need to persist some secrets that are generated in this chart.

Also, this chart runs rauthy on http inside the cluster. I am not sure of a generic way to setup TLS for communication between the ingress proxy and the services inside the cluster. If there is a good generic solution that works be default with all ingress setups, I think that would be a obvious next step.