### PR TITLE
fix: Allow @ character in redirect_uri pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,6 +4765,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustls",
+ "serde",
  "serde_json",
  "spow",
  "tikv-jemallocator",

--- a/frontend/src/utils/patterns.ts
+++ b/frontend/src/utils/patterns.ts
@@ -25,6 +25,6 @@ export const PATTERN_ORIGIN = '^(http|https)://[a-z0-9.:\\-]+$';
 export const PATTERN_PHONE = '^\\+[0-9]{0,32}$';
 export const PATTERN_SCOPE_SPACE = '^[a-zA-Z0-9\\-_\\/:\\s*]{0,512}$';
 export const PATTERN_STREET = '^[a-zA-Z0-9À-ÿ\\-.\\s]{0,48}$';
-export const PATTERN_URI = "^[a-zA-Z0-9,.:\\/_\\-&?=~#!$'\\(\\)*+%]*$";
+export const PATTERN_URI = "^[a-zA-Z0-9,.:\\/_\\-&?=~#!$'\\(\\)*+%@]*$";
 export const PATTERN_USER_NAME =
     "^[a-zA-Z0-9À-ɏ\\-'\\s\\u3041-\\u3096\\u30A0-\\u30FF\\u3400-\\u4DB5\\u4E00-\\u9FCB\\uF900-\\uFA6A\\u2E80-\\u2FD5\\uFF66-\\uFF9F\\uFFA1-\\uFFDC\\u31F0-\\u31FF]{1,32}$";


### PR DESCRIPTION
# Title : fix: Allow @ character in redirect_uri pattern

## Change

Add @ to regex PATTERN_URI in frontend/src/utils/patterns.ts

## Reason

Support URIs with path segments like /@warpgate/api/sso/return

Redirect URI for some apps contains @ like the following example :
https://warpgate.domain.com/@warpgate#/login?next=%2F%40warpgate%2Fadmin

The redirect URI for warpgate is https://warpgate.domain.com/@warpgate/api/sso/return

In Authelia this usage is documented (https://www.authelia.com/integration/openid-connect/clients/warpgate/)


## Other notes

The Cargo.lock file is not modified by me but by the command "just fmt" (just in case you ask yourself why, this is not on purpose 🙂 )


Have a good day !