### PR TITLE
fix(ui): URL-encode `client.id` in admin path segments

### DIFF
--- a/frontend/src/lib/ClientLogo.svelte
+++ b/frontend/src/lib/ClientLogo.svelte
@@ -12,8 +12,8 @@
     let showDefault = $state(false);
     let src = $derived(
         updated
-            ? `/auth/v1/clients/${clientId}/logo?updated=${updated}`
-            : `/auth/v1/clients/${clientId}/logo`,
+            ? `/auth/v1/clients/${encodeURIComponent(clientId)}/logo?updated=${updated}`
+            : `/auth/v1/clients/${encodeURIComponent(clientId)}/logo`,
     );
 </script>
 

--- a/frontend/src/lib/admin/clients/ClientConfig.svelte
+++ b/frontend/src/lib/admin/clients/ClientConfig.svelte
@@ -173,7 +173,7 @@
     });
 
     async function fetchClientDetails() {
-        let res = await fetchGet<ClientResponse>(`/auth/v1/clients/${client.id}`);
+        let res = await fetchGet<ClientResponse>(`/auth/v1/clients/${encodeURIComponent(client.id)}`);
         if (res.body) {
             let resp = res.body;
             // The only real difference here can be the `client.scim`, as all the rest is already included in the
@@ -275,7 +275,7 @@
 </script>
 
 <div class="container">
-    <Form action={`/auth/v1/clients/${client.id}`} {onSubmit}>
+    <Form action={`/auth/v1/clients/${encodeURIComponent(client.id)}`} {onSubmit}>
         <h5>{ta.common.information}</h5>
 
         <LabeledValue label="ID" mono copyToClip={client.id}>

--- a/frontend/src/lib/admin/clients/ClientDelete.svelte
+++ b/frontend/src/lib/admin/clients/ClientDelete.svelte
@@ -23,7 +23,7 @@
         err = '';
         isLoading = true;
 
-        let res = await fetchDelete(`/auth/v1/clients/${client.id}`);
+        let res = await fetchDelete(`/auth/v1/clients/${encodeURIComponent(client.id)}`);
         isLoading = false;
 
         if (res.error) {

--- a/frontend/src/lib/admin/clients/ClientSecret.svelte
+++ b/frontend/src/lib/admin/clients/ClientSecret.svelte
@@ -47,7 +47,7 @@
     });
 
     async function fetchSecret() {
-        let res = await fetchPost<ClientSecretResponse>(`/auth/v1/clients/${client.id}/secret`);
+        let res = await fetchPost<ClientSecretResponse>(`/auth/v1/clients/${encodeURIComponent(client.id)}/secret`);
         if (res.body) {
             if (res.body.secret) {
                 secret = res.body.secret;
@@ -62,7 +62,7 @@
             cache_current_hours: cacheSecret ? Number.parseInt(cacheCurrentHours) : undefined,
         };
         let res = await fetchPut<ClientSecretResponse>(
-            `/auth/v1/clients/${client.id}/secret`,
+            `/auth/v1/clients/${encodeURIComponent(client.id)}/secret`,
             payload,
         );
         if (res.body) {

--- a/frontend/src/lib/admin/clients/branding/ClientBranding.svelte
+++ b/frontend/src/lib/admin/clients/branding/ClientBranding.svelte
@@ -30,8 +30,8 @@
     let theme: ThemeRequestResponse | undefined = $state();
 
     let logoKey = $state(genKey());
-    let logoUrl = $derived(`/auth/v1/clients/${client.id}/logo?${logoKey}`);
-    let url = $derived(`/auth/v1/theme/${client.id}`);
+    let logoUrl = $derived(`/auth/v1/clients/${encodeURIComponent(client.id)}/logo?${logoKey}`);
+    let url = $derived(`/auth/v1/theme/${encodeURIComponent(client.id)}`);
 
     $effect(() => {
         fetchTheme();
@@ -72,7 +72,7 @@
         if (res.error) {
             err = res.error.message;
         } else {
-            await fetchDelete(`/auth/v1/clients/${client.id}/logo`);
+            await fetchDelete(`/auth/v1/clients/${encodeURIComponent(client.id)}/logo`);
 
             await fetchTheme();
             logoKey = genKey();
@@ -121,7 +121,7 @@
                 <p>Logo Upload</p>
                 <InputFile
                     method="PUT"
-                    url={`/auth/v1/clients/${client.id}/logo`}
+                    url={`/auth/v1/clients/${encodeURIComponent(client.id)}/logo`}
                     fileName="logo"
                     onSuccess={onUploadSuccess}
                 />


### PR DESCRIPTION
## Summary

The admin UI interpolates `client.id` directly into the path segment of `/auth/v1/clients/<id>...` requests across multiple components. For opaque-string client_ids (`dyn$Abc123`, `rauthy`, etc.) this is fine. For URL-shaped client_ids — which `RE_CLIENT_ID` already allows (`[a-zA-Z0-9,.:/_\-&?=~#!()*+%]{2,256}`) — the slashes and colons leak into the path and produce 404s on every UI action: viewing config, generating/rotating secrets, deleting, uploading branding/logo, fetching theme.

URL-shaped client_ids are useful for OAuth resource servers that want the audience to byte-match the resource URL (`aud = client.id = https://api.example.com/`), or for the MCP ecosystem where the connector resource URL doubles as the client identity.

## Fix

Wrap every path-segment `${client.id}` (and `${clientId}` in `ClientLogo.svelte`) with `encodeURIComponent`. The interpolation as a body/form/query value is unchanged — that's already safe.

## Affected files

- `frontend/src/lib/ClientLogo.svelte`
- `frontend/src/lib/admin/clients/ClientConfig.svelte`
- `frontend/src/lib/admin/clients/ClientDelete.svelte`
- `frontend/src/lib/admin/clients/ClientSecret.svelte`
- `frontend/src/lib/admin/clients/branding/ClientBranding.svelte`

5 files, 11 lines, no behaviour change for any client_id that doesn't contain URL-unsafe characters.

## Test plan

- [x] Verified locally against a static client with `id = "https://otel-rauthy-mcp.demo.altinity.cloud/"` — before the patch every admin-UI action 404s, after the patch each works (Config tab loads, Secret generation succeeds, Branding saves, Delete works).
- [x] Verified opaque-string clients (`dyn$*`, `rauthy`) still work — `encodeURIComponent` is a no-op for them.
- [x] No backend changes; backend's actix-web extractor already URL-decodes the path segment.