### PR TITLE
Docs: Improved docker compose config

### DIFF
--- a/book/src/getting_started/docker.md
+++ b/book/src/getting_started/docker.md
@@ -47,6 +47,8 @@ volumes:
   data:
 ```
 
+_Optional: Create `.env` file with `COMPOSE_PROJECT_NAME=myapp` for custom container/volume name prefix._
+
 Save this into `docker-compose.yaml` and start with:
 
 ```


### PR DESCRIPTION
* Don't see the reason for manually creating a network - docker compose already creates a new network and puts all containers in it
* Removed manually set container name - instead use service name/key via `docker compose ... {service}` 
  * Container name prefix can be [customized via `.env`](https://docs.docker.com/compose/how-tos/environment-variables/envvars/#compose_project_name)

----

P.S. I was not able to build the docs (and will not do it - too much time spent, I am not a Rust dev)

> I tried to build but without success:
> 
> * `mdbook` fails:
> 
> ```
> $ mdbook serve -n 0.0.0.0
>  INFO Book building has started
> [2025-11-27T11:34:40Z ERROR mdbook_admonish] Fatal error: Unable to parse the input
> [2025-11-27T11:34:40Z ERROR mdbook_admonish]   - Unable to parse the input
> [2025-11-27T11:34:40Z ERROR mdbook_admonish]   - invalid type: null, expected any valid TOML value at line 1 column 129
>  WARN Error writing the RenderContext to the backend, Broken pipe (os error 32)
> ERROR The "admonish" preprocessor exited unsuccessfully with exit status: 1 status
> ```
> 
> * `just` command doesn't exist


