### PR TITLE
allows for upper cased letters on client ID

### DIFF
--- a/frontend/src/api/types/auth_provider.ts
+++ b/frontend/src/api/types/auth_provider.ts
@@ -58,7 +58,7 @@ export interface ProviderLoginRequest {
     // values for the downstream client
     /// Validation: `email`
     email?: string;
-    /// Validation: PATTERN_CLIENT_ID_EPHEMERAL
+    /// Validation: PATTERN_CLIENT_ID
     client_id: string;
     /// Validation: PATTERN_URI
     redirect_uri: string;

--- a/frontend/src/api/types/authorize.ts
+++ b/frontend/src/api/types/authorize.ts
@@ -7,7 +7,7 @@ export interface LoginRequest {
     /// Validation: max 256
     password?: string;
     pow: string;
-    /// Validation: PATTERN_CLIENT_ID_EPHEMERAL
+    /// Validation: PATTERN_CLIENT_ID
     client_id: string;
     /// Validation: PATTERN_URI
     redirect_uri: string;
@@ -24,7 +24,7 @@ export interface LoginRequest {
 }
 
 export interface LoginRefreshRequest {
-    /// Validation: PATTERN_CLIENT_ID_EPHEMERAL
+    /// Validation: PATTERN_CLIENT_ID
     client_id: string;
     /// Validation: PATTERN_URI
     redirect_uri: string;

--- a/frontend/src/api/types/clients.ts
+++ b/frontend/src/api/types/clients.ts
@@ -10,7 +10,7 @@ export type AuthFlow =
 export type CodeChallengeMethod = 'plain' | 'S256';
 
 export interface NewClientRequest {
-    /// Validation: PATTERN_LOWERCASE
+    /// Validation: PATTERN_CLIENT_ID
     id: string;
     /// Validation: PATTERN_CLIENT_NAME
     name?: string;
@@ -32,7 +32,7 @@ export interface ScimClientRequestResponse {
 }
 
 export interface UpdateClientRequest {
-    /// Validation: PATTERN_CLIENT_ID_EPHEMERAL
+    /// Validation: PATTERN_CLIENT_ID
     id: string;
     /// Validation: PATTERN_CLIENT_NAME
     name?: string;

--- a/frontend/src/lib/admin/clients/ClientAddNew.svelte
+++ b/frontend/src/lib/admin/clients/ClientAddNew.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Button from '$lib5/button/Button.svelte';
     import Input from '$lib5/form/Input.svelte';
-    import { PATTERN_CLIENT_NAME, PATTERN_LOWERCASE } from '$utils/patterns';
+    import { PATTERN_CLIENT_ID, PATTERN_CLIENT_NAME } from '$utils/patterns';
     import Form from '$lib5/form/Form.svelte';
     import { fetchPost } from '$api/fetch';
     import { useI18n } from '$state/i18n.svelte';
@@ -69,7 +69,7 @@
             label="Client ID"
             placeholder="Client ID"
             required
-            pattern={PATTERN_LOWERCASE}
+            pattern={PATTERN_CLIENT_ID}
         />
         <Input
             bind:value={name}

--- a/frontend/src/utils/patterns.ts
+++ b/frontend/src/utils/patterns.ts
@@ -6,7 +6,7 @@ export const PATTERN_ATTR = '^[a-zA-Z0-9\\-_\\/]{2,32}$';
 export const PATTERN_ATTR_DESC = '^[a-zA-Z0-9\\-_\\/\\s]{0,128}$';
 export const PATTERN_API_KEY = '^[a-zA-Z0-9_\\/\\-]{2,24}$';
 export const PATTERN_CITY = '^[a-zA-Z0-9À-ÿ\\-]{0,48}$';
-// export const PATTERN_CLIENT_ID_EPHEMERAL = '^[a-zA-Z0-9,.:\\/_\\-&?=~#!$\'\\(\\)*+%]{2,256}$';
+export const PATTERN_CLIENT_ID = "^[a-zA-Z0-9,.:\\/_\\-&?=~#!$'\\(\\)*+%]{2,256}$";
 export const PATTERN_CLIENT_NAME =
     '^[a-zA-Z0-9À-ɏ\\-\\s\\u3041-\\u3096\\u30A0-\\u30FF\\u3400-\\u4DB5\\u4E00-\\u9FCB\\uF900-\\uFA6A\\u2E80-\\u2FD5\\uFF66-\\uFF9F\\uFFA1-\\uFFDC\\u31F0-\\u31FF]{2,128}$';
 // export const PATTERN_DATE_STR = '[0-9]{4}\\-[0-9]{2}-[0-9]{2}$';

--- a/src/api_types/src/auth_providers.rs
+++ b/src/api_types/src/auth_providers.rs
@@ -1,7 +1,7 @@
 use crate::cust_validation::validate_vec_scopes;
 use rauthy_common::regex::{
-    RE_ALNUM, RE_ATPROTO_HANDLE, RE_CLIENT_ID_EPHEMERAL, RE_CLIENT_NAME, RE_CODE_CHALLENGE,
-    RE_SCOPE_SPACE, RE_URI,
+    RE_ALNUM, RE_ATPROTO_HANDLE, RE_CLIENT_ID, RE_CLIENT_NAME, RE_CODE_CHALLENGE, RE_SCOPE_SPACE,
+    RE_URI,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -102,7 +102,7 @@ pub struct ProviderLoginRequest {
     pub email: Option<String>,
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub client_id: String,
@@ -126,7 +126,7 @@ pub struct ProviderLoginRequest {
     pub code_challenge_method: Option<String>,
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub pow: String,

--- a/src/api_types/src/clients.rs
+++ b/src/api_types/src/clients.rs
@@ -1,8 +1,7 @@
 use crate::cust_validation::*;
 use crate::oidc::JwkKeyPairAlg;
 use rauthy_common::regex::{
-    RE_CLIENT_ID_EPHEMERAL, RE_CLIENT_NAME, RE_GROUPS, RE_LOWERCASE, RE_SCOPE_SPACE,
-    RE_TOKEN_ENDPOINT_AUTH_METHOD, RE_URI,
+    RE_CLIENT_ID, RE_CLIENT_NAME, RE_GROUPS, RE_SCOPE_SPACE, RE_TOKEN_ENDPOINT_AUTH_METHOD, RE_URI,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -79,7 +78,7 @@ pub struct DynamicClientRequest {
 pub struct EphemeralClientRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
     ))]
     pub client_id: String,
@@ -119,7 +118,10 @@ pub struct EphemeralClientRequest {
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewClientRequest {
     /// Validation: `^[a-z0-9-_/]{2,128}$`
-    #[validate(regex(path = "*RE_LOWERCASE", code = "^[a-z0-9-_/]{2,128}$"))]
+    #[validate(regex(
+        path = "*RE_CLIENT_ID",
+        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
+    ))]
     pub id: String,
     /// Validation: None - will not be deserialized
     #[serde(skip_deserializing)]
@@ -142,7 +144,7 @@ pub struct NewClientRequest {
 pub struct UpdateClientRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
     ))]
     pub id: String,

--- a/src/api_types/src/fed_cm.rs
+++ b/src/api_types/src/fed_cm.rs
@@ -1,4 +1,4 @@
-use rauthy_common::regex::{RE_ALNUM, RE_CLIENT_ID_EPHEMERAL, RE_URI};
+use rauthy_common::regex::{RE_ALNUM, RE_CLIENT_ID, RE_URI};
 use serde::Deserialize;
 use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
@@ -7,7 +7,7 @@ use validator::Validate;
 pub struct FedCMAssertionRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub client_id: String,
@@ -29,7 +29,7 @@ pub struct FedCMAssertionRequest {
 pub struct FedCMClientMetadataRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub client_id: String,

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -4,8 +4,8 @@ use crate::sessions::SessionState;
 use actix_web::HttpRequest;
 use actix_web::http::header;
 use rauthy_common::regex::{
-    RE_ALNUM, RE_BASE64, RE_CLIENT_ID_EPHEMERAL, RE_CODE_CHALLENGE_METHOD, RE_CODE_VERIFIER,
-    RE_GRANT_TYPES, RE_LOWERCASE, RE_SCOPE_SPACE, RE_URI,
+    RE_ALNUM, RE_BASE64, RE_CLIENT_ID, RE_CODE_CHALLENGE_METHOD, RE_CODE_VERIFIER, RE_GRANT_TYPES,
+    RE_LOWERCASE, RE_SCOPE_SPACE, RE_URI,
 };
 use rauthy_common::utils::base64_decode;
 use rauthy_error::{ErrorResponse, ErrorResponseType};
@@ -34,7 +34,7 @@ pub struct AddressClaim {
 pub struct AuthRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
     ))]
     pub client_id: String,
@@ -100,13 +100,13 @@ pub struct LoginRequest {
     pub password: Option<String>,
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub pow: String,
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub client_id: String,
@@ -134,7 +134,7 @@ pub struct LoginRequest {
 pub struct LoginRefreshRequest {
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub client_id: String,
@@ -227,7 +227,7 @@ pub struct TokenRequest {
     pub redirect_uri: Option<String>,
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
-        path = "*RE_CLIENT_ID_EPHEMERAL",
+        path = "*RE_CLIENT_ID",
         code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,128}$"
     ))]
     pub client_id: Option<String>,

--- a/src/api_types/src/themes.rs
+++ b/src/api_types/src/themes.rs
@@ -1,4 +1,4 @@
-use rauthy_common::regex::{RE_CLIENT_ID_EPHEMERAL, RE_CSS_VALUE_LOOSE};
+use rauthy_common::regex::{RE_CLIENT_ID, RE_CSS_VALUE_LOOSE};
 use rauthy_error::{ErrorResponse, ErrorResponseType};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -77,7 +77,7 @@ pub struct ThemeRequestResponse {
 
 impl ThemeRequestResponse {
     pub fn validate(&self) -> Result<(), ErrorResponse> {
-        if !RE_CLIENT_ID_EPHEMERAL.is_match(&self.client_id) {
+        if !RE_CLIENT_ID.is_match(&self.client_id) {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
                 "client_id must match: ^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$",

--- a/src/bin/src/init_static_vars.rs
+++ b/src/bin/src/init_static_vars.rs
@@ -141,7 +141,7 @@ pub fn trigger() {
     let _ = *RE_CODE_CHALLENGE_METHOD;
     let _ = *RE_CITY;
     if vars.ephemeral_clients.enable {
-        let _ = *RE_CLIENT_ID_EPHEMERAL;
+        let _ = *RE_CLIENT_ID;
     }
     let _ = *RE_CLIENT_NAME;
     let _ = *RE_CODE_CHALLENGE;

--- a/src/common/src/regex.rs
+++ b/src/common/src/regex.rs
@@ -19,7 +19,7 @@ pub static RE_CODE_CHALLENGE_METHOD: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(plain|S256)$").unwrap());
 pub static RE_CITY: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9À-ÿ-]{0,48}$").unwrap());
-pub static RE_CLIENT_ID_EPHEMERAL: LazyLock<Regex> =
+pub static RE_CLIENT_ID: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$").unwrap());
 pub static RE_CLIENT_NAME: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[a-zA-Z0-9À-ɏ-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{2,128}$").unwrap()


### PR DESCRIPTION
Addresses the issue #1410

I've made the unilateral decision to merge ephemeral clients and non ephemeral clients regex. Let me know what you think of it, and I'll re-create it with them being two again.

- Allows clientID to follow the same rules as ephemeral clients with upper cased letters
- Removes the now duplicate client-id-ephemeral regex