### PR TITLE
feat: add redirect from `/auth/v1/` to `/auth/v1/account`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -271,6 +271,14 @@ whoami_headers = true
 # overwritten by: ADMIN_BUTTON_HIDE
 admin_button_hide = false
 
+# If set to `true`, requests to `/auth/v1/` will be redirected to
+# `/auth/v1/account` (the account dashboard). This is useful if you want
+# users to land directly on their account page when visiting the root URL.
+#
+# default: false
+# overwritten by: REDIRECT_ROOT_TO_ACCOUNT
+redirect_root_to_account = false
+
 [atproto]
 # Set to `true` to enable the ATProto provider. If the public URL is
 # 'localhost' it should be changed to '127.0.0.1', if `dev_mode = true`

--- a/src/api/src/html.rs
+++ b/src/api/src/html.rs
@@ -3,6 +3,7 @@ use actix_web::http::header;
 use actix_web::{HttpRequest, HttpResponse, get, web};
 use rauthy_data::entity::theme::ThemeCssFull;
 use rauthy_data::html::HtmlCached;
+use rauthy_data::rauthy_config::RauthyConfig;
 use rauthy_error::ErrorResponse;
 use std::borrow::Cow;
 
@@ -42,9 +43,15 @@ pub async fn get_static_assets(
 
 #[get("/")]
 pub async fn get_index(req: HttpRequest) -> Result<HttpResponse, ErrorResponse> {
-    HtmlCached::Index
-        .handle(req, ThemeCssFull::find_theme_ts_rauthy().await?, true)
-        .await
+    if RauthyConfig::get().vars.access.redirect_root_to_account {
+        Ok(HttpResponse::Found()
+            .insert_header(("location", "/auth/v1/account"))
+            .finish())
+    } else {
+        HtmlCached::Index
+            .handle(req, ThemeCssFull::find_theme_ts_rauthy().await?, true)
+            .await
+    }
 }
 
 #[get("/account")]

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -309,6 +309,7 @@ impl Default for Vars {
                 token_revoke_device_tokens: false,
                 whoami_headers: false,
                 admin_button_hide: false,
+                redirect_root_to_account: false,
             },
             auth_headers: VarsAuthHeaders {
                 enable: false,
@@ -1182,6 +1183,14 @@ impl Vars {
             "ADMIN_BUTTON_HIDE",
         ) {
             self.access.admin_button_hide = v;
+        }
+        if let Some(v) = t_bool(
+            &mut table,
+            "access",
+            "redirect_root_to_account",
+            "REDIRECT_ROOT_TO_ACCOUNT",
+        ) {
+            self.access.redirect_root_to_account = v;
         }
     }
 
@@ -3192,6 +3201,7 @@ pub struct VarsAccess {
     pub token_revoke_device_tokens: bool,
     pub whoami_headers: bool,
     pub admin_button_hide: bool,
+    pub redirect_root_to_account: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Adds a new configuration option `redirect_root_to_account` in the `[access]` section that enables HTTP 302 redirect from `/auth/v1/` to `/auth/v1/account` (user account dashboard).

When Rauthy is used as the primary identity provider, users visiting the root URL typically want to access their account page directly. This change provides a cleaner UX without requiring users to navigate to `/account` manually.