### PR TITLE
Fix: Remove default maxLength attribute from InputPassword

### DIFF
--- a/frontend/src/lib/form/InputPassword.svelte
+++ b/frontend/src/lib/form/InputPassword.svelte
@@ -18,6 +18,7 @@
         autocomplete = 'current-password',
         placeholder = 'Password',
         disabled = false,
+        maxLength,
         required,
         pattern,
         errMsg,
@@ -39,6 +40,7 @@
         autocomplete?: FullAutoFill | null | undefined;
         placeholder: string;
         disabled?: boolean | null | undefined;
+        maxLength?: number | null | undefined;
         min?: string;
         max?: string;
         required?: boolean;
@@ -130,6 +132,7 @@
             {disabled}
             required={required || undefined}
             aria-required={required || false}
+            maxlength={maxLength || undefined}
             pattern={pattern || undefined}
             class:invalid={isError}
             {oninput}


### PR DESCRIPTION
Currently untested, will need to be compiled and checked.
I might not be able to today.

fixes #1394