### PR TITLE
UI: fix client ID validation

### DIFF
--- a/frontend/src/lib/admin/clients/ClientAddNew.svelte
+++ b/frontend/src/lib/admin/clients/ClientAddNew.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Button from '$lib5/button/Button.svelte';
     import Input from '$lib5/form/Input.svelte';
-    import { PATTERN_CLIENT_ID, PATTERN_CLIENT_NAME } from '$utils/patterns';
+    import { PATTERN_CLIENT_ID_NEW, PATTERN_CLIENT_NAME } from '$utils/patterns';
     import Form from '$lib5/form/Form.svelte';
     import { fetchPost } from '$api/fetch';
     import { useI18n } from '$state/i18n.svelte';
@@ -69,7 +69,7 @@
             label="Client ID"
             placeholder="Client ID"
             required
-            pattern={PATTERN_CLIENT_ID}
+            pattern={PATTERN_CLIENT_ID_NEW}
         />
         <Input
             bind:value={name}

--- a/frontend/src/utils/patterns.ts
+++ b/frontend/src/utils/patterns.ts
@@ -6,7 +6,12 @@ export const PATTERN_ATTR = '^[a-zA-Z0-9\\-_\\/]{2,32}$';
 export const PATTERN_ATTR_DESC = '^[a-zA-Z0-9\\-_\\/\\s]{0,128}$';
 export const PATTERN_API_KEY = '^[a-zA-Z0-9_\\/\\-]{2,24}$';
 export const PATTERN_CITY = '^[a-zA-Z0-9À-ÿ\\-\\s]{0,48}$';
-export const PATTERN_CLIENT_ID = "^[a-zA-Z0-9,.:\\/_\\-&?=~#!$'\\(\\)*+%]{2,256}$";
+// Technically, the API accepts `PATTERN_CLIENT_ID_EPHEMERAL` everywhere to make resolving via URL possible.
+// However, we don't want to allow that in the UI, as it would be very confusing. We also want to reject IDs
+// that could potentially overlap with any `dyn$*` clients created via DCR to avoid conflicts.
+// Via direct API call, it's still possible to create conflicts, but this has to be very intentional.
+export const PATTERN_CLIENT_ID_NEW = '^[a-zA-Z0-9._\\-]{2,256}$';
+export const PATTERN_CLIENT_ID_EPHEMERAL = "^[a-zA-Z0-9,.:\\/_\\-&?=~#!$'\\(\\)*+%]{2,256}$";
 export const PATTERN_CLIENT_NAME =
     '^[a-zA-Z0-9À-ɏ\\-\\s\\u3041-\\u3096\\u30A0-\\u30FF\\u3400-\\u4DB5\\u4E00-\\u9FCB\\uF900-\\uFA6A\\u2E80-\\u2FD5\\uFF66-\\uFF9F\\uFFA1-\\uFFDC\\u31F0-\\u31FF]{2,128}$';
 // export const PATTERN_DATE_STR = '[0-9]{4}\\-[0-9]{2}-[0-9]{2}$';


### PR DESCRIPTION
The API accepts Client IDs as full URIs. This is mandatory to make ephemeral clients work.

However, with a change a while ago, where UPPERCASE characters were added to the validation regex for new Client IDs, I accidentially allowed full URI IDs in the UI. This is not an issue on it's own, because the API works perfectly fine with it. The issue with this is:

1. It was now possible to theoretically create conflicts manually with clients created by the backend during DCR.
2. It was technically allowed to enter a URI as Client ID, which made the UI fail, because it does not URL encode Client IDs during API requests. It could be allowed and fixed easily, but it should never be necessary in the first place. If you add a Client with a URI as ID to the DB, Rauthy would lookup the whole configuration dynamically, because it would be treated as an ephemeral client. 

To fix these misleading issues, the regex was restricted a lot more again. It is now the following:

```
^[a-zA-Z0-9._\-]{2,256}$
```

This still allows for CamelCasedClientIDs, and it keeps all characters in a URL-safe range.

