### PR TITLE
remove "multilingual" k/v pair from book.toml

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["sebastiandobe@mailbox.org"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Rauthy Documentation"
 


### PR DESCRIPTION
afaict, `multilingual = ...` isn't a supported option for mdbook.