### PR TITLE
Feature: Helm Chart

### DIFF
--- a/charts/rauthy/.helmignore
+++ b/charts/rauthy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/rauthy/Chart.yaml
+++ b/charts/rauthy/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: rauthy
+description: A Helm chart for Rauthy
+type: application
+version: 0.32.3
+appVersion: "0.32.3"
+
+# Chart metadata
+home: https://github.com/sebadob/rauthy
+icon: https://sebadob.github.io/rauthy/rauthy_grey_small.png
+sources:
+  - https://github.com/sebadob/rauthy
+
+# Keywords for chart discovery
+keywords:
+  - authentication
+  - authorization
+  - oidc
+  - openid-connect
+  - sso
+  - single-sign-on
+  - identity
+  - rust
+
+# Maintainer information
+maintainers:
+  - name: Reversing0148
+    url: https://github.com/Reversing0148
+
+# Minimum Kubernetes version requirement
+kubeVersion: ">=1.19.0-0"
+
+# Annotations for additional metadata
+annotations:
+  category: Authentication
+  licenses: Apache-2.0

--- a/charts/rauthy/templates/NOTES.txt
+++ b/charts/rauthy/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Rauthy was deployed.
+
+Feel free to contribute by updating the notes.
+I lost my sanity while writing the secret template.

--- a/charts/rauthy/templates/_helpers.tpl
+++ b/charts/rauthy/templates/_helpers.tpl
@@ -1,0 +1,130 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rauthy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rauthy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rauthy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rauthy.labels" -}}
+helm.sh/chart: {{ include "rauthy.chart" . }}
+{{ include "rauthy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rauthy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rauthy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
+Check if TLS is enabled through either ingress or httpRoute
+*/}}
+{{- define "rauthy.isTLSEnabled" -}}
+{{- if and .Values.ingress.enabled .Values.ingress.tls -}}
+true
+{{- else if and .Values.httpRoute.enabled .Values.httpRoute.rules -}}
+{{- range .Values.httpRoute.rules -}}
+{{- if .filters -}}
+{{- range .filters -}}
+{{- if and (eq .type "RequestHeaderModifier") .requestHeaderModifier.set -}}
+{{- range .requestHeaderModifier.set -}}
+{{- if and (eq .name "X-Forwarded-Proto") (eq .value "https") -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
+Get the domain name by checking ingress hosts first, then httpRoute hosts, falling back to rauthy.local
+*/}}
+{{- define "rauthy.domainName" -}}
+{{- if and .Values.ingress.enabled .Values.ingress.hosts }}
+{{- (index .Values.ingress.hosts 0).host }}
+{{- else if and .Values.httpRoute.enabled .Values.httpRoute.hostnames }}
+{{- index .Values.httpRoute.hostnames 0 }}
+{{- else -}}
+rauthy.local
+{{- end }}
+{{- end }}
+
+{{/*
+Get the external scheme based on TLS configuration
+*/}}
+{{- define "rauthy.externalScheme" -}}
+{{- if eq (include "rauthy.isTLSEnabled" .) "true" -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end }}
+
+{{/*
+Generate the public URL based on the external scheme and domain name
+*/}}
+{{- define "rauthy.pubUrl" -}}
+{{- printf "%s://%s" (include "rauthy.externalScheme" .) (include "rauthy.domainName" .) -}}
+{{- end }}
+
+{{/*
+Generate the rp_origin based on the external scheme and domain name with appropriate port
+*/}}
+{{- define "rauthy.rpOrigin" -}}
+{{- if eq (include "rauthy.isTLSEnabled" .) "true" -}}
+{{- printf "%s://%s:443" (include "rauthy.externalScheme" .) (include "rauthy.domainName" .) -}}
+{{- else -}}
+{{- printf "%s://%s:%d" (include "rauthy.externalScheme" .) (include "rauthy.domainName" .) (int .Values.ports.http) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Get the server scheme based on port configuration
+*/}}
+{{- define "rauthy.apiScheme" -}}
+{{- if .Values.ports.https -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end }}

