### PR TITLE
feat: hierarchical scope matching for URNs

### DIFF
--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -1934,6 +1934,15 @@ level_access = 'modifying'
 # overwritten by: LOG_FMT
 #log_fmt = 'text'
 
+[matrix]
+# Enables specific compatibility support for Matrix MSC3861 (Matrix 2.0 native OIDC).
+# This enables hierarchical scope matching (e.g. 'device' matches 'device:ID').
+# Note: Dynamic Client Registration (DCR) should be enabled for full support.
+#
+# default: false
+# overwritten by: MATRIX_SUPPORT_ENABLE
+#msc3861_enable = false
+
 [mfa]
 # If 'true', MFA for an account must be enabled to access the
 # rauthy admin UI.

--- a/config.toml
+++ b/config.toml
@@ -1968,6 +1968,15 @@ level_database = 'info'
 # overwritten by: LOG_FMT
 #log_fmt = 'json'
 
+[matrix]
+# Enables specific compatibility support for Matrix MSC3861 (Matrix 2.0 native OIDC).
+# This enables hierarchical scope matching (e.g. 'device' matches 'device:ID').
+# Note: Dynamic Client Registration (DCR) should be enabled for full support.
+#
+# default: false
+# overwritten by: MATRIX_SUPPORT_ENABLE
+msc3861_enable = false
+
 [mfa]
 # If 'true', MFA for an account must be enabled to access the
 # rauthy admin UI.

--- a/docs/config/config.html
+++ b/docs/config/config.html
@@ -2107,6 +2107,15 @@ level_access = 'modifying'
 # overwritten by: LOG_FMT
 #log_fmt = 'text'
 
+[matrix]
+# Enables specific compatibility support for Matrix MSC3861 (Matrix 2.0 native OIDC).
+# This enables hierarchical scope matching (e.g. 'device' matches 'device:ID').
+# Note: Dynamic Client Registration (DCR) should be enabled for full support.
+#
+# default: false
+# overwritten by: MATRIX_SUPPORT_ENABLE
+#msc3861_enable = false
+
 [mfa]
 # If 'true', MFA for an account must be enabled to access the
 # rauthy admin UI.

--- a/env_vars_migration.md
+++ b/env_vars_migration.md
@@ -183,6 +183,7 @@
 | LOG_LEVEL_DATABASE                         | logging.level_database                      | Level      |          |
 | LOG_LEVEL_ACCESS                           | logging.level_access                        | String     |          |
 | LOG_FMT                                    | logging.log_fmt                             | "json"     |          |
+| MATRIX_SUPPORT_ENABLE                      | matrix.msc3861_enable                       | bool       |          |
 | ADMIN_FORCE_MFA                            | mfa.admin_force_mfa                         | bool       |          |
 | POW_DIFFICULTY                             | pow.difficulty                              | u16        |          |
 | POW_EXP                                    | pow.exp                                     | u16        |          |

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -1068,12 +1068,18 @@ impl Client {
             res.push(s.to_string());
         }
 
+        let matrix_enabled = RauthyConfig::get().vars.matrix.msc3861_enable;
+
         for s in scopes {
-            if self.default_scopes.contains(s) {
+            if self.default_scopes.split(',').any(|d| d == s) {
                 continue;
             }
 
-            if self.scopes.contains(s) {
+            if self
+                .scopes
+                .split(',')
+                .any(|allowed| Scope::matches(allowed, s, matrix_enabled))
+            {
                 res.push(s.clone());
             }
         }

--- a/src/data/src/entity/scopes.rs
+++ b/src/data/src/entity/scopes.rs
@@ -435,6 +435,23 @@ impl Scope {
             && scope != "phone"
             && scope != "profile"
     }
+
+    /// Returns `true` if the `requested` scope matches the `allowed` scope.
+    /// Supports hierarchical matching for URNs if Matrix support is enabled
+    /// (e.g. `...:device` matches `...:device:ID`), as required by Matrix (MSC3861).
+    /// Reference: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
+    #[inline]
+    pub fn matches(allowed: &str, requested: &str, matrix_enabled: bool) -> bool {
+        if allowed == requested {
+            return true;
+        }
+
+        if matrix_enabled && let Some(suffix) = requested.strip_prefix(allowed) {
+            return suffix.starts_with(':');
+        }
+
+        false
+    }
 }
 
 impl From<Scope> for ScopeResponse {

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -266,6 +266,7 @@ pub struct Vars {
     pub i18n: VarsI18n,
     pub lifetimes: VarsLifetimes,
     pub logging: VarsLogging,
+    pub matrix: VarsMatrix,
     pub mfa: VarsMfa,
     pub pam: VarsPam,
     pub pow: VarsPow,
@@ -539,6 +540,9 @@ impl Default for Vars {
                 level_database: "info".into(),
                 level_access: "modifying".into(),
                 log_fmt: "text".into(),
+            },
+            matrix: VarsMatrix {
+                msc3861_enable: false,
             },
             mfa: VarsMfa {
                 admin_force_mfa: true,
@@ -869,6 +873,7 @@ impl Vars {
         slf.parse_i18n(&mut table);
         slf.parse_lifetimes(&mut table);
         slf.parse_logging(&mut table);
+        slf.parse_matrix(&mut table);
         slf.parse_mfa(&mut table);
         slf.parse_pam(&mut table);
         slf.parse_pow(&mut table);
@@ -2248,6 +2253,19 @@ impl Vars {
         }
     }
 
+    fn parse_matrix(&mut self, table: &mut toml::Table) {
+        let mut table = t_table(table, "matrix");
+
+        if let Some(v) = t_bool(
+            &mut table,
+            "matrix",
+            "msc3861_enable",
+            "MATRIX_SUPPORT_ENABLE",
+        ) {
+            self.matrix.msc3861_enable = v;
+        }
+    }
+
     fn parse_mfa(&mut self, table: &mut toml::Table) {
         let mut table = t_table(table, "mfa");
 
@@ -3224,6 +3242,11 @@ pub struct VarsLogging {
     pub level_database: Cow<'static, str>,
     pub level_access: Cow<'static, str>,
     pub log_fmt: Cow<'static, str>,
+}
+
+#[derive(Debug)]
+pub struct VarsMatrix {
+    pub msc3861_enable: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Adds support for flexible scope matching. This is required for Matrix (MSC3861) to handle dynamic URNs, like `urn:matrix:device:some_id`. It now correctly matches base URNs (e.g., `urn:matrix:device`) with their hierarchical extensions.

This logic is opt-in via the new `[matrix]` config section (`MATRIX_SUPPORT_ENABLE`).

Also improved validation by splitting the CSV scope string, which avoids accidental substring matches (e.g., `api` matching `matrix:api`).