### PR TITLE
Client: fix token exp validation

### DIFF
--- a/rauthy-client/CHANGELOG.md
+++ b/rauthy-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.14.1
+
+After the new custom JWT validation, the token expiration was not checked in `v0.14.0` when no
+allowed clock skew was specified. This was fixed in this version. If you use `v0.14.0`, update
+immediately. This version also sets a (for now) hardcoded allowed clock skew of 5 seconds for the
+validation.
+
 ## v0.14.0
 
 This update comes with a few but easy to fix **breaking changes**.

--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rauthy-client"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/rauthy-client/examples/actix-web/Cargo.lock
+++ b/rauthy-client/examples/actix-web/Cargo.lock
@@ -1750,7 +1750,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rauthy-client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "actix-web",
  "base64",

--- a/rauthy-client/examples/axum/Cargo.lock
+++ b/rauthy-client/examples/axum/Cargo.lock
@@ -1492,7 +1492,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rauthy-client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "axum",
  "axum-extra",

--- a/rauthy-client/examples/generic/Cargo.lock
+++ b/rauthy-client/examples/generic/Cargo.lock
@@ -1771,7 +1771,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rauthy-client"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "base64",
  "bincode",

--- a/rauthy-client/src/tokens/token.rs
+++ b/rauthy-client/src/tokens/token.rs
@@ -73,7 +73,7 @@ impl JwtToken {
             &config.allowed_issuers,
             &config.allowed_audiences,
             expected_type,
-            None,
+            Some(5),
         )?;
 
         Ok(())
@@ -103,19 +103,17 @@ impl ValidationClaims<'_> {
         expected_type: Option<TokenType>,
         allowed_clock_skew_seconds: Option<u16>,
     ) -> Result<(), RauthyError> {
-        if let Some(skew) = allowed_clock_skew_seconds {
-            let now = Utc::now().timestamp();
-            let skew = skew as i64;
+        let now = Utc::now().timestamp();
+        let skew = allowed_clock_skew_seconds.unwrap_or(0) as i64;
 
-            if self.iat - skew > now {
-                return Err(RauthyError::InvalidJwt("Token was issued in the future"));
-            }
-            if self.exp + skew < now {
-                return Err(RauthyError::InvalidJwt("Token has expired"));
-            }
-            if self.nbf - skew > now {
-                return Err(RauthyError::InvalidJwt("Token is not valid yet"));
-            }
+        if self.iat - skew > now {
+            return Err(RauthyError::InvalidJwt("Token was issued in the future"));
+        }
+        if self.exp + skew < now {
+            return Err(RauthyError::InvalidJwt("Token has expired"));
+        }
+        if self.nbf - skew > now {
+            return Err(RauthyError::InvalidJwt("Token is not valid yet"));
         }
         if let Some(typ) = expected_type
             && self.typ != typ


### PR DESCRIPTION
Fixes a critical logic issue in the new custom JWT impl for the `rauthy-client`. When now clock skew was allowed during validation, the `exp` claim was skipped during the validation, which means tokens were accepted that have expired already.