### PR TITLE
feat: process nonce within device authorization flow

### DIFF
--- a/src/api/src/oidc.rs
+++ b/src/api/src/oidc.rs
@@ -616,7 +616,7 @@ pub async fn post_device_auth(
     }
 
     // we are good - create the code
-    let code = match DeviceAuthCode::new(scopes, client.id, payload.client_secret).await {
+    let code = match DeviceAuthCode::new(scopes, client.id, payload.client_secret, payload.nonce).await {
         Ok(code) => code,
         Err(err) => {
             return HttpResponse::InternalServerError().json(OAuth2ErrorResponse {

--- a/src/api/src/oidc.rs
+++ b/src/api/src/oidc.rs
@@ -616,15 +616,16 @@ pub async fn post_device_auth(
     }
 
     // we are good - create the code
-    let code = match DeviceAuthCode::new(scopes, client.id, payload.client_secret, payload.nonce).await {
-        Ok(code) => code,
-        Err(err) => {
-            return HttpResponse::InternalServerError().json(OAuth2ErrorResponse {
-                error: OAuth2ErrorTypeResponse::InvalidRequest,
-                error_description: Some(err.message),
-            });
-        }
-    };
+    let code =
+        match DeviceAuthCode::new(scopes, client.id, payload.client_secret, payload.nonce).await {
+            Ok(code) => code,
+            Err(err) => {
+                return HttpResponse::InternalServerError().json(OAuth2ErrorResponse {
+                    error: OAuth2ErrorTypeResponse::InvalidRequest,
+                    error_description: Some(err.message),
+                });
+            }
+        };
 
     let user_code = code.user_code();
     let verification_uri = code.verification_uri();

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -193,6 +193,9 @@ pub struct DeviceGrantRequest {
     /// Validation: `[a-zA-Z0-9-_/:\s*]{0,512}`
     #[validate(regex(path = "*RE_SCOPE_SPACE", code = "[a-zA-Z0-9-_/:\\s*]{0,512}"))]
     pub scope: Option<String>,
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$`
+    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$"))]
+    pub nonce: Option<String>,
 }
 
 #[derive(Deserialize, Validate, ToSchema)]

--- a/src/data/src/entity/devices.rs
+++ b/src/data/src/entity/devices.rs
@@ -180,6 +180,7 @@ pub struct DeviceAuthCode {
     pub exp: DateTime<Utc>,
     pub last_poll: DateTime<Utc>,
     pub scopes: Option<String>,
+    pub nonce: Option<String>,
     // TODO we should probably save it hashed, even though it is only very shortly lived
     // saved additionally here to have fewer cache requests during client polling
     pub client_secret: Option<String>,
@@ -195,6 +196,7 @@ impl DeviceAuthCode {
         scopes: Option<String>,
         client_id: String,
         client_secret: Option<String>,
+        nonce: Option<String>,
     ) -> Result<Self, ErrorResponse> {
         let now = Utc::now();
         let ttl = RauthyConfig::get().vars.device_grant.code_lifetime as i64;
@@ -206,6 +208,7 @@ impl DeviceAuthCode {
             exp,
             last_poll: now,
             scopes,
+            nonce,
             client_secret,
             warnings: 0,
         };

--- a/src/service/src/oidc/grant_types/device_code.rs
+++ b/src/service/src/oidc/grant_types/device_code.rs
@@ -1,4 +1,4 @@
-use crate::token_set::{AuthCodeFlow, AuthTime, DeviceCodeFlow, TokenScopes, TokenSet};
+use crate::token_set::{AuthCodeFlow, AuthTime, DeviceCodeFlow, TokenNonce, TokenScopes, TokenSet};
 use actix_web::HttpResponse;
 use chrono::Utc;
 use rauthy_api_types::oidc::{OAuth2ErrorResponse, OAuth2ErrorTypeResponse, TokenRequest};
@@ -160,7 +160,7 @@ pub async fn grant_type_device_code(peer_ip: IpAddr, payload: TokenRequest) -> H
             &client,
             AuthTime::now(),
             None,
-            None,
+            code.nonce.map(TokenNonce),
             code.scopes.map(TokenScopes),
             None,
             AuthCodeFlow::No,


### PR DESCRIPTION
This commit:
- Accepts a nonce within the device authorization flow
- Stores the nonce in the cache when the device code is created
- Returns the nonce with the token once the device code is authorized

A nonce is useful in this flow to prevent token replay attacks.