### PR TITLE
feat(token): emit `email_verified` in access tokens

### DIFF
--- a/src/jwt/src/claims.rs
+++ b/src/jwt/src/claims.rs
@@ -124,6 +124,8 @@ pub struct JwtAccessClaims<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub email_verified: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<&'a str>>,

--- a/src/service/src/token_set.rs
+++ b/src/service/src/token_set.rs
@@ -146,6 +146,11 @@ impl TokenSet {
         } else {
             None
         };
+        let email_verified = if scope.contains("email") {
+            user.as_ref().map(|u| u.email_verified)
+        } else {
+            None
+        };
         let roles = user.map(|u| u.roles_iter().collect());
         let groups = if scope.contains("groups") {
             user.map(|u| u.groups_iter().collect())
@@ -187,6 +192,7 @@ impl TokenSet {
             },
             allowed_origins: None,
             email,
+            email_verified,
             roles,
             groups,
             custom: None,


### PR DESCRIPTION
## Summary

`JwtIdClaims` already emits `email_verified` when the `email` scope is granted (see `token_set.rs` `build_id_token`). `JwtAccessClaims` doesn't.

RFC 7519 / RFC 9068 don't restrict claim location, and resource servers commonly validate identity claims directly off the bearer access token rather than fetching userinfo or pairing an id-token. Without `email_verified` on the access token, resource servers can't enforce policies like "only allow tokens whose principal has a verified email" against bearer requests.

Auth0, Keycloak (with the right scope-mapping), and Hydra all put `email_verified` on the access token when the `email` scope is granted. This brings Rauthy in line with that convention.

## Change

Two files. Mirror the existing `email` derivation in `build_access_token`:

```rust
let email_verified = if scope.contains("email") {
    user.as_ref().map(|u| u.email_verified)
} else {
    None
};
```

and add `email_verified,` to the `JwtAccessClaims` struct literal. Plus the `email_verified: Option<bool>` field on `JwtAccessClaims` itself (already on `JwtIdClaims` lines 145-147 of `claims.rs`).

The field uses `#[serde(skip_serializing_if = "Option::is_none")]` so output is byte-identical for token requests that don't carry the `email` scope — no surprise for existing integrations.

## Test plan

- [x] Verified locally: token issued with `scope=openid+email+profile` against a Rauthy 0.35.1+patch carries `email_verified: true` for a Google-brokered user (whose Rauthy local `User.email_verified` is `true`) and `email_verified: false` for a local-password admin who never verified.
- [x] Token issued without `email` scope has no `email_verified` field at all (skip-if-none works).
- [x] `cargo build --release` clean, no new warnings.