### PR TITLE
feat: opt-in cleanup for inactive dynamic clients

### DIFF
--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -998,6 +998,16 @@ pg_password = '123SuperSafe'
 # overwritten by: DYN_CLIENT_CLEANUP_MINUTES
 #cleanup_minutes = 60
 
+# Defines the number of days after which an inactive dynamic client will be
+# cleaned up. This applies to clients that have been used at least once but
+# have not been active since the configured amount of days.
+#
+# WARNING: This will permanently delete client registrations.
+#
+# default: 0 (disabled)
+# overwritten by: DYN_CLIENT_CLEANUP_INACTIVE_DAYS
+#cleanup_inactive_days = 0
+
 # The rate-limiter timeout for dynamic client registration.
 # This is the timeout in seconds which will prevent an IP from
 # registering another dynamic client, if no `DYN_CLIENT_REG_TOKEN`

--- a/config.toml
+++ b/config.toml
@@ -1005,6 +1005,16 @@ cleanup_interval = 60
 # overwritten by: DYN_CLIENT_CLEANUP_MINUTES
 cleanup_minutes = 60
 
+# Defines the number of days after which an inactive dynamic client will be
+# cleaned up. This applies to clients that have been used at least once but
+# have not been active since the configured amount of days.
+#
+# WARNING: This will permanently delete client registrations.
+#
+# default: 0 (disabled)
+# overwritten by: DYN_CLIENT_CLEANUP_INACTIVE_DAYS
+cleanup_inactive_days = 0
+
 # The rate-limiter timeout for dynamic client registration.
 # This is the timeout in seconds which will prevent an IP from
 # registering another dynamic client, if no `DYN_CLIENT_REG_TOKEN`

--- a/docs/config/config.html
+++ b/docs/config/config.html
@@ -1171,6 +1171,16 @@ pg_password = '123SuperSafe'
 # overwritten by: DYN_CLIENT_CLEANUP_MINUTES
 #cleanup_minutes = 60
 
+# Defines the number of days after which an inactive dynamic client will be
+# cleaned up. This applies to clients that have been used at least once but
+# have not been active since the configured amount of days.
+#
+# WARNING: This will permanently delete client registrations.
+#
+# default: 0 (disabled)
+# overwritten by: DYN_CLIENT_CLEANUP_INACTIVE_DAYS
+#cleanup_inactive_days = 0
+
 # The rate-limiter timeout for dynamic client registration.
 # This is the timeout in seconds which will prevent an IP from
 # registering another dynamic client, if no `DYN_CLIENT_REG_TOKEN`

--- a/env_vars_migration.md
+++ b/env_vars_migration.md
@@ -101,6 +101,7 @@
 | DYN_CLIENT_SECRET_AUTO_ROTATE              | dynamic_clients.secret_auto_rotate          | bool       |          |
 | DYN_CLIENT_CLEANUP_INTERVAL                | dynamic_clients.cleanup_interval            | u32        |          |
 | DYN_CLIENT_CLEANUP_MINUTES                 | dynamic_clients.cleanup_minutes             | u32        |          |
+| DYN_CLIENT_CLEANUP_INACTIVE_DAYS           | dynamic_clients.cleanup_inactive_days       | u32        |          |
 | DYN_CLIENT_RATE_LIMIT_SEC                  | dynamic_clients.rate_limit_sec              | u32        |          |
 | RAUTHY_ADMIN_EMAIL                         | email.rauthy_admin_email                    | String     |          |
 | EMAIL_SUB_PREFIX                           | email.sub_prefix                            | String     |          |

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -377,6 +377,7 @@ impl Default for Vars {
                 secret_auto_rotate: true,
                 cleanup_interval: 60,
                 cleanup_minutes: 60,
+                cleanup_inactive_days: 0,
                 rate_limit_sec: 60,
             },
             email: VarsEmail {
@@ -1362,6 +1363,14 @@ impl Vars {
             "DYN_CLIENT_CLEANUP_MINUTES",
         ) {
             self.dynamic_clients.cleanup_minutes = v;
+        }
+        if let Some(v) = t_u32(
+            &mut table,
+            "dynamic_clients",
+            "cleanup_inactive_days",
+            "DYN_CLIENT_CLEANUP_INACTIVE_DAYS",
+        ) {
+            self.dynamic_clients.cleanup_inactive_days = v;
         }
         if let Some(v) = t_u32(
             &mut table,
@@ -3037,6 +3046,7 @@ pub struct VarsDynamicClients {
     pub secret_auto_rotate: bool,
     pub cleanup_interval: u32,
     pub cleanup_minutes: u32,
+    pub cleanup_inactive_days: u32,
     pub rate_limit_sec: u32,
 }
 


### PR DESCRIPTION
As discussed previously (see [here](https://github.com/sebadob/rauthy/pull/1316#issuecomment-3759177068)), this PR implements an opt-in scheduler for cleaning up inactive dynamic client registrations.

Added `DYN_CLIENT_CLEANUP_INACTIVE_DAYS` config (default: `0`, disabled).
When enabled, the `dyn_client_cleanup` scheduler extends its scope to include clients that have `last_used` older than the configured threshold.
The scheduler still cleans up never-used clients as before.

This addresses the concern of database bloat from dynamic clients that are no longer in use, while allowing administrators to explicitly enable and configure this behavior to avoid unexpected deletions.