### PR TITLE
fix: missing run `just setup` before build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,9 @@ To work with this project, you need to have the following tools available on you
 
 ### Building from source
 
-If you only care about building from source and don't need any testing or development, you need to do 2 things:
+If you only care about building from source and don't need any testing or development, you need to do 3 things:
 
+- `just setup`
 - `just build-ui`
 - `cargo build --release`
 


### PR DESCRIPTION
missing `just setup` command for building guide on a fresh cloned repo

may produce error like this 
```
❯ just build-ui
+ mkdir -p templates/html
+ mkdir -p static/v1
+ rm -rf 'static/v1/*'
+ rm -rf 'templates/html/*'
+ [[ local == \c\o\n\t\a\i\n\e\r ]]
+ cd frontend
+ npm run build

> frontend@0.0.1 build
> vite build

sh: vite: command not found
error: Recipe `build-ui` failed with exit code 127
```

build won't succeed since node modules are not installed and wasm module is not built