### PR TITLE
Add API keys advanced bootstrap JSON

### DIFF
--- a/book/src/config/bootstrap.md
+++ b/book/src/config/bootstrap.md
@@ -1,6 +1,6 @@
 # Bootstrapping
 
-Rauthy can bootstrap most values that are nore statically configured. There are only very few
+Rauthy can bootstrap most values that are not statically configured. There are only very few
 exceptions, so you should be able to achieve anything you need. The most important things live in
 the config to be able to run everything from a single file. However, when you want to do more
 advanced / custom stuff, you will need to provide additional JSON files.
@@ -60,61 +60,83 @@ it is a bit more cumbersome to use from outside the browser because of additiona
 security features. If you want to automatically set up Rauthy with external tooling after the first
 startup, you would want to do this with an API key most probably.
 
-If Rauthy starts up with an empty database, you can bootstrap a single API key with providing a
-base64 encoded json.
+If Rauthy starts up with an empty database, you can bootstrap API keys via
+`api_keys.json` in your configured `bootstrap_dir`. The older `bootstrap.api_key`
+config value shown below is still supported for a single key.
 
-An example json, which would create a key named `bootstrap` with access to `clients, roles, groups`
-with all `read, write, update, delete` could look like this:
+An example `api_keys.json`, which would create a key named `bootstrap` with access to
+`clients`, `roles`, and `groups` with all `read`, `create`, `update`, `delete`
+rights could look like this:
 
 ```json
-{
-  "name": "bootstrap",
-  "exp": 1735599600,
-  "access": [
-    {
-      "group": "Clients",
-      "access_rights": [
-        "read",
-        "create",
-        "update",
-        "delete"
-      ]
+[
+  {
+    "name": "bootstrap",
+    "exp": 1735599600,
+    "secret": {
+      "Plain": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     },
-    {
-      "group": "Roles",
-      "access_rights": [
-        "read",
-        "create",
-        "update",
-        "delete"
-      ]
-    },
-    {
-      "group": "Groups",
-      "access_rights": [
-        "read",
-        "create",
-        "update",
-        "delete"
-      ]
-    }
-  ]
-}
+    "access": [
+      {
+        "group": "Clients",
+        "access_rights": [
+          "read",
+          "create",
+          "update",
+          "delete"
+        ]
+      },
+      {
+        "group": "Roles",
+        "access_rights": [
+          "read",
+          "create",
+          "update",
+          "delete"
+        ]
+      },
+      {
+        "group": "Groups",
+        "access_rights": [
+          "read",
+          "create",
+          "update",
+          "delete"
+        ]
+      }
+    ]
+  }
+]
 ```
 
-The config documentation for the bootstrap value should explain all further questions:
+The `secret` can be either `{"Plain": "..."}` or `{"Encrypted": "..."}`. Plain secrets must
+be at least 64 characters long. Encrypted secrets are encrypted with
+[`cryptr`](https://github.com/sebadob/cryptr) and base64-encoded, just like encrypted
+client secrets.
+
+```admonish caution
+Only bootstrap short-lived API keys for production automation. Set `exp` to a timestamp
+that expires after your first-start provisioning is complete, for example after about 10
+minutes. Long-lived bootstrap API keys increase the blast radius if the bootstrap files or
+deployment secrets are leaked. The example timestamp above is intentionally finite; replace it
+with a short-lived value for your deployment.
+```
+
+The legacy config documentation for bootstrapping a single API key should explain all
+further questions:
 
 ```toml
 [bootstrap]
-# You can provide an API Key during the initial prod database
-# bootstrap. This key must match the format and pass validation.
+# You can provide a single API Key during the initial prod database
+# bootstrap. This legacy config value must match the format and pass validation.
+# Prefer `api_keys.json` in `bootstrap_dir` for new deployments.
 # You need to provide it as a base64 encoded JSON in the format:
 #
 # ```
 # struct ApiKeyRequest {
 #     /// Validation: `^[a-zA-Z0-9_-/]{2,24}$`
 #     name: String,
-#     /// Unix timestamp in seconds in the future (max year 2099)
+#     /// Unix timestamp in seconds
 #     exp: Option<i64>,
 #     access: Vec<ApiKeyAccess>,
 # }
@@ -136,6 +158,7 @@ The config documentation for the bootstrap value should explain all further ques
 #     Scopes,
 #     UserAttributes,
 #     Users,
+#     Pam,
 # }
 #
 # #[serde(rename_all="lowercase")]
@@ -184,9 +207,9 @@ Authorization: API-Key bootstrap$twUA2M7RZ8H3FyJHbti2AcMADPDCxDqUKbvi8FDnm3nYidw
 ```
 
 ```admonish caution
-At the time of writing, it is not possible (yet) to provide API key secrets as encrypted values.
-This will probably be added in a future version. If you bootstrap API keys for production setup,
-make sure they always auto-expire.
+If you bootstrap API keys for production setup, make sure they always auto-expire. Bootstrap
+JSON is only read while initializing an empty production database; changing `api_keys.json`
+later does not reconcile live API keys.
 ```
 
 ## Advanced / Custom Configuration
@@ -202,6 +225,7 @@ First, make sure to check the `bootstrap_dir` and configure it if necessary:
 # try to parse and apply them during the bootstrapping process.
 #
 # The following files will be parsed in the given directory:
+# - api_keys.json
 # - roles.json
 # - groups.json
 # - scopes.json

--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -399,15 +399,16 @@ Kubernetes secrets, or simply provide the whole config as one secret (my preferr
 # overwritten by: BOOTSTRAP_ADMIN_PASSWORD_ARGON2ID
 #pasword_argon2id = '$argon2id$v=19$m=32768,t=3,p=2$mK+3taI5mnA+Gx8OjjKn5Q$XsOmyvt9fr0V7Dghhv3D0aTe/FjF36BfNS5QlxOPep0'
 
-# You can provide an API Key during the initial prod database
-# bootstrap. This key must match the format and pass validation.
+# You can provide a single API Key during the initial prod database
+# bootstrap. This legacy config value must match the format and pass validation.
+# Prefer `api_keys.json` in `bootstrap_dir` for new deployments.
 # You need to provide it as a base64 encoded JSON in the format:
 #
 # ```
 # struct ApiKeyRequest {
 #     /// Validation: `^[a-zA-Z0-9_-/]{2,24}$`
 #     name: String,
-#     /// Unix timestamp in seconds in the future (max year 2099)
+#     /// Unix timestamp in seconds
 #     exp: Option<i64>,
 #     access: Vec<ApiKeyAccess>,
 # }
@@ -429,6 +430,7 @@ Kubernetes secrets, or simply provide the whole config as one secret (my preferr
 #     Scopes,
 #     UserAttributes,
 #     Users,
+#     Pam,
 # }
 #
 # #[serde(rename_all="lowercase")]
@@ -463,6 +465,7 @@ Kubernetes secrets, or simply provide the whole config as one secret (my preferr
 # try to parse and apply them during the bootstrapping process.
 #
 # The following files will be parsed in the given directory:
+# - api_keys.json
 # - roles.json
 # - groups.json
 # - scopes.json

--- a/book/src/work/api_keys.md
+++ b/book/src/work/api_keys.md
@@ -39,7 +39,9 @@ logins to limit the likelihood of privilege escalation in case of leaked credent
 ## Creating a new API Key
 
 Apart from the initial [bootstrap](../config/bootstrap.md#api-key), the creation and modification of API Keys is only
-allowed via the Admin UI.
+allowed via the Admin UI. API keys declared in `api_keys.json` should have a short expiry for production bootstrap,
+for example around 10 minutes, so first-start automation can finish and the credential then becomes useless
+automatically. Bootstrap JSON is not live reconciliation; later file changes do not update existing API keys.
 
 Navigate to the `API Keys` section, click `New Key`, fill out the inputs and `Save`. You can set an optional key expiry.
 By default, API Keys never expire.

--- a/bootstrap/api_keys.json
+++ b/bootstrap/api_keys.json
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "bootstrap",
+        "exp": 1735599600,
+        "secret": {
+            "Plain": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "access": [
+            {
+                "group": "Clients",
+                "access_rights": [
+                    "read",
+                    "create",
+                    "update",
+                    "delete"
+                ]
+            },
+            {
+                "group": "Roles",
+                "access_rights": [
+                    "read",
+                    "create",
+                    "update",
+                    "delete"
+                ]
+            },
+            {
+                "group": "Groups",
+                "access_rights": [
+                    "read",
+                    "create",
+                    "update",
+                    "delete"
+                ]
+            }
+        ]
+    }
+]

--- a/config.toml
+++ b/config.toml
@@ -413,15 +413,16 @@ password_plain = '123SuperSafe'
 # overwritten by: BOOTSTRAP_ADMIN_PASSWORD_ARGON2ID
 pasword_argon2id = '$argon2id$v=19$m=32768,t=3,p=2$mK+3taI5mnA+Gx8OjjKn5Q$XsOmyvt9fr0V7Dghhv3D0aTe/FjF36BfNS5QlxOPep0'
 
-# You can provide an API Key during the initial prod database
-# bootstrap. This key must match the format and pass validation.
+# You can provide a single API Key during the initial prod database
+# bootstrap. This legacy config value must match the format and pass validation.
+# Prefer `api_keys.json` in `bootstrap_dir` for new deployments.
 # You need to provide it as a base64 encoded JSON in the format:
 #
 # ```
 # struct ApiKeyRequest {
 #     /// Validation: `^[a-zA-Z0-9_-/]{2,24}$`
 #     name: String,
-#     /// Unix timestamp in seconds in the future (max year 2099)
+#     /// Unix timestamp in seconds
 #     exp: Option<i64>,
 #     access: Vec<ApiKeyAccess>,
 # }
@@ -443,6 +444,7 @@ pasword_argon2id = '$argon2id$v=19$m=32768,t=3,p=2$mK+3taI5mnA+Gx8OjjKn5Q$XsOmyv
 #     Scopes,
 #     UserAttributes,
 #     Users,
+#     Pam,
 # }
 #
 # #[serde(rename_all="lowercase")]
@@ -477,6 +479,7 @@ api_key_secret = 'twUA2M7RZ8H3FyJHbti2AcMADPDCxDqUKbvi8FDnm3nYidwQx57Wfv6iaVTQyn
 # try to parse and apply them during the bootstrapping process.
 #
 # The following files will be parsed in the given directory:
+# - api_keys.json
 # - roles.json
 # - groups.json
 # - scopes.json

--- a/src/data/src/migration/bootstrap/api_key.rs
+++ b/src/data/src/migration/bootstrap/api_key.rs
@@ -1,16 +1,27 @@
 use crate::database::DB;
 use crate::entity::api_keys::ApiKeyEntity;
+use crate::migration::bootstrap::bootstrap_data;
+use crate::migration::bootstrap::types::{ApiKey as BootstrapApiKey, ApiKeySecret};
 use crate::rauthy_config::RauthyConfig;
 use cryptr::EncValue;
 use hiqlite::macros::params;
 use rauthy_api_types::api_keys::ApiKeyRequest;
+use rauthy_common::constants::API_KEY_LENGTH;
 use rauthy_common::utils::base64_decode;
 use rauthy_common::{is_hiqlite, sha256};
 use rauthy_error::ErrorResponse;
-use tracing::debug;
+use tracing::{debug, info};
 use validator::Validate;
+use zeroize::Zeroize;
 
 pub async fn bootstrap() -> Result<(), ErrorResponse> {
+    bootstrap_legacy_config_api_key().await?;
+    bootstrap_api_keys_json().await?;
+
+    Ok(())
+}
+
+async fn bootstrap_legacy_config_api_key() -> Result<(), ErrorResponse> {
     let Some(api_key_raw) = RauthyConfig::get().vars.bootstrap.api_key.as_ref() else {
         return Ok(());
     };
@@ -25,28 +36,96 @@ pub async fn bootstrap() -> Result<(), ErrorResponse> {
 
     debug!("Bootstrapping API Key:\n{req:?}");
     let key_name = req.name.clone();
-    let _ = ApiKeyEntity::create(
+    let mut generated_secret = ApiKeyEntity::create(
         req.name,
         req.exp,
         req.access.into_iter().map(|a| a.into()).collect(),
     )
     .await?;
+    generated_secret.zeroize();
 
     if let Some(secret_plain) = RauthyConfig::get().vars.bootstrap.api_key_secret.as_ref() {
-        assert!(secret_plain.len() >= 64);
-        let secret_enc = EncValue::encrypt(sha256!(secret_plain.as_bytes()))?
-            .into_bytes()
-            .to_vec();
-
-        let sql = "UPDATE api_keys SET secret = $1 WHERE name = $2";
-        if is_hiqlite() {
-            DB::hql()
-                .execute(sql, params!(secret_enc, key_name))
-                .await?;
-        } else {
-            DB::pg_execute(sql, &[&secret_enc, &key_name]).await?;
-        }
+        set_api_key_secret(&key_name, secret_plain).await?;
     }
 
     Ok(())
+}
+
+async fn bootstrap_api_keys_json() -> Result<(), ErrorResponse> {
+    let api_keys = bootstrap_data!(BootstrapApiKey, "api_keys");
+
+    let len = api_keys.len();
+    for api_key in api_keys {
+        let key_name = api_key.name.clone();
+        debug!("Bootstrapping API Key: {key_name}");
+
+        let mut generated_secret = ApiKeyEntity::create(
+            api_key.name,
+            api_key.exp,
+            api_key.access.into_iter().map(|a| a.into()).collect(),
+        )
+        .await?;
+        generated_secret.zeroize();
+
+        let mut secret_plain = api_key_secret_plain(api_key.secret);
+        set_api_key_secret(&key_name, &secret_plain).await?;
+        secret_plain.zeroize();
+    }
+
+    info!("Migrated {len} API keys.");
+
+    Ok(())
+}
+
+async fn set_api_key_secret(name: &str, secret_plain: &str) -> Result<(), ErrorResponse> {
+    assert!(
+        secret_plain.len() >= API_KEY_LENGTH,
+        "Given API Key secret too short. Expected at least {API_KEY_LENGTH} characters."
+    );
+
+    let secret_enc = EncValue::encrypt(sha256!(secret_plain.as_bytes()))?
+        .into_bytes()
+        .to_vec();
+
+    let sql = "UPDATE api_keys SET secret = $1 WHERE name = $2";
+    if is_hiqlite() {
+        DB::hql()
+            .execute(sql, params!(secret_enc, name.to_string()))
+            .await?;
+    } else {
+        DB::pg_execute(sql, &[&secret_enc, &name]).await?;
+    }
+
+    Ok(())
+}
+
+fn api_key_secret_plain(secret: ApiKeySecret) -> String {
+    match secret {
+        ApiKeySecret::Plain(s) => s,
+        ApiKeySecret::Encrypted(enc) => {
+            let bytes = base64_decode(&enc)
+                .expect("Cannot decode base64 encoded, encrypted API Key secret");
+            let dec = EncValue::try_from(bytes)
+                .expect("Invalid format for encrypted API Key secret")
+                .decrypt()
+                .expect("Failed to decrypt encrypted API Key secret. Make sure Rauthy has access to the used ENC_KEY");
+            String::from_utf8(dec.to_vec())
+                .expect("Invalid characters in API Key secret. Cannot convert to lossless String.")
+        }
+    }
+}
+
+impl From<crate::migration::bootstrap::types::ApiKeyAccess>
+    for crate::entity::api_keys::ApiKeyAccess
+{
+    fn from(value: crate::migration::bootstrap::types::ApiKeyAccess) -> Self {
+        Self {
+            group: value.group.into(),
+            access_rights: value
+                .access_rights
+                .into_iter()
+                .map(|ar| ar.into())
+                .collect(),
+        }
+    }
 }

--- a/src/data/src/migration/bootstrap/types.rs
+++ b/src/data/src/migration/bootstrap/types.rs
@@ -19,10 +19,10 @@ use rauthy_api_types::oidc::JwkKeyPairAlg;
 use rauthy_api_types::users::{UserAttrValueRequest, UserValuesRequest};
 use rauthy_common::regex::*;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::fmt::{Debug, Formatter};
 use std::sync::LazyLock;
-use validator::Validate;
+use validator::{Validate, ValidationError, ValidationErrors};
 
 pub static RE_DB_ID: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9]{24}$").unwrap());
 
@@ -74,17 +74,49 @@ pub struct Scope {
     pub attr_include_id: Option<Vec<String>>,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize)]
 pub struct ApiKey {
     /// Validation: `^[a-zA-Z0-9_-/]{2,24}$`
-    #[validate(regex(path = "*RE_API_KEY", code = "^[a-zA-Z0-9_-/]{2,24}$"))]
     pub name: String,
     /// Unix timestamp in seconds.
-    #[validate(range(min = 1719784800))]
     pub exp: Option<i64>,
     pub secret: ApiKeySecret,
-    #[validate(length(min = 1), nested)]
     pub access: Vec<ApiKeyAccess>,
+}
+
+impl Validate for ApiKey {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+
+        if !RE_API_KEY.is_match(&self.name) {
+            let mut err = ValidationError::new("^[a-zA-Z0-9_-/]{2,24}$");
+            err.add_param(std::borrow::Cow::from("value"), &self.name);
+            errors.add("name", err);
+        }
+
+        if let Some(exp) = self.exp
+            && exp < 1719784800
+        {
+            let mut err = ValidationError::new("range");
+            err.add_param(std::borrow::Cow::from("min"), &1719784800);
+            err.add_param(std::borrow::Cow::from("value"), &exp);
+            errors.add("exp", err);
+        }
+
+        if self.access.is_empty() {
+            let mut err = ValidationError::new("length");
+            err.add_param(std::borrow::Cow::from("min"), &1);
+            errors.add("access", err);
+        } else {
+            errors.merge_self("access", self.access.validate());
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -102,7 +134,7 @@ impl Debug for ApiKeySecret {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Validate)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct ApiKeyAccess {
     pub group: AccessGroup,
     #[validate(length(min = 1))]

--- a/src/data/src/migration/bootstrap/types.rs
+++ b/src/data/src/migration/bootstrap/types.rs
@@ -12,13 +12,15 @@
 //! used. If it is not given, a random ID will be generated.
 
 use crate::language::Language;
+use rauthy_api_types::api_keys::{AccessGroup, AccessRights};
 use rauthy_api_types::clients::ScimClientRequestResponse;
 use rauthy_api_types::cust_validation::*;
 use rauthy_api_types::oidc::JwkKeyPairAlg;
 use rauthy_api_types::users::{UserAttrValueRequest, UserValuesRequest};
 use rauthy_common::regex::*;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 use std::sync::LazyLock;
 use validator::Validate;
 
@@ -70,6 +72,41 @@ pub struct Scope {
     /// `[UserAttribute.name]`s that should be included in the `id_token` if this scope is
     /// requested.
     pub attr_include_id: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct ApiKey {
+    /// Validation: `^[a-zA-Z0-9_-/]{2,24}$`
+    #[validate(regex(path = "*RE_API_KEY", code = "^[a-zA-Z0-9_-/]{2,24}$"))]
+    pub name: String,
+    /// Unix timestamp in seconds.
+    #[validate(range(min = 1719784800))]
+    pub exp: Option<i64>,
+    pub secret: ApiKeySecret,
+    #[validate(length(min = 1), nested)]
+    pub access: Vec<ApiKeyAccess>,
+}
+
+#[derive(Deserialize)]
+pub enum ApiKeySecret {
+    // Plain text secret
+    Plain(String),
+    // Must be encrypted using [cryptr](https://github.com/sebadob/cryptr) with an `ENC_KEY` that
+    // the Rauthy instance must have available. The encrypted data is expected as **base64**.
+    Encrypted(String),
+}
+
+impl Debug for ApiKeySecret {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<hidden>")
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Validate)]
+pub struct ApiKeyAccess {
+    pub group: AccessGroup,
+    #[validate(length(min = 1))]
+    pub access_rights: Vec<AccessRights>,
 }
 
 #[derive(Debug, Deserialize, Validate)]
@@ -210,4 +247,26 @@ pub struct User {
 pub enum UserPassword {
     Plain(String),
     Argon2ID(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use validator::Validate;
+
+    #[test]
+    fn parses_api_keys_bootstrap_example() {
+        let api_keys = serde_json::from_str::<Vec<ApiKey>>(include_str!(
+            "../../../../../bootstrap/api_keys.json"
+        ))
+        .expect("api_keys bootstrap example should parse");
+
+        assert_eq!(api_keys.len(), 1);
+        assert_eq!(api_keys[0].name, "bootstrap");
+        for api_key in &api_keys {
+            api_key
+                .validate()
+                .expect("api_keys bootstrap example should validate");
+        }
+    }
 }


### PR DESCRIPTION
This follows the maintainer-accepted scope from #1584: add API keys to Advanced Bootstrapping JSON, without adding an admin-token or trusted-local auth primitive.

### Changes

- Adds `bootstrap/api_keys.json` support during empty production database bootstrap.
- Keeps the existing single-key `bootstrap.api_key` / `BOOTSTRAP_API_KEY_SECRET` compatibility path.
- Supports declared plain and encrypted API-key secrets, stores only the encrypted hash, and zeroizes generated / declared plaintext strings after use.
- Adds an `ApiKey` bootstrap type plus an example-parse validation test.
- Documents short-lived production bootstrap API-key guidance and notes that bootstrap JSON is not live reconciliation.

Refs #1584.