### PR TITLE
fix: add trailing slash to issuer for better OIDC discovery compatibility

### DIFF
--- a/src/data/src/entity/well_known.rs
+++ b/src/data/src/entity/well_known.rs
@@ -85,19 +85,19 @@ impl WellKnown {
     pub fn new(scopes_supported: Vec<String>) -> Self {
         let issuer = &RauthyConfig::get().issuer;
 
-        let authorization_endpoint = format!("{issuer}/oidc/authorize");
-        let device_authorization_endpoint = format!("{issuer}/oidc/device");
-        let token_endpoint = format!("{issuer}/oidc/token");
-        let introspection_endpoint = format!("{issuer}/oidc/introspect");
-        let revocation_endpoint = format!("{issuer}/oidc/token/revoke");
-        let userinfo_endpoint = format!("{issuer}/oidc/userinfo");
+        let authorization_endpoint = format!("{issuer}oidc/authorize");
+        let device_authorization_endpoint = format!("{issuer}oidc/device");
+        let token_endpoint = format!("{issuer}oidc/token");
+        let introspection_endpoint = format!("{issuer}oidc/introspect");
+        let revocation_endpoint = format!("{issuer}oidc/token/revoke");
+        let userinfo_endpoint = format!("{issuer}oidc/userinfo");
         let registration_endpoint = RauthyConfig::get()
             .vars
             .dynamic_clients
             .enable
-            .then_some(format!("{issuer}/clients_dyn"));
-        let end_session_endpoint = format!("{issuer}/oidc/logout");
-        let jwks_uri = format!("{issuer}/oidc/certs");
+            .then_some(format!("{issuer}clients_dyn"));
+        let end_session_endpoint = format!("{issuer}oidc/logout");
+        let jwks_uri = format!("{issuer}oidc/certs");
 
         WellKnown {
             issuer: String::from(issuer),

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -111,7 +111,7 @@ impl RauthyConfig {
             ListenScheme::HttpHttps | ListenScheme::Https | ListenScheme::UnixHttps
         ) || vars.server.proxy_mode;
         let issuer_scheme = if is_https { "https" } else { "http" };
-        let issuer = format!("{issuer_scheme}://{}/auth/v1", vars.server.pub_url);
+        let issuer = format!("{issuer_scheme}://{}/auth/v1/", vars.server.pub_url);
 
         let Ok(log_level_access) = LogLevelAccess::from_str(&vars.logging.level_access) else {
             panic!(


### PR DESCRIPTION
Rauthy default issuer format (`/auth/v1`) currently breaks OIDC discovery in clients that use standard URL resolution (RFC 3986), such as [`matrix-js-sdk`](https://github.com/matrix-org/matrix-js-sdk/blob/8073f27d98acd385a143a12f1d754d301a2f82f1/src/oidc/discovery.ts#L36).

When the issuer URL lacks a trailing slash, the standard `new URL()` constructor treats the last segment (`v1`) as a filename and strips it when joining the discovery path.

**Example of the issue:**
```javascript
// Current Rauthy default
const issuer = "https://example.com/auth/v1";
new URL(".well-known/openid-configuration", issuer).href;
// Returns: https://example.com/auth/.well-known/openid-configuration
// The 'v1' segment is lost, leading to 404s.
```

By adding a trailing slash to the base issuer, we ensure that the `/v1/` segment is preserved as part of the path. I've also updated the endpoint formatting in `well_known.rs` to prevent double slashes in the generated metadata.