### PR TITLE
feat(oidc): advertise CIMD support + add RFC 8414 endpoint alias

### DIFF
--- a/src/api/src/oidc.rs
+++ b/src/api/src/oidc.rs
@@ -1230,6 +1230,17 @@ pub async fn get_forward_auth(req: HttpRequest) -> Result<HttpResponse, ErrorRes
 ///
 /// Capable OIDC clients can use this endpoint to auto-discover all necessary OIDC information and
 /// endpoints that are provided by rauthy to automatically choose the best / safest options.
+async fn well_known_response() -> Result<HttpResponse, ErrorResponse> {
+    let wk = WellKnown::json().await?;
+    Ok(HttpResponse::Ok()
+        .insert_header((CONTENT_TYPE, APPLICATION_JSON))
+        .insert_header((
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            HeaderValue::from_static("*"),
+        ))
+        .body(wk))
+}
+
 #[utoipa::path(
     get,
     path = "/.well-known/openid-configuration",
@@ -1240,12 +1251,14 @@ pub async fn get_forward_auth(req: HttpRequest) -> Result<HttpResponse, ErrorRes
 )]
 #[get("/.well-known/openid-configuration")]
 pub async fn get_well_known() -> Result<HttpResponse, ErrorResponse> {
-    let wk = WellKnown::json().await?;
-    Ok(HttpResponse::Ok()
-        .insert_header((CONTENT_TYPE, APPLICATION_JSON))
-        .insert_header((
-            header::ACCESS_CONTROL_ALLOW_ORIGIN,
-            HeaderValue::from_static("*"),
-        ))
-        .body(wk))
+    well_known_response().await
+}
+
+// RFC 8414 alias for `/.well-known/openid-configuration`. Some MCP clients
+// (ChatGPT's connector backend) prefer the RFC 8414 endpoint for AS-metadata
+// discovery and won't read `client_id_metadata_document_supported` from the
+// OIDC-only doc. Body is identical; we just expose it under the second path.
+#[get("/.well-known/oauth-authorization-server")]
+pub async fn get_well_known_oauth() -> Result<HttpResponse, ErrorResponse> {
+    well_known_response().await
 }

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -244,6 +244,7 @@ async fn server_with_metrics() -> std::io::Result<()> {
             // out the correct type yet.
             .wrap(metrics_collector.clone())
             .service(oidc::get_well_known)
+            .service(oidc::get_well_known_oauth)
             .service(fed_cm::get_fed_cm_well_known)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first
@@ -328,6 +329,7 @@ async fn server_without_metrics() -> std::io::Result<()> {
             .wrap(CsrfProtectionMiddleware)
             .wrap(default_headers())
             .service(oidc::get_well_known)
+            .service(oidc::get_well_known_oauth)
             .service(fed_cm::get_fed_cm_well_known)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first
@@ -676,6 +678,7 @@ fn api_services() -> actix_web::Scope {
                 .service(themes::put_theme)
                 .service(themes::delete_theme)
                 .service(oidc::get_well_known)
+                .service(oidc::get_well_known_oauth)
                 .service(generic::get_health)
                 .service(generic::get_i18n_config)
                 .service(generic::get_ready)

--- a/src/bin/tests/handler_generic.rs
+++ b/src/bin/tests/handler_generic.rs
@@ -43,6 +43,7 @@ pub struct WellKnown {
     pub service_documentation: String,
     pub ui_locales_supported: Vec<String>,
     pub claims_parameter_supported: bool,
+    pub client_id_metadata_document_supported: bool,
 }
 
 #[tokio::test]

--- a/src/data/src/entity/well_known.rs
+++ b/src/data/src/entity/well_known.rs
@@ -40,6 +40,11 @@ pub struct WellKnown {
     pub service_documentation: &'static str,
     pub ui_locales_supported: Vec<&'static str>,
     pub claims_parameter_supported: bool,
+    /// SEP-991 / draft-jonesmichael-oauth-cimd. Signals that this AS accepts
+    /// clients identified by a Client ID Metadata Document URL (Rauthy already
+    /// implements this via `ephemeral_from_url`). ChatGPT's custom-connector UI
+    /// greys out the CIMD option until the AS discovery doc carries this flag.
+    pub client_id_metadata_document_supported: bool,
 }
 
 static IDX: &str = ".well-known";
@@ -145,6 +150,7 @@ impl WellKnown {
             service_documentation: "https://sebadob.github.io/rauthy/",
             ui_locales_supported: Language::iter().map(|l| l.as_str()).collect(),
             claims_parameter_supported: true,
+            client_id_metadata_document_supported: true,
         }
     }
 }


### PR DESCRIPTION
## Summary

Two related changes that make Rauthy's existing CIMD support (`Client::ephemeral_from_url`) discoverable to standards-compliant MCP clients without changing any auth behaviour:

1. **Add `client_id_metadata_document_supported: true` to `WellKnown`.** Per the [MCP authorization spec 2025-11-25 §"Client ID Metadata Documents"](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents) and [draft-ietf-oauth-client-id-metadata-document-00](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00), authorization servers signal CIMD acceptance via this boolean on AS metadata. Rauthy already accepts URL-shaped client_ids and fetches the metadata document via `ephemeral_from_url` (`src/data/src/entity/clients.rs:1375`) — this just announces the capability. The OpenAI Apps SDK docs explicitly say "If you support CIMD, set `client_id_metadata_document_supported: true` in your authorization server metadata."

2. **Add a route at `/.well-known/oauth-authorization-server`** (RFC 8414) that returns the same `WellKnown` body. Empirically, ChatGPT's connector backend reads CIMD support specifically from the RFC 8414 endpoint and falls back to "no CIMD" if it 404s — checking the OIDC discovery URL is not sufficient. [MCP spec §"Authorization Server Metadata Discovery"](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-metadata-discovery) requires ASs to provide *at least one of* RFC 8414 / OIDC Discovery; serving both maximises client interop (Auth0, Keycloak, Okta etc all do this).

## Change

| File | Change |
|---|---|
| `src/data/src/entity/well_known.rs` | `+pub client_id_metadata_document_supported: bool` on `WellKnown` struct + `true` init. |
| `src/bin/tests/handler_generic.rs` | Mirror field on the `Deserialize` test struct (per the comment on the upstream struct). |
| `src/api/src/oidc.rs` | Extract a private `well_known_response()` helper; `get_well_known` (OIDC) and the new `get_well_known_oauth` (RFC 8414) both delegate to it. Same body, two paths. |
| `src/bin/src/server.rs` | Register `oidc::get_well_known_oauth` alongside `oidc::get_well_known` at all 3 service-builder sites. |

4 files, +31/-8.

## Evidence trail for the RFC 8414 alias (the load-bearing part)

I ran the ChatGPT "Add custom connector" flow against a Rauthy with **only** the `client_id_metadata_document_supported: true` flag on `/.well-known/openid-configuration`. ChatGPT's `oauth_config` response had `"client_id_metadata_document_supported": null`, and the CIMD option in the UI was greyed with "the server did not advertise CIMD support." After adding the RFC 8414 alias (no other change), ChatGPT immediately read the flag, ungreyed the CIMD option and auto-selected it. claude.ai doesn't expose a CIMD-vs-DCR toggle in its free-tier UI but its connector flow also queries the RFC 8414 endpoint when present.

## What this PR does NOT do

- Doesn't touch the existing CIMD client-creation, auth-code, or token-issuance code. Only discovery.

## Test plan

- [x] `cargo build --release` clean on `aarch64-unknown-linux-gnu`.
- [x] `curl -fsS /.well-known/openid-configuration` and `curl -fsS /.well-known/oauth-authorization-server` return identical bodies, both containing `"client_id_metadata_document_supported": true`.
- [x] ChatGPT custom-connector form ungreys the CIMD option after deploy.
- [x] Existing OIDC clients (regular `dyn$*` DCR clients) continue to work unchanged — the new field is additive, the RFC 8414 route is additive.