--- a/charts/rauthy/templates/httproute.yaml
+++ b/charts/rauthy/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "rauthy.fullname" . -}}
+{{- $svcPort := .Values.ports.http -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/rauthy/templates/ingress.yaml
+++ b/charts/rauthy/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "rauthy.fullname" $ }}
+                port:
+                  {{- if $.Values.ports.https }}
+                  number: {{ $.Values.ports.https }}
+                  {{- else }}
+                  number: {{ $.Values.ports.http }}
+                  {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/rauthy/templates/poddistruptionbudget.yaml
+++ b/charts/rauthy/templates/poddistruptionbudget.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "rauthy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/rauthy/templates/secret.yaml
+++ b/charts/rauthy/templates/secret.yaml
@@ -1,0 +1,55 @@
+{{- if not .Values.externalSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rauthy.fullname" . }}-config
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  config.toml: |-
+    [server]
+    scheme = {{ include "rauthy.apiScheme" . | quote }}
+    pub_url = {{ include "rauthy.domainName" . | quote }}
+    proxy_mode = true
+    trusted_proxies = ["10.0.0.0/8"]
+    {{- if and .Values.ports.metrics .Values.serviceMonitor.enabled }}
+    metrics_enable = true
+    metrics_port = {{ int .Values.ports.metrics }}
+    {{- end }}
+
+    [cluster]
+    node_id_from = "k8s"
+    {{- $root := . }}
+    {{- $headless := include "rauthy.fullname" . | printf "%s-headless" }}
+    {{- if gt (int .Values.replicaCount) 1 }}
+    nodes = [
+      {{- range $i, $ := until (int $root.Values.replicaCount) }}
+        "{{ add $i 1 }} {{ $root.Release.Name }}-{{ $i }}.{{ $headless }}:{{ $root.Values.ports.raft }} {{ $root.Release.Name }}-{{ $i }}.{{ $headless }}:{{ $root.Values.ports.api }}",
+      {{- end }}
+    ]
+    {{- else }}
+    nodes = [
+        "1 localhost:{{ $root.Values.ports.raft }} localhost:{{ $root.Values.ports.api }}"
+    ]
+    log_sync = "immediate"
+    {{- end }}
+    
+    secret_raft = "{{ randAlphaNum 48 }}"
+    secret_api = "{{ randAlphaNum 48 }}"
+
+    [encryption]
+    {{- $randAlphaNum16 := randAlphaNum 16 }}
+    keys = [
+        "{{ printf "%s/%s" ($randAlphaNum16) (b64enc (randAlphaNum 32)) }}"
+    ]
+    key_active = "{{ $randAlphaNum16 }}"
+
+    [bootstrap]
+    admin_email = "admin@localhost"
+
+    [webauthn]
+    rp_id = {{ include "rauthy.domainName" . | quote }}
+    rp_origin = {{ include "rauthy.rpOrigin" . | quote }}
+    rp_name = "Rauthy"
+{{- end }}

--- a/charts/rauthy/templates/service.yaml
+++ b/charts/rauthy/templates/service.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "rauthy.selectorLabels" . | nindent 4 }}
+  ports:
+  {{- if .Values.ports.http }}
+    - name: http
+      port: {{ .Values.ports.http }}
+      targetPort: http
+      protocol: TCP
+  {{- end }}
+  {{- if .Values.ports.https }}
+    - name: https
+      port: {{ .Values.ports.https }}
+      targetPort: https
+      protocol: TCP
+  {{- end }}
+  {{- if and .Values.ports.metrics .Values.serviceMonitor.enabled }}
+    - name: metrics
+      port: {{ .Values.ports.metrics }}
+      targetPort: metrics
+      protocol: TCP
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rauthy.fullname" . }}-headless
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  sessionAffinity: None
+  selector:
+    {{- include "rauthy.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: raft
+      protocol: TCP
+      port: {{ .Values.ports.raft }}
+      targetPort: raft
+    - name: api
+      protocol: TCP
+      port: {{ .Values.ports.api }}
+      targetPort: api

--- a/charts/rauthy/templates/servicemonitor.yaml
+++ b/charts/rauthy/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rauthy.fullname" . }}-servicemonitor
+  labels:
+    app: {{ include "rauthy.name" . }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "rauthy.name" . }}
+  endpoints:
+  - port: {{ .Values.serviceMonitor.port }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    path: /metrics
+{{- end }}

--- a/charts/rauthy/templates/statefulset.yaml
+++ b/charts/rauthy/templates/statefulset.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "rauthy.fullname" . }}
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "rauthy.fullname" . }}-headless
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      {{- include "rauthy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "rauthy.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: default
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- if .Values.ports.http }}
+            - name: http
+              containerPort: {{ .Values.ports.http }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.ports.https }}
+            - name: https
+              containerPort: {{ .Values.ports.https }}
+              protocol: TCP
+            {{- end }}
+            - name: raft
+              containerPort: {{ .Values.ports.raft }}
+              protocol: TCP
+            - name: api
+              containerPort: {{ .Values.ports.api }}
+              protocol: TCP
+            {{- if and .Values.ports.metrics .Values.serviceMonitor.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.ports.metrics }}
+              protocol: TCP
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ include "rauthy.fullname" . }}-data
+              mountPath: /app/data
+              readOnly: false
+            - name: rauthy-config
+              mountPath: /app/config.toml
+              readOnly: true
+              subPath: config.toml
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: rauthy-config
+          secret:
+            secretName: {{ include "rauthy.fullname" . }}-config
+        {{- if not .Values.persistence.enabled }}
+        - name: {{ include "rauthy.fullname" . }}-data
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "rauthy.fullname" . }}-data
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName | quote }}
+        {{- end }}
+  {{- end }}

--- a/charts/rauthy/templates/tests/test-connection.yaml
+++ b/charts/rauthy/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "rauthy.fullname" . }}-test-connection"
+  labels:
+    {{- include "rauthy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:
+        - '--no-check-certificate'
+        - '-qO-'
+        - '{{ include "rauthy.pubUrl" . }}/health'
+  restartPolicy: Never

--- a/charts/rauthy/values.yaml
+++ b/charts/rauthy/values.yaml
@@ -1,0 +1,196 @@
+# Default values for rauthy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+# Setting a relica count of higher than 1 will enable clustered mode for rauthy.
+# Odd numbers are recommended for raft consensus. 
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: ghcr.io/sebadob/rauthy
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# Configuration for the update strategy of the StatefulSet more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    # For clustered applications, you might want to set the partition to (replicaCount - 1) to update one pod at a time.
+    partition: 0
+
+# This helps ensure minimum availability during voluntary disruptions more information can be found here: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget:
+  enabled: false
+  # Additional annotations for the PodDisruptionBudget
+  annotations: {}
+  # Either minAvailable or maxUnavailable should be specified, not both
+  # For clustered applications, setting minAvailable to (replicaCount - 1) is a good practice.
+  minAvailable: 2
+  # maxUnavailable: 1
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  runAsUser: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+
+ports:
+  http: 8080
+  # https: 8443
+  raft: 8100
+  api: 8200
+  metrics: 9090
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #   - secretName: rauthy-ingress-tls
+  #     hosts:
+  #       - chart-example.local
+
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+httpRoute:
+  # HTTPRoute enabled.
+  enabled: false
+  # HTTPRoute annotations.
+  annotations: {}
+  # Which Gateways this Route is attached to.
+  parentRefs:
+  - name: gateway
+    sectionName: http
+    # namespace: default
+  # Hostnames matching HTTP header.
+  hostnames:
+  - chart-example.local
+  # List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /headers
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #       - name: My-Overwrite-Header
+  #         value: this-is-the-only-value
+  #       remove:
+  #       - User-Agent
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /echo
+  #     headers:
+  #     - name: version
+  #       value: v2
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /auth/v1/health
+    port: http
+  initialDelaySeconds: 1
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /ping
+    port: api
+  initialDelaySeconds: 5
+  periodSeconds: 1
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# This allows for mounting config.toml.
+# If left unset, a new Secret will be generated using this values.yaml.
+# The generated config.toml is enough to get you experimenting.
+# It is in your own interest, to set this to a known secret, so that
+# you can retain your configuration and keys across redeployments.
+externalSecret: ""
+
+# Persistence configuration for the volumeClaimTemplate.
+# Emptydir will be used if disabled
+persistence:
+  enabled: false
+  size: 128Mi
+  accessMode: ReadWriteOnce
+  storageClassName: "longhorn"
+
+# Configuration for enabling and customizing the ServiceMonitor resource.
+# This is used to integrate with Prometheus for monitoring purposes.
+serviceMonitor:
+  # Enable or disable the ServiceMonitor resource.
+  enabled: false
+  # The port exposed by the service to scrape metrics from.
+  port: metrics
+  # The interval at which Prometheus will scrape metrics.
+  interval: 30s


### PR DESCRIPTION
Hello!

I have been hard at work creating a helm chart to get new folks up and running with rauthy, while also implementing support for advanced features.

It supports easy setup for both standalone and high availability deployments.
You can also configure usage of an external secret with, for production use.

A helm release github action is also available [here](https://github.com/Reversing0148/rauthy-helm), although I excluded it from this pr.

Please have a look and let me know your thoughts.

