### PR TITLE
Feat: configurable residentKey requirement for passkey registration

### DIFF
--- a/src/data/src/entity/webauthn.rs
+++ b/src/data/src/entity/webauthn.rs
@@ -941,18 +941,42 @@ pub async fn reg_start(
             let cfg = &RauthyConfig::get().vars.webauthn;
             ccr.public_key.timeout = Some(cfg.req_exp as u32 * 1000);
 
+            let resident_key = match cfg.resident_key.as_str() {
+                "preferred" => ResidentKeyRequirement::Preferred,
+                "required" => ResidentKeyRequirement::Required,
+                _ => ResidentKeyRequirement::Discouraged,
+            };
+            let require_resident_key = matches!(resident_key, ResidentKeyRequirement::Required);
+
             if cfg.force_uv || user.account_type() == AccountType::Passkey {
                 // in this case we need to force UV no matter what is set in the config
                 ccr.public_key.authenticator_selection =
                     if let Some(mut auth_sel) = ccr.public_key.authenticator_selection {
                         auth_sel.user_verification = UserVerificationPolicy::Required;
+                        auth_sel.resident_key = Some(resident_key);
+                        auth_sel.require_resident_key = require_resident_key;
                         Some(auth_sel)
                     } else {
                         Some(AuthenticatorSelectionCriteria {
                             authenticator_attachment: None,
-                            resident_key: Some(ResidentKeyRequirement::Discouraged),
-                            require_resident_key: false,
+                            resident_key: Some(resident_key),
+                            require_resident_key,
                             user_verification: UserVerificationPolicy::Required,
+                        })
+                    };
+            } else if !matches!(resident_key, ResidentKeyRequirement::Discouraged) {
+                // apply non-default resident_key even when UV is not forced
+                ccr.public_key.authenticator_selection =
+                    if let Some(mut auth_sel) = ccr.public_key.authenticator_selection {
+                        auth_sel.resident_key = Some(resident_key);
+                        auth_sel.require_resident_key = require_resident_key;
+                        Some(auth_sel)
+                    } else {
+                        Some(AuthenticatorSelectionCriteria {
+                            authenticator_attachment: None,
+                            resident_key: Some(resident_key),
+                            require_resident_key,
+                            user_verification: UserVerificationPolicy::Preferred,
                         })
                     };
             };

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -1028,6 +1028,7 @@ Your account has not been compromised and no data was leaked."#.into()),
                 renew_exp: 2160,
                 force_uv: false,
                 no_password_exp: true,
+                resident_key: "discouraged".into(),
             },
             atproto: VarsAtproto { enable: false },
         }
@@ -3281,6 +3282,20 @@ impl Vars {
         ) {
             self.webauthn.no_password_exp = v;
         }
+        if let Some(v) = t_str(
+            &mut table,
+            "webauthn",
+            "resident_key",
+            "WEBAUTHN_RESIDENT_KEY",
+        ) {
+            match v.as_str() {
+                "discouraged" | "preferred" | "required" => self.webauthn.resident_key = v,
+                other => panic!(
+                    "Invalid value for `webauthn.resident_key` / WEBAUTHN_RESIDENT_KEY: \
+                     '{other}'. Must be one of: discouraged, preferred, required"
+                ),
+            }
+        }
 
         check_empty(table, "webauthn");
     }
@@ -3867,6 +3882,9 @@ pub struct VarsWebauthn {
     pub renew_exp: u16,
     pub force_uv: bool,
     pub no_password_exp: bool,
+    /// Controls the `residentKey` authenticator selection criterion during registration.
+    /// "discouraged" (default) | "preferred" | "required"
+    pub resident_key: String,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Adds WEBAUTHN_RESIDENT_KEY / webauthn.resident_key config option (discouraged | preferred | required, default: discouraged) so operators can enable discoverable credentials for Apple passkey compatibility.