### PR TITLE
fix: don't panic when an e-mail is undeliverable

### DIFF
--- a/src/api_types/src/events.rs
+++ b/src/api_types/src/events.rs
@@ -36,6 +36,7 @@ pub enum EventType {
     LoginNewLocation,
     TokenIssued,
     CredentialStuffing,
+    EmailSendError,
 }
 
 #[derive(Deserialize, Validate, ToSchema, IntoParams)]

--- a/src/data/src/email/custom.rs
+++ b/src/data/src/email/custom.rs
@@ -1,4 +1,4 @@
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::theme::ThemeCssFull;
 use crate::entity::users::User;
 use crate::rauthy_config::RauthyConfig;
@@ -88,6 +88,7 @@ pub async fn send_custom(
 ) -> Result<(), ErrorResponse> {
     let email_sub_prefix = &RauthyConfig::get().vars.email.sub_prefix;
     let req = EMail {
+        typ: EmailType::Custom,
         recipient_name: user.email_recipient_name(),
         address: user.email.to_string(),
         subject: format!("{email_sub_prefix} - {subject}"),

--- a/src/data/src/email/email_change_confirm.rs
+++ b/src/data/src/email/email_change_confirm.rs
@@ -1,5 +1,5 @@
 use crate::email::i18n::confirm_change::I18nEmailConfirmChange;
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::theme::ThemeCssFull;
 use crate::entity::users::User;
 use crate::rauthy_config::RauthyConfig;
@@ -63,6 +63,7 @@ pub async fn send_email_confirm_change(
     };
 
     let req = EMail {
+        typ: EmailType::EmailChangeConfirm,
         recipient_name: user.email_recipient_name(),
         address: email_addr.to_string(),
         subject: format!("{email_sub_prefix} - {}", i18n.subject),

--- a/src/data/src/email/email_change_info.rs
+++ b/src/data/src/email/email_change_info.rs
@@ -1,6 +1,6 @@
 use crate::email::email_ts_prettify;
 use crate::email::i18n::change_info_new::I18nEmailChangeInfoNew;
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::magic_links::MagicLink;
 use crate::entity::theme::ThemeCssFull;
 use crate::entity::users::User;
@@ -81,6 +81,7 @@ pub async fn send_email_change_info_new(
     };
 
     let req = EMail {
+        typ: EmailType::EmailChangeInfo,
         recipient_name: user.email_recipient_name(),
         address: new_email.clone(),
         subject: format!("{} - {}", email_sub_prefix, i18n.subject),

--- a/src/data/src/email/email_registered_already.rs
+++ b/src/data/src/email/email_registered_already.rs
@@ -1,5 +1,5 @@
 use crate::email::i18n::email_registered_already::I18nEmailRegisteredAlready;
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::theme::ThemeCssFull;
 use crate::entity::users::User;
 use crate::rauthy_config::RauthyConfig;
@@ -68,6 +68,7 @@ pub async fn send_email_registered_already(user: &User) {
     };
 
     let req = EMail {
+        typ: EmailType::EmailRegisteredAlready,
         recipient_name: user.email_recipient_name(),
         address: user.email.clone(),
         subject: format!("{} - {}", email_sub_prefix, i18n.subject),

--- a/src/data/src/email/login_location.rs
+++ b/src/data/src/email/login_location.rs
@@ -1,5 +1,5 @@
 use crate::email::i18n::login_location::I18nEmailLoginLocation;
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::theme::ThemeCssFull;
 use crate::entity::users::User;
 use crate::rauthy_config::RauthyConfig;
@@ -90,6 +90,7 @@ pub async fn send_login_location(
     };
 
     let req = EMail {
+        typ: EmailType::LoginLocation,
         recipient_name: user.email_recipient_name(),
         address: user.email.to_string(),
         subject: format!("{email_sub_prefix} - {}", i18n.subject),

--- a/src/data/src/email/mailer.rs
+++ b/src/data/src/email/mailer.rs
@@ -1,6 +1,7 @@
 use crate::database::DB;
 use crate::email::mailer_microsoft_graph::sender_microsoft_graph;
 use crate::email::smtp_oauth_token::SmtpOauthToken;
+use crate::events::event::Event;
 use crate::rauthy_config::RauthyConfig;
 use lettre::message::{MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::Mechanism;
@@ -8,12 +9,41 @@ use lettre::transport::smtp::{authentication, client};
 use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor, message};
 use rauthy_error::{ErrorResponse, ErrorResponseType};
 use serde::Deserialize;
+use std::fmt::{Display, Formatter};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EmailType {
+    Custom,
+    EmailChangeConfirm,
+    EmailChangeInfo,
+    EmailRegisteredAlready,
+    LoginLocation,
+    Notification,
+    PasswordReset,
+    PasswordResetInfo,
+}
+
+impl Display for EmailType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Custom => write!(f, "Custom"),
+            Self::EmailChangeConfirm => write!(f, "EmailChangeConfirm"),
+            Self::EmailChangeInfo => write!(f, "EmailChangeInfo"),
+            Self::EmailRegisteredAlready => write!(f, "EmailRegisteredAlready"),
+            Self::LoginLocation => write!(f, "LoginLocation"),
+            Self::Notification => write!(f, "Notification"),
+            Self::PasswordReset => write!(f, "PasswordReset"),
+            Self::PasswordResetInfo => write!(f, "PasswordResetInfo"),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct EMail {
+    pub typ: EmailType,
     pub recipient_name: String,
     pub address: String,
     pub subject: String,
@@ -146,9 +176,17 @@ async fn sender_default_smtp(smtp_url: &str, mut rx: mpsc::Receiver<EMail>) {
                             info!("E-Mail to '{}' sent successfully after retry!", req.address);
                         }
                         Err(err) => {
-                            // we want to panic if multiple sends fail so emails don't get lost
-                            // silently
-                            panic!("Could not send E-Mail even after retrying: {err:?}");
+                            // Log loudly and emit an event so admins see the failure.
+                            error!(
+                                error = ?err,
+                                "Could not send E-Mail to '{}' even after retrying - dropping it",
+                                req.address
+                            );
+                            if let Err(err) =
+                                Event::email_send_error(req.typ, &req.address).send().await
+                            {
+                                error!(?err, "Could not push EmailSendError event");
+                            }
                         }
                     }
                 }

--- a/src/data/src/email/mailer_microsoft_graph.rs
+++ b/src/data/src/email/mailer_microsoft_graph.rs
@@ -1,5 +1,6 @@
 use crate::email::mailer::EMail;
 use crate::email::smtp_oauth_token::SmtpOauthToken;
+use crate::events::event::Event;
 use crate::rauthy_config::RauthyConfig;
 use lettre::message;
 use rauthy_common::HTTP_CLIENT;
@@ -97,6 +98,10 @@ pub async fn sender_microsoft_graph(mut rx: mpsc::Receiver<EMail>) {
                 }
             };
 
+            // capture before `req` is moved into the message
+            let email_typ = req.typ;
+            let recipient = req.address.clone();
+
             let email = MicrosoftMessage {
                 message: MicrosoftEmail {
                     bcc_recipients: Vec::default(),
@@ -121,9 +126,14 @@ pub async fn sender_microsoft_graph(mut rx: mpsc::Receiver<EMail>) {
                 tokio::time::sleep(Duration::from_millis(500)).await;
 
                 if let Err(err) = send_email(&email).await {
-                    // we want to panic if multiple sends fail so emails don't get lost
-                    // silently
-                    panic!("Could not send E-Mail even after retrying: {err:?}");
+                    error!(
+                        error = ?err,
+                        "Could not send E-Mail to '{}' even after retrying - dropping it",
+                        recipient
+                    );
+                    if let Err(err) = Event::email_send_error(email_typ, &recipient).send().await {
+                        error!(?err, "Could not push EmailSendError event");
+                    }
                 }
             }
         } else {

--- a/src/data/src/email/notification.rs
+++ b/src/data/src/email/notification.rs
@@ -1,4 +1,4 @@
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::theme::ThemeCssFull;
 use askama::Template;
 use rauthy_notify::Notification;
@@ -48,6 +48,7 @@ pub async fn send_email_notification(
     };
 
     let req = EMail {
+        typ: EmailType::Notification,
         recipient_name,
         address,
         subject: notification.head.to_string(),

--- a/src/data/src/email/password_reset.rs
+++ b/src/data/src/email/password_reset.rs
@@ -1,7 +1,7 @@
 use crate::email::email_ts_prettify;
 use crate::email::i18n::password_new::I18nEmailPasswordNew;
 use crate::email::i18n::reset::I18nEmailReset;
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::magic_links::MagicLink;
 use crate::entity::theme::ThemeCssFull;
 use crate::entity::users::User;
@@ -138,6 +138,7 @@ pub async fn send_pwd_reset(magic_link: &MagicLink, user: &User, user_tz: Option
     };
 
     let req = EMail {
+        typ: EmailType::PasswordReset,
         recipient_name: user.email_recipient_name(),
         address: user.email.to_string(),
         subject: format!("{email_sub_prefix} - {subject}"),

--- a/src/data/src/email/password_reset_info.rs
+++ b/src/data/src/email/password_reset_info.rs
@@ -1,6 +1,6 @@
 use crate::email::email_ts_prettify;
 use crate::email::i18n::reset_info::I18nEmailResetInfo;
-use crate::email::mailer::EMail;
+use crate::email::mailer::{EMail, EmailType};
 use crate::entity::theme::ThemeCssFull;
 use crate::entity::users::User;
 use crate::rauthy_config::RauthyConfig;
@@ -69,6 +69,7 @@ pub async fn send_pwd_reset_info(user: &User) {
     };
 
     let req = EMail {
+        typ: EmailType::PasswordResetInfo,
         recipient_name: user.email_recipient_name(),
         address: user.email.to_string(),
         subject: format!("{email_sub_prefix} - {}", i18n.subject),

--- a/src/data/src/events/event.rs
+++ b/src/data/src/events/event.rs
@@ -163,6 +163,7 @@ pub enum EventType {
     LoginNewLocation,
     TokenIssued,
     CredentialStuffing,
+    EmailSendError,
 }
 
 impl Display for EventType {
@@ -191,6 +192,7 @@ impl Display for EventType {
             Self::LoginNewLocation => write!(f, "Login from new location"),
             Self::TokenIssued => write!(f, "JWT Token issued"),
             Self::CredentialStuffing => write!(f, "Possible credential stuffing"),
+            Self::EmailSendError => write!(f, "E-Mail send error"),
         }
     }
 }
@@ -223,6 +225,7 @@ impl From<rauthy_api_types::events::EventType> for EventType {
             rauthy_api_types::events::EventType::LoginNewLocation => Self::LoginNewLocation,
             rauthy_api_types::events::EventType::TokenIssued => Self::TokenIssued,
             rauthy_api_types::events::EventType::CredentialStuffing => Self::CredentialStuffing,
+            rauthy_api_types::events::EventType::EmailSendError => Self::EmailSendError,
         }
     }
 }
@@ -253,6 +256,7 @@ impl From<EventType> for rauthy_api_types::events::EventType {
             EventType::LoginNewLocation => Self::LoginNewLocation,
             EventType::TokenIssued => Self::TokenIssued,
             EventType::CredentialStuffing => Self::CredentialStuffing,
+            EventType::EmailSendError => Self::EmailSendError,
         }
     }
 }
@@ -283,6 +287,7 @@ impl EventType {
             Self::LoginNewLocation => "LoginNewLocation",
             Self::TokenIssued => "TokenIssued",
             Self::CredentialStuffing => "CredentialStuffing",
+            Self::EmailSendError => "EmailSendError",
         }
     }
 
@@ -314,6 +319,7 @@ impl EventType {
             EventType::LoginNewLocation => 20,
             EventType::TokenIssued => 21,
             EventType::CredentialStuffing => 22,
+            EventType::EmailSendError => 23,
         }
     }
 }
@@ -344,6 +350,7 @@ impl From<String> for EventType {
             "LoginNewLocation" => Self::LoginNewLocation,
             "TokenIssued" => Self::TokenIssued,
             "CredentialStuffing" => Self::CredentialStuffing,
+            "EmailSendError" => Self::EmailSendError,
             // just return test to never panic
             s => {
                 error!("EventType::from() for invalid String: {s}");
@@ -385,6 +392,7 @@ impl From<i64> for EventType {
             20 => EventType::LoginNewLocation,
             21 => EventType::TokenIssued,
             22 => EventType::CredentialStuffing,
+            23 => EventType::EmailSendError,
             _ => EventType::Test,
         }
     }
@@ -495,6 +503,7 @@ impl From<&Event> for Notification {
                 "Potential credential stuffing detected from IP: '{}'",
                 value.ip.as_deref().unwrap_or_default()
             )),
+            EventType::EmailSendError => value.text.clone(),
         };
 
         Self {
@@ -870,6 +879,20 @@ impl Event {
         )
     }
 
+    pub fn email_send_error(typ: crate::email::mailer::EmailType, address: &str) -> Self {
+        Self::new(
+            RauthyConfig::get()
+                .vars
+                .events
+                .level_email_send_error
+                .clone(),
+            EventType::EmailSendError,
+            None,
+            None,
+            Some(format!("{typ} -> {address}")),
+        )
+    }
+
     pub fn scim_task_failed(client_id: &str, action: &ScimAction, retries: i32) -> Self {
         Self::new(
             RauthyConfig::get()
@@ -1036,6 +1059,7 @@ impl Event {
             EventType::SuspiciousApiScan => self.text.clone().unwrap_or_default(),
             EventType::LoginNewLocation => self.text.clone().unwrap_or_default(),
             EventType::TokenIssued => self.text.clone().unwrap_or_default(),
+            EventType::EmailSendError => self.text.clone().unwrap_or_default(),
         }
     }
 

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -479,6 +479,7 @@ impl Default for Vars {
                 level_force_logout: EventLevel::Notice,
                 level_user_login_revoke: EventLevel::Warning,
                 level_scim_task_failed: EventLevel::Critical,
+                level_email_send_error: EventLevel::Critical,
                 level_suspicious_request: EventLevel::Notice,
                 level_new_login_location: EventLevel::Notice,
                 level_token_issued: EventLevel::Info,
@@ -2132,6 +2133,15 @@ impl Vars {
         if let Some(v) = t_str(
             &mut table,
             "events",
+            "level_email_send_error",
+            "EVENT_LEVEL_EMAIL_SEND_ERROR",
+        ) {
+            self.events.level_email_send_error =
+                EventLevel::from_str(&v).expect("Cannot parse EventLevel for email_send_error");
+        }
+        if let Some(v) = t_str(
+            &mut table,
+            "events",
             "level_suspicious_request",
             "EVENT_LEVEL_SUSPICIOUS_REQUEST",
         ) {
@@ -3468,6 +3478,7 @@ pub struct VarsEvents {
     pub level_force_logout: EventLevel,
     pub level_user_login_revoke: EventLevel,
     pub level_scim_task_failed: EventLevel,
+    pub level_email_send_error: EventLevel,
     pub level_suspicious_request: EventLevel,
     pub level_new_login_location: EventLevel,
     pub level_token_issued: EventLevel,


### PR DESCRIPTION
Closes #1556

The mailer worker calls `panic!` when a message still fails after the retry. As noted in the issue, a user registering with an invalid email domain (no MX/A record) is enough to trigger a permanent SMTP failure, which then panics the `tokio-rt-worker` and brings down the instance.

This replaces the `panic!` with a loud `error!` log including the recipient address, so the failure is visible but the worker keeps running and other queued mails are still delivered.