### PR TITLE
Fix: misleading type hint for err msg during config validation

### DIFF
--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -3816,7 +3816,7 @@ fn t_i64(map: &mut toml::Table, parent: &str, key: &str, env_var: &str) -> Optio
     }
 
     let Value::Integer(i) = map.remove(key)? else {
-        panic!("{}", err_t(key, parent, "bool"));
+        panic!("{}", err_t(key, parent, "Integer"));
     };
     Some(i)
 }


### PR DESCRIPTION
fixes #1581