### PR TITLE
Change start_index to be an optional field

### DIFF
--- a/src/data/src/entity/scim_types.rs
+++ b/src/data/src/entity/scim_types.rs
@@ -373,7 +373,7 @@ pub struct ScimListResponse {
     pub schemas: Option<Vec<Cow<'static, str>>>,
     pub items_per_page: i64,
     pub total_results: i64,
-    pub start_index: i64,
+    pub start_index: Option<i64>,
     #[serde(rename = "Resources")]
     pub resources: Vec<ScimResource>,
 }


### PR DESCRIPTION
VMware vCenter returns an emtpy list without an start index:
```
{
  "schemas": [
    "urn:com.vmware.vidm.usergroup.scim2.UserListResponse"
  ],
  "totalResults": 0,
  "Resources": [],
  "itemsPerPage": 20
}
```