### PR TITLE
Fix: SVG sanitization for user profile pictures

### DIFF
--- a/frontend/src/lib/UserPicture.svelte
+++ b/frontend/src/lib/UserPicture.svelte
@@ -25,7 +25,7 @@
     } = $props();
 
     const id = genKey();
-    const accept = 'image/png, image/jpeg, image/webp';
+    const accept = 'image/png, image/jpeg, image/webp, image/svg+xml';
 
     let t = useI18n();
 
@@ -148,7 +148,7 @@
 
         for (let file of list) {
             if (!accept.includes(file.type)) {
-                err = 'Invalid File Format, allowed: ' + accept;
+                err = 'Invalid File Format, allowed: ' + accept + ', found: ' + file.type;
                 break;
             }
             if (file.size > config.content_len_limit) {

--- a/src/data/src/entity/pictures.rs
+++ b/src/data/src/entity/pictures.rs
@@ -214,7 +214,7 @@ impl UserPicture {
                             return Err(ErrorResponse::new(
                                 ErrorResponseType::BadRequest,
                                 "invalid content_type, expected one of: image/svg+xml, \
-                                image/jpeg, image/png",
+                                image/jpeg, image/png, image/webp",
                             ));
                         }
                     }
@@ -250,8 +250,7 @@ impl UserPicture {
             .await?
             .await?
         } else {
-            Logo::sanitize_svg(&mut buf)?;
-            buf
+            Logo::sanitize_svg(&mut buf)?
         };
 
         // save img to db + storage

--- a/src/data/src/entity/theme.rs
+++ b/src/data/src/entity/theme.rs
@@ -105,6 +105,7 @@ impl From<ThemeCssFull> for ThemeRequestResponse {
 impl ThemeCssFull {
     /// Returns either the custom theme for a client, if it exists, and the default on any error.
     pub async fn find_with_default(client_id: String) -> Result<Self, ErrorResponse> {
+        // TODO cache these - they are fetched for each HTML Cached Get
         let sql = "SELECT * FROM themes WHERE client_id = $1";
         let slf: Self = if is_hiqlite() {
             DB::hql()


### PR DESCRIPTION
SVGs for user profile pictures had an issue during sanitzation. They were properly recognized as SVG and sanitized, but the unsanitized version was saved instead of the sanitized one. This made it possible to embed Javascript code inside them. When they are used inside an `<img>` tag, everything is fine, the browser protection will kick in, and it's impossible to execute any XSS with them. However, if you would open them via their direct URI directly inside the browser, or a downstream client does werid things like fetching them via JS and then somehow injecting them into HTML (which you should never do, especially for external sources), this would be an attack vector.