### PR TITLE
feat: add configurable PostgreSQL SSL mode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -807,22 +807,22 @@ pg_db_name = 'rauthy'
 # overwritten by: PG_TLS_NO_VERIFY
 pg_tls_no_verify = true
 
-# PostgreSQL SSL mode configuration.
-# Defines how PostgreSQL connections handle SSL/TLS encryption.
+# PostgreSQL TLS mode configuration.
+# Defines how PostgreSQL connections handle TLS encryption.
 #
 # Options:
-# - disable: Only try a non-SSL connection
-# - allow: First try a non-SSL connection; if that fails, try an SSL connection
-# - prefer: First try an SSL connection; if that fails, try a non-SSL connection (default)
-# - require: Only try an SSL connection, but don't verify the certificate
-# - verify-ca: Only try an SSL connection and verify the certificate
-# - verify-full: Only try an SSL connection, verify the certificate and hostname
+# - disable: Only try a non-TLS connection
+# - allow: First try a non-TLS connection; if that fails, try a TLS connection
+# - prefer: First try a TLS connection; if that fails, try a non-TLS connection (default)
+# - require: Only try a TLS connection, but don't verify the certificate
+# - verify-ca: Only try a TLS connection and verify the certificate
+# - verify-full: Only try a TLS connection, verify the certificate and hostname
 #
 # Note: For managed database services (AWS RDS, DigitalOcean, etc.), use 'require' or higher.
 #
 # default: prefer
-# overwritten by: PG_SSL_MODE
-#pg_ssl_mode = 'prefer'
+# overwritten by: PG_TLS_MODE
+#pg_tls_mode = 'prefer'
 
 # Max DB connections for the Postgres pool.
 #

--- a/src/data/src/database.rs
+++ b/src/data/src/database.rs
@@ -147,18 +147,7 @@ impl DB {
         config.keepalives_idle(Duration::from_secs(30));
         // config.keepalives_interval()
         config.load_balance_hosts(LoadBalanceHosts::Random);
-
-        // Configure SSL mode from config (default: prefer)
-        let ssl_mode = match RauthyConfig::get().vars.database.pg_ssl_mode.as_str() {
-            "disable" => SslMode::Disable,
-            "allow" => SslMode::Allow,
-            "prefer" => SslMode::Prefer,
-            "require" => SslMode::Require,
-            "verify-ca" => SslMode::VerifyCa,
-            "verify-full" => SslMode::VerifyFull,
-            _ => SslMode::Prefer, // fallback to default
-        };
-        config.ssl_mode(ssl_mode);
+        config.ssl_mode(RauthyConfig::get().vars.database.pg_tls_mode);
 
         let tls_config = if RauthyConfig::get().vars.database.pg_tls_no_verify {
             rustls::ClientConfig::builder()


### PR DESCRIPTION
- Add pg_ssl_mode configuration option to VarsDatabase struct
- Support SSL modes: disable, allow, prefer, require, verify-ca, verify-full
- Default to 'prefer' (maintains backward compatibility)
- Configurable via PG_SSL_MODE environment variable or config.toml
- Add validation to ensure only valid SSL modes are accepted
- Update config.toml with comprehensive documentation

This allows users to configure PostgreSQL SSL mode based on their database requirements, particularly useful for managed database services like AWS RDS, DigitalOcean, and Azure which often require SSL connections.

Fixes connection issues with managed PostgreSQL databases that enforce SSL.