### PR TITLE
SCIM only create user if !unlink_ext_id set by group prefix match result

### DIFF
--- a/src/data/src/entity/clients_scim.rs
+++ b/src/data/src/entity/clients_scim.rs
@@ -955,7 +955,7 @@ impl ClientScim {
             None => {
                 if !unlink_ext_id {
                     self.create_user(expected_groups, payload, groups_local, groups_remote)
-                    .await?;
+                        .await?;
                 }
             }
             Some(user_remote) => {


### PR DESCRIPTION
Done.
Works like expected.

fixes #1396 