### PR TITLE
Fix: move `MALLOC_CONF` from build step into the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG TARGETARCH
 ARG TARGET_USER="10001:10001"
 USER $TARGET_USER
 
+# default jemalloc tuning suitable for most deployments
+ENV MALLOC_CONF="abort_conf:true,narenas:8,tcache_max:4096,dirty_decay_ms:5000,muzzy_decay_ms:5000"
+
 WORKDIR /app
 
 COPY --chown=$TARGET_USER ./out/rauthy_$TARGETARCH ./rauthy

--- a/justfile
+++ b/justfile
@@ -402,7 +402,6 @@ build image="ghcr.io/sebadob/rauthy" push="push": build-wasm build-ui
         -v {{ cargo_home }}/registry:{{ container_cargo_registry }} \
         -v {{ invocation_directory() }}/:/work/ \
         -w /work \
-        -e {{ jemalloc_conf }} \
         {{ map_docker_user }} \
         {{ builder_image }}:{{ builder_tag_date }} \
         cargo build --release --target x86_64-unknown-linux-gnu
@@ -416,7 +415,6 @@ build image="ghcr.io/sebadob/rauthy" push="push": build-wasm build-ui
         -v {{ cargo_home }}/registry:{{ container_cargo_registry }} \
         -v {{ invocation_directory() }}/:/work/ \
         -w /work \
-        -e {{ jemalloc_conf }} \
         -e JEMALLOC_SYS_WITH_LG_PAGE=16 \
         {{ map_docker_user }} \
         {{ builder_image }}:{{ builder_tag_date }} \


### PR DESCRIPTION
To avoid conflicting configs when used with / without prefix, and during build or not, the `MALLOC_CONF` will now exist inside the final `Dockerfile` as a default ENV var only. This gets rid of possible conflicts and it can be overwritten easily, just as it was before.