### PR TITLE
Fix: make sure `page_size` in `PaginationParams` can never be `0`

### DIFF
--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -59,6 +59,7 @@ use rauthy_service::oidc::helpers::get_bearer_token_from_header;
 use rauthy_service::oidc::logout;
 use rauthy_service::password_reset;
 use spow::pow::Pow;
+use std::cmp::max;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use tokio::task;
@@ -95,8 +96,9 @@ pub async fn get_users(
     params.validate()?;
 
     let user_count = User::count().await?;
-    if user_count >= RauthyConfig::get().vars.server.ssp_threshold as i64 {
-        let page_size = params.page_size.unwrap_or(20) as i64;
+    let ssp_threshold = RauthyConfig::get().vars.server.ssp_threshold;
+    if user_count >= ssp_threshold as i64 {
+        let page_size = max(params.page_size.unwrap_or(20), ssp_threshold) as i64;
         let offset = params.offset.unwrap_or(0) as i64;
         let backwards = params.backwards.unwrap_or(false);
         let continuation_token = if let Some(token) = &params.continuation_token {

--- a/src/api_types/src/generic.rs
+++ b/src/api_types/src/generic.rs
@@ -48,6 +48,7 @@ pub struct LogoParams {
 
 #[derive(Deserialize, Validate, ToSchema, IntoParams)]
 pub struct PaginationParams {
+    #[validate(range(min = 1))]
     pub page_size: Option<u16>,
     pub offset: Option<u16>,
     pub backwards: Option<bool>,

--- a/src/data/src/entity/sessions.rs
+++ b/src/data/src/entity/sessions.rs
@@ -240,7 +240,7 @@ impl Session {
         #[allow(unused_assignments)]
         let mut res = None;
         let mut latest_ts = 0;
-        let size_hint = max(page_size as usize, 1);
+        let size_hint = page_size as usize;
 
         if let Some(token) = continuation_token {
             if backwards {

--- a/src/data/src/entity/users.rs
+++ b/src/data/src/entity/users.rs
@@ -474,7 +474,7 @@ ORDER BY created_at ASC"#;
         offset: i64,
         backwards: bool,
     ) -> Result<(Vec<UserResponseSimple>, Option<ContinuationToken>), ErrorResponse> {
-        let size_hint = max(page_size, 1) as usize;
+        let size_hint = page_size as usize;
 
         let res = if let Some(token) = continuation_token {
             if backwards {


### PR DESCRIPTION
We do an `x / page_size` inside the code, so it should never be possible to become `0`. Very unexpectedly, even if it's `0`, the code will not `panic` because of a typecast as `f64` beforehand. The `(x / 0.0).ceil()` makes it actually infinity, and it's then limited as a `u32`, which will lead to a `u32::MAX` as the result. Even though it does not produce a `panic`, no one would expect that result.

We also want to limit the max `page_size` to `server.ssp_threshold` instead of `u16::MAX`, which is a more reasonable value.