### PR TITLE
fix: broken dynamic client cleanup scheduler

### DIFF
--- a/src/schedulers/src/dyn_clients.rs
+++ b/src/schedulers/src/dyn_clients.rs
@@ -37,7 +37,7 @@ pub async fn dyn_client_cleanup() {
         }
         debug!("Running dynamic_client_cleanup scheduler");
 
-        let sql = "SELECT * FROM clients_dyn WHERE last_used = null";
+        let sql = "SELECT * FROM clients_dyn WHERE last_used IS NULL";
         let clients_res: Result<Vec<ClientDyn>, String> = if is_hiqlite() {
             DB::hql()
                 .query_as(sql, params!())


### PR DESCRIPTION
The cleanup scheduler was using `last_used = null`, which is invalid SQL and always returns false.
Changed to `last_used IS NULL` so unused dynamic clients are actually found and deleted according to the configuration.