### PR TITLE
Fix typo in default config and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ It is now also possible to include the `preferred_username` in forward auth head
 ```toml
 [auth_headers]
 
-# If additionally, the preferred username header shuold be enabled.
+# If additionally, the preferred username header should be enabled.
 # This requires an additional DB lookup each time and is therefore
 # disabled by default.
 #

--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -288,7 +288,7 @@ Kubernetes secrets, or simply provide the whole config as one secret (my preferr
 # overwritten by: AUTH_HEADERS_ENABLE
 #enable = false
 
-# If additionally, the preferred username header shuold be enabled.
+# If additionally, the preferred username header should be enabled.
 # This requires an additional DB lookup each time and is therefore
 # disabled by default.
 #

--- a/config.toml
+++ b/config.toml
@@ -302,7 +302,7 @@ admin_button_hide = false
 # overwritten by: AUTH_HEADERS_ENABLE
 enable = true
 
-# If additionally the preferred username header shuold be enabled.
+# If additionally the preferred username header should be enabled.
 # This requires an additiona DB lookup each time and is therefore
 # disabled by default.
 #

--- a/docs/config/config.html
+++ b/docs/config/config.html
@@ -461,7 +461,7 @@ Kubernetes secrets, or simply provide the whole config as one secret (my preferr
 # overwritten by: AUTH_HEADERS_ENABLE
 #enable = false
 
-# If additionally, the preferred username header shuold be enabled.
+# If additionally, the preferred username header should be enabled.
 # This requires an additional DB lookup each time and is therefore
 # disabled by default.
 #

--- a/docs/print.html
+++ b/docs/print.html
@@ -5899,7 +5899,7 @@ Kubernetes secrets, or simply provide the whole config as one secret (my preferr
 # overwritten by: AUTH_HEADERS_ENABLE
 #enable = false
 
-# If additionally, the preferred username header shuold be enabled.
+# If additionally, the preferred username header should be enabled.
 # This requires an additional DB lookup each time and is therefore
 # disabled by default.
 #


### PR DESCRIPTION
There is one remaining match for `shuold` in `docs/searchindex.js`, I don't have the right MdBook version at hand to rebuild it.

There was no newline at the end of `config.toml`, not sure if that is intentional; my editor added one.

(Feel free to close this if I got the contribution flow wrong, it’s probably easier for you to just fix the typo.)