### PR TITLE
feat: add configurable allowed and default scopes for dynamic client registration

### DIFF
--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -926,6 +926,18 @@ pg_password = '123SuperSafe'
 # overwritten by: ENABLE_DYN_CLIENT_REG
 #enable = false
 
+# The allowed scopes separated by ' ' for dynamic clients.
+#
+# default: ['openid', 'profile', 'email', 'groups']
+# overwritten by: DYN_CLIENT_ALLOWED_SCOPES - single String, \n separated values
+#allowed_scopes = ['openid', 'profile', 'email', 'groups']
+
+# The default scopes separated by ' ' for dynamic clients.
+#
+# default: ['openid']
+# overwritten by: DYN_CLIENT_DEFAULT_SCOPES - single String, \n separated values
+#default_scopes = ['openid']
+
 # If specified, this secret token will be expected during
 # dynamic client registrations to be given as a
 # `Bearer <DYN_CLIENT_REG_TOKEN>` token. Needs to be communicated

--- a/config.toml
+++ b/config.toml
@@ -933,6 +933,18 @@ nonce_exp = 900
 # overwritten by: ENABLE_DYN_CLIENT_REG
 enable = true
 
+# The allowed scopes separated by ' ' for dynamic clients.
+#
+# default: ['openid', 'profile', 'email', 'groups']
+# overwritten by: DYN_CLIENT_ALLOWED_SCOPES - single String, \n separated values
+allowed_scopes = ['openid', 'profile', 'email', 'groups']
+
+# The default scopes separated by ' ' for dynamic clients.
+#
+# default: ['openid']
+# overwritten by: DYN_CLIENT_DEFAULT_SCOPES - single String, \n separated values
+default_scopes = ['openid']
+
 # If specified, this secret token will be expected during
 # dynamic client registrations to be given as a
 # `Bearer <DYN_CLIENT_REG_TOKEN>` token. Needs to be communicated

--- a/docs/config/config.html
+++ b/docs/config/config.html
@@ -1099,6 +1099,18 @@ pg_password = '123SuperSafe'
 # overwritten by: ENABLE_DYN_CLIENT_REG
 #enable = false
 
+# The allowed scopes separated by ' ' for dynamic clients.
+#
+# default: ['openid', 'profile', 'email', 'groups']
+# overwritten by: DYN_CLIENT_ALLOWED_SCOPES - single String, \n separated values
+#allowed_scopes = ['openid', 'profile', 'email', 'groups']
+
+# The default scopes separated by ' ' for dynamic clients.
+#
+# default: ['openid']
+# overwritten by: DYN_CLIENT_DEFAULT_SCOPES - single String, \n separated values
+#default_scopes = ['openid']
+
 # If specified, this secret token will be expected during
 # dynamic client registrations to be given as a
 # `Bearer &lt;DYN_CLIENT_REG_TOKEN&gt;` token. Needs to be communicated

--- a/env_vars_migration.md
+++ b/env_vars_migration.md
@@ -94,6 +94,8 @@
 | DPOP_FORCE_NONCE                           | dpop.force_nonce                            | bool       |          |
 | DPOP_NONCE_EXP                             | dpop.nonce_exp                              | u32        |          |
 | ENABLE_DYN_CLIENT_REG                      | dynamic_clients.enable                      | bool       |          |
+| DYN_CLIENT_ALLOWED_SCOPES                  | dynamic_clients.allowed_scopes              | \[String\] |          |
+| DYN_CLIENT_DEFAULT_SCOPES                  | dynamic_clients.default_scopes              | \[String\] |          |
 | DYN_CLIENT_REG_TOKEN                       | dynamic_clients.reg_token                   | String     | *5       |
 | DYN_CLIENT_DEFAULT_TOKEN_LIFETIME          | dynamic_clients.default_token_lifetime      | u32        |          |
 | DYN_CLIENT_SECRET_AUTO_ROTATE              | dynamic_clients.secret_auto_rotate          | bool       |          |

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -1658,6 +1658,16 @@ impl Client {
 
             (!origins.is_empty()).then_some(origins)
         });
+        let scopes = RauthyConfig::get()
+            .vars
+            .dynamic_clients
+            .allowed_scopes
+            .join(",");
+        let default_scopes = RauthyConfig::get()
+            .vars
+            .dynamic_clients
+            .default_scopes
+            .join(",");
 
         Ok(Self {
             id,
@@ -1679,6 +1689,8 @@ impl Client {
                     .default_token_lifetime,
                 i32::MAX as u32,
             ) as i32,
+            scopes,
+            default_scopes,
             challenge: (!confidential).then_some("S256".to_string()),
             force_mfa: false,
             client_uri: req.client_uri,

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -365,6 +365,13 @@ impl Default for Vars {
             },
             dynamic_clients: VarsDynamicClients {
                 enable: false,
+                allowed_scopes: vec![
+                    "openid".into(),
+                    "profile".into(),
+                    "email".into(),
+                    "groups".into(),
+                ],
+                default_scopes: vec!["openid".into()],
                 reg_token: None,
                 default_token_lifetime: 1800,
                 secret_auto_rotate: true,
@@ -1299,6 +1306,22 @@ impl Vars {
             "ENABLE_DYN_CLIENT_REG",
         ) {
             self.dynamic_clients.enable = v;
+        }
+        if let Some(v) = t_str_vec(
+            &mut table,
+            "dynamic_clients",
+            "allowed_scopes",
+            "DYN_CLIENT_ALLOWED_SCOPES",
+        ) {
+            self.dynamic_clients.allowed_scopes = v.into_iter().map(Cow::from).collect::<Vec<_>>();
+        }
+        if let Some(v) = t_str_vec(
+            &mut table,
+            "dynamic_clients",
+            "default_scopes",
+            "DYN_CLIENT_DEFAULT_SCOPES",
+        ) {
+            self.dynamic_clients.default_scopes = v.into_iter().map(Cow::from).collect::<Vec<_>>();
         }
         if let Some(v) = t_str(
             &mut table,
@@ -3007,6 +3030,8 @@ pub struct VarsDpop {
 #[derive(Debug)]
 pub struct VarsDynamicClients {
     pub enable: bool,
+    pub allowed_scopes: Vec<Cow<'static, str>>,
+    pub default_scopes: Vec<Cow<'static, str>>,
     pub reg_token: Option<String>,
     pub default_token_lifetime: u32,
     pub secret_auto_rotate: bool,


### PR DESCRIPTION
Dynamically registered clients were previously restricted to a hardcoded 
set of scopes (openid, profile, email, groups). This made it impossible 
to support Matrix-native OIDC (MSC3861) and other protocols requiring 
specific URN-based scopes.

This change:
- Adds `DYN_CLIENT_ALLOWED_SCOPES` and `DYN_CLIENT_DEFAULT_SCOPES` configuration variable
- Updates `Client::try_from_dyn_reg` to assign these scopes during DCR
- Updates documentation and configuration templates