### PR TITLE
fix: enable CORS for revocation_endpoint

### DIFF
--- a/src/api/src/cors_preflight.rs
+++ b/src/api/src/cors_preflight.rs
@@ -66,6 +66,16 @@ pub async fn options_token() -> HttpResponse {
         .finish()
 }
 
+#[options("/oidc/token/revoke")]
+pub async fn options_token_revoke() -> HttpResponse {
+    HttpResponse::NoContent()
+        .insert_header((ACCESS_CONTROL_ALLOW_ORIGIN, "*"))
+        .insert_header((ACCESS_CONTROL_ALLOW_METHODS, "POST, OPTIONS"))
+        .insert_header((ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"))
+        .insert_header((ACCESS_CONTROL_ALLOW_HEADERS, ALLOW_HEADERS_WITH_AUTH))
+        .finish()
+}
+
 #[options("/oidc/introspect")]
 pub async fn options_introspect() -> HttpResponse {
     HttpResponse::NoContent()

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -295,6 +295,7 @@ fn api_services() -> actix_web::Scope {
                 .service(cors_preflight::options_certs_by_kid)
                 .service(cors_preflight::options_logout)
                 .service(cors_preflight::options_token)
+                .service(cors_preflight::options_token_revoke)
                 .service(cors_preflight::options_introspect)
                 .service(cors_preflight::options_userinfo)
                 .service(cors_preflight::options_users_picture)

--- a/src/middlewares/src/csrf_protection.rs
+++ b/src/middlewares/src/csrf_protection.rs
@@ -135,6 +135,7 @@ fn is_path_csrf_exception(path: &str) -> bool {
             // have their own custom validation
             path == "/oidc/authorize"
                 || path == "/oidc/token"
+                || path == "/oidc/token/revoke"
                 || path == "/oidc/logout"
                 // no issue with CORS
                 || path == "/clients_dyn"


### PR DESCRIPTION
Add CORS support to the `/oidc/token/revoke` endpoint. This is required for web-based apps like Element Web to properly handle token revocation from the browser.