### PR TITLE
fix: allow space-delimited prompt parameter and handle 'consent'

### DIFF
--- a/src/api/src/oidc.rs
+++ b/src/api/src/oidc.rs
@@ -111,7 +111,7 @@ pub async fn get_authorize(
     let mut force_new_session = if params
         .prompt
         .as_ref()
-        .map(|p| p.as_str() == "login")
+        .map(|p| p.contains("login"))
         .unwrap_or(false)
     {
         true
@@ -145,7 +145,11 @@ pub async fn get_authorize(
 
     // check for `prompt=none` and redirect if we don't have a valid session
     if !force_new_session
-        && params.prompt.as_deref() == Some("none")
+        && params
+            .prompt
+            .as_ref()
+            .map(|p| p.contains("none"))
+            .unwrap_or(false)
         && principal.validate_session_auth().is_err()
     {
         let mut loc = params.redirect_uri;
@@ -189,7 +193,12 @@ pub async fn get_authorize(
     }
 
     // if the user is still authenticated and everything is valid -> immediate refresh
-    if !force_new_session && principal.validate_session_auth().is_ok() {
+    let prompt_consent = params
+        .prompt
+        .as_ref()
+        .map(|p| p.contains("consent"))
+        .unwrap_or(false);
+    if !force_new_session && !prompt_consent && principal.validate_session_auth().is_ok() {
         let csrf = principal.get_session_csrf_token()?;
 
         templates.push(HtmlTemplate::CsrfToken(csrf.to_string()));

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -59,8 +59,8 @@ pub struct AuthRequest {
     pub code_challenge_method: Option<String>,
     #[validate(range(min = 0))]
     pub max_age: Option<i64>,
-    /// Validation: `[a-zA-Z0-9]`
-    #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
+    /// Validation: `[a-zA-Z0-9_\s]{0,128}`
+    #[validate(regex(path = "*RE_SCOPE_SPACE", code = "[a-zA-Z0-9_\\s]{0,128}"))]
     pub prompt: Option<String>,
 }
 


### PR DESCRIPTION
Relaxed prompt validation in AuthRequest to allow spaces and underscores (supporting standard values like select_account and lists).
Updated get_authorize logic to use .contains() for checking login, none, and consent values in the prompt string.
Implemented consent handling by preventing the automatic "immediate refresh" when specified, forcing the user to interact with the login flow.
Fixes issue where clients sending prompt=consent select_account received a BadRequest validation error.