### PR TITLE
catch magic link cleanup error and try to get additional debug output

### DIFF
--- a/src/data/src/entity/users.rs
+++ b/src/data/src/entity/users.rs
@@ -191,7 +191,7 @@ impl User {
         Ok(())
     }
 
-    async fn count_dec() -> Result<(), ErrorResponse> {
+    pub async fn count_dec() -> Result<(), ErrorResponse> {
         let mut count = Self::count().await?;
         // theoretically, we could have overlaps here, but we don't really care
         // -> used for dynamic pagination only

--- a/src/schedulers/src/magic_links.rs
+++ b/src/schedulers/src/magic_links.rs
@@ -2,7 +2,9 @@ use chrono::Utc;
 use hiqlite::macros::params;
 use rauthy_common::is_hiqlite;
 use rauthy_data::database::DB;
-use rauthy_error::ErrorResponse;
+use rauthy_data::entity::user_login_states::UserLoginState;
+use rauthy_data::entity::users::User;
+use rauthy_error::{ErrorResponse, ErrorResponseType};
 use std::ops::Sub;
 use std::time::Duration;
 use tokio::time;
@@ -51,26 +53,109 @@ WHERE id IN (
     WHERE exp < $1 AND used = false)
 AND password IS NULL AND webauthn_user_id IS NULL"#;
 
-    let rows_affected = if is_hiqlite() {
-        DB::hql().execute(sql, params!(exp)).await?
+    let res = if is_hiqlite() {
+        DB::hql().execute(sql, params!(exp)).await.map_err(|err| {
+            ErrorResponse::new(
+                ErrorResponseType::Database,
+                format!("Error during Magic Link Cleanup: {err}"),
+            )
+        })
     } else {
-        DB::pg_execute(sql, &[&exp]).await?
+        DB::pg_execute(sql, &[&exp]).await.map_err(|err| {
+            ErrorResponse::new(
+                ErrorResponseType::Database,
+                format!("Error during Magic Link Cleanup: {err}"),
+            )
+        })
     };
 
-    if rows_affected > 0 {
-        info!(
-            "Cleaned up {rows_affected} users which did not use their initial password reset magic link"
-        );
+    match res {
+        Ok(rows_affected) => {
+            if rows_affected > 0 {
+                info!(
+                    "Cleaned up {rows_affected} users which did not use their initial password reset magic link"
+                );
+                for _ in 0..rows_affected {
+                    User::count_dec().await?;
+                }
+
+                // now we can just delete all expired magic links
+                let sql = "DELETE FROM magic_links WHERE exp < $1";
+                let rows_affected = if is_hiqlite() {
+                    DB::hql().execute(sql, params!(exp)).await?
+                } else {
+                    DB::pg_execute(sql, &[&exp]).await?
+                };
+                debug!("Cleaned up {rows_affected} expired and used magic links");
+            }
+        }
+        Err(err) => {
+            // This should never happen, but we have this catch for better debugging.
+            // There was a reported issue that this query can fail, but I was not able to reproduce it.
+            // If we ever get here, we want to log some more information to try to debug it in a live
+            // env.
+            error!("{err}");
+
+            let sql = r#"
+SELECT * FROM users
+WHERE id IN (
+    SELECT DISTINCT user_id
+    FROM magic_links
+    WHERE exp < $1 AND used = false)
+AND password IS NULL AND webauthn_user_id IS NULL"#;
+
+            let users: Vec<User> = if is_hiqlite() {
+                DB::hql().query_as(sql, params!(exp)).await?
+            } else {
+                DB::pg_query(sql, &[&exp], 1).await?
+            };
+
+            let mut states = Vec::new();
+            for user in &users {
+                let login_states = UserLoginState::find_by_user(user.id.clone()).await?;
+                states.push(login_states);
+            }
+
+            error!(
+                r#"
+
+This Magic Link cleanup error should never happen. This is additional debugging
+information. It was not possible to cleanup the following users. Please confirm
+manually that they are actually fresh, un-initiliazed users that never logged in.
+The only table restricting this action should only ever contain data when a user
+logged in at least once. In this case though, this query should also never catch
+such users.
+
+{users:?}
+
+
+Did you do anything special / manually for the listed users? Please report at:
+
+https://github.com/sebadob/rauthy/issues/1532
+
+"#
+            );
+
+            if !states.is_empty() {
+                error!(
+                    r#"
+Additional debugging information about user magic link cleanup error. The following
+login states were found:
+
+{states:?}
+
+
+This should never happen. There should not be any login states for users without
+a password and no passkey. Did you do anything special / manually for the listed
+users? Please report at:
+
+https://github.com/sebadob/rauthy/issues/1532
+
+                "#
+                );
+            }
+        }
     }
-
-    // now we can just delete all expired magic links
-    let sql = "DELETE FROM magic_links WHERE exp < $1";
-    let rows_affected = if is_hiqlite() {
-        DB::hql().execute(sql, params!(exp)).await?
-    } else {
-        DB::pg_execute(sql, &[&exp]).await?
-    };
-    debug!("Cleaned up {rows_affected} expired and used magic links");
 
     Ok(())
 }


### PR DESCRIPTION
#1532 

Catches Magic Link cleanup scheduler errors specifically and tries to get additional debugging information. I was not able to reproduce the error, so hopefully that helps.
