### PR TITLE
Add vendored feature for utoipa-swagger-ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6690,8 +6690,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-postgres = { version = "0.7.10", features = ["with-chrono-0_4"] }
 tokio-postgres-rustls = { version = "0.13", features = [] }
 utoipa = { version = "5", features = ["actix_extras", "chrono", "openapi_extensions"] }
-utoipa-swagger-ui = { version = "9.0.0", features = ["actix-web"] }
+utoipa-swagger-ui = { version = "9.0.0", features = ["actix-web", "vendored"] }
 validator = { version = "0.20.0", features = ["derive"] }
 webauthn-rs = { version = "0.5", features = [
     "danger-allow-state-serialisation", "danger-credential-internals"


### PR DESCRIPTION
This would simplify packaging Rauthy with Nix, as the swagger files will be downloaded when the crates are fetched, rather than at build time (when Nix disallows internet access to ensure reproducibility).