### PR TITLE
feat(scopes): emit custom attributes at token root per-scope (#1595)

### DIFF
--- a/frontend/src/api/types/scopes.ts
+++ b/frontend/src/api/types/scopes.ts
@@ -5,6 +5,7 @@ export interface ScopeRequest {
     attr_include_access?: string[];
     /// Validation: PATTERN_ATTR
     attr_include_id?: string[];
+    claims_at_root?: boolean;
 }
 
 export interface ScopeResponse {
@@ -12,4 +13,5 @@ export interface ScopeResponse {
     name: string;
     attr_include_access?: string[];
     attr_include_id?: string[];
+    claims_at_root: boolean;
 }

--- a/frontend/src/i18n/admin/de.ts
+++ b/frontend/src/i18n/admin/de.ts
@@ -455,6 +455,11 @@ export let I18nAdminDe: I18nAdmin = {
         name: 'Rollenname',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: 'Dies ist ein Default OIDC Scope. Diese sind unveränderbar.',
         delete1: 'Soll dieser Scope wirklich gelöscht werden?',
         deleteDefault: 'OIDC default scopes cannot be deleted',

--- a/frontend/src/i18n/admin/en.ts
+++ b/frontend/src/i18n/admin/en.ts
@@ -435,6 +435,11 @@ export let I18nAdminEn: I18nAdmin = {
         name: 'Role Name',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: 'This is a default OIDC Scope. These are immutable.',
         delete1: 'Are you sure you want to delete this scope?',
         deleteDefault: 'Default OIDC scopes cannot be deleted.',

--- a/frontend/src/i18n/admin/fr.ts
+++ b/frontend/src/i18n/admin/fr.ts
@@ -465,6 +465,11 @@ export let I18nAdminFr: I18nAdmin = {
         name: 'Nom du rôle',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: `Il s'agit d'une étendue OIDC par défaut. Ces étendues sont immuables.`,
         delete1: 'Êtes-vous sûr de vouloir supprimer cette étendue ?',
         deleteDefault: 'Les étendues OIDC par défaut ne peuvent pas être supprimées.',

--- a/frontend/src/i18n/admin/interface.ts
+++ b/frontend/src/i18n/admin/interface.ts
@@ -377,6 +377,8 @@ export interface I18nAdmin {
         name: string;
     };
     scopes: {
+        claimsAtRoot: string;
+        claimsAtRootWarning: string;
         defaultNoMod: string;
         delete1: string;
         deleteDefault: string;

--- a/frontend/src/i18n/admin/ko.ts
+++ b/frontend/src/i18n/admin/ko.ts
@@ -425,6 +425,11 @@ export let I18nAdminKo: I18nAdmin = {
         name: '역할 이름',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: '이것은 OIDC 기본 범위 중 하나입니다. 변경할 수 없습니다.',
         delete1: '이 범위를 삭제하시겠습니까?',
         deleteDefault: 'OIDC 기본 범위는 삭제할 수 없습니다.',

--- a/frontend/src/i18n/admin/nb.ts
+++ b/frontend/src/i18n/admin/nb.ts
@@ -410,6 +410,11 @@ export let I18nAdminNb: I18nAdmin = {
         name: 'Rollenavn',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: 'Dette er en standard OIDC Scope. Disse kan ikke endres.',
         delete1: 'Skal denne scope slettes?',
         deleteDefault: 'OIDC standard scopes kan ikke slettes',

--- a/frontend/src/i18n/admin/ru.ts
+++ b/frontend/src/i18n/admin/ru.ts
@@ -443,6 +443,11 @@ export let I18nAdminRu: I18nAdmin = {
         name: 'Имя роли',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: 'Это стандартная область OIDC. Стандартные области неизменяемы.',
         delete1: 'Вы уверены, что хотите удалить эту область?',
         deleteDefault: 'Стандартные области OIDC нельзя удалить.',

--- a/frontend/src/i18n/admin/uk.ts
+++ b/frontend/src/i18n/admin/uk.ts
@@ -445,6 +445,11 @@ export let I18nAdminUk: I18nAdmin = {
         name: 'Назва ролі',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: 'Це стандартний OIDC скоуп. Вони є незмінними.',
         delete1: 'Дійсно видалити цей скоуп?',
         deleteDefault: 'Стандартні OIDC скоупи не можна видалити.',

--- a/frontend/src/i18n/admin/zh.ts
+++ b/frontend/src/i18n/admin/zh.ts
@@ -419,6 +419,11 @@ export let I18nAdminZh: I18nAdmin = {
         name: '角色名称',
     },
     scopes: {
+        claimsAtRoot: 'Emit claims at token root',
+        claimsAtRootWarning: `When enabled, this scope's mapped attributes are written at the token root
+            instead of being nested under 'custom'. You own collision-correctness: if a mapped
+            attribute name collides with a reserved JWT claim, token issuance fails. Root-level custom
+            claims may also break with future protocol or feature changes. Reference:`,
         defaultNoMod: '这是默认OIDC作用域。这些是不可变的。',
         delete1: '您确定要删除此作用域吗？',
         deleteDefault: '默认OIDC作用域无法删除。',

--- a/frontend/src/lib/admin/scopes/ScopeConfig.svelte
+++ b/frontend/src/lib/admin/scopes/ScopeConfig.svelte
@@ -5,6 +5,7 @@
     import type { UserAttrConfigValueResponse } from '$api/types/user_attrs.ts';
     import type { ScopeRequest, ScopeResponse } from '$api/types/scopes.ts';
     import IconCheck from '$icons/IconCheck.svelte';
+    import Switch from '$lib5/Switch.svelte';
     import { useI18n } from '$state/i18n.svelte';
     import { useI18nAdmin } from '$state/i18n_admin.svelte';
     import { fetchPut } from '$api/fetch';
@@ -37,10 +38,12 @@
     let name = $state(untrack(() => scope.name));
     let itemsAccess: undefined | SelectItem[] = $state();
     let itemsId: undefined | SelectItem[] = $state();
+    let claimsAtRoot = $state(untrack(() => scope.claims_at_root));
 
     $effect(() => {
         if (scope.id) {
             name = scope.name;
+            claimsAtRoot = scope.claims_at_root;
         }
     });
 
@@ -93,6 +96,7 @@
                 payload.attr_include_id = filtered;
             }
         }
+        payload.claims_at_root = claimsAtRoot;
 
         let res = await fetchPut(form.action, payload);
         if (res.error) {
@@ -136,6 +140,22 @@
         {#if itemsId}
             <SelectList bind:items={itemsId}>Id Token Mappings</SelectList>
         {/if}
+
+        <div class="rootClaims">
+            <Switch bind:checked={claimsAtRoot} ariaLabel={ta.scopes.claimsAtRoot}>
+                {ta.scopes.claimsAtRoot}
+            </Switch>
+        </div>
+        <p class="warn">
+            {ta.scopes.claimsAtRootWarning}
+            <a
+                href="https://www.iana.org/assignments/jwt/jwt.xhtml"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                IANA JWT Claims Registry
+            </a>
+        </p>
     {/if}
 
     {#if !isDefault}
@@ -158,4 +178,13 @@
 </Form>
 
 <style>
+    .rootClaims {
+        margin: 1rem 0 0.25rem 0;
+    }
+
+    .warn {
+        max-width: 30rem;
+        font-size: 0.9rem;
+        opacity: 0.8;
+    }
 </style>

--- a/src/api_types/src/scopes.rs
+++ b/src/api_types/src/scopes.rs
@@ -16,6 +16,13 @@ pub struct ScopeRequest {
     /// Validation: `^[a-zA-Z0-9-_/]{2,128}$`
     #[validate(custom(function = "validate_vec_attr"))]
     pub attr_include_id: Option<Vec<String>>,
+    /// If `true`, the custom attributes mapped by this scope are emitted at the
+    /// token root instead of nested under `custom`. The admin owns collision
+    /// correctness: issuance fails if a mapped attribute name collides with a
+    /// reserved JWT claim. Defaults to `false` and is only meaningful for custom
+    /// scopes.
+    #[serde(default)]
+    pub claims_at_root: bool,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -27,4 +34,5 @@ pub struct ScopeResponse {
     pub attr_include_access: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attr_include_id: Option<Vec<String>>,
+    pub claims_at_root: bool,
 }

--- a/src/bin/tests/handler_scopes.rs
+++ b/src/bin/tests/handler_scopes.rs
@@ -28,6 +28,7 @@ async fn test_scopes() -> Result<(), Box<dyn Error>> {
         scope: "scope123".to_string(),
         attr_include_access: None,
         attr_include_id: None,
+        claims_at_root: false,
     };
     let res = client
         .post(&url)
@@ -96,6 +97,7 @@ async fn test_scopes() -> Result<(), Box<dyn Error>> {
         scope: "scope456".to_string(),
         attr_include_access: None,
         attr_include_id: None,
+        claims_at_root: false,
     };
     let url_name = format!("{}/{}", url, scope.id);
     let res = client

--- a/src/bin/tests/zza_handler_cust_attrs.rs
+++ b/src/bin/tests/zza_handler_cust_attrs.rs
@@ -54,6 +54,7 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         scope: "cust_scope".to_string(),
         attr_include_access: None,
         attr_include_id: None,
+        claims_at_root: false,
     };
     let url_scopes = format!("{}/scopes", backend_url);
     let res = client
@@ -73,6 +74,7 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         scope: "cust_scope".to_string(),
         attr_include_access: Some(vec!["cust1".to_string()]),
         attr_include_id: Some(vec!["cust1".to_string()]),
+        claims_at_root: false,
     };
     let url_scope = format!("{}/{}", url_scopes, scope.id);
     let res = client
@@ -177,6 +179,64 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         cust_claims.get("cust1").unwrap(),
         &Value::String("Some String".to_string())
     );
+
+    // === issue #1595: per-scope `claims_at_root` ===
+    // Flip the scope so its mapped attribute is emitted at the token root (flattened)
+    // instead of nested under `custom`, then assert the change end-to-end.
+    let req = ScopeRequest {
+        scope: "cust_scope".to_string(),
+        attr_include_access: Some(vec!["cust1".to_string()]),
+        attr_include_id: Some(vec!["cust1".to_string()]),
+        claims_at_root: true,
+    };
+    let res = client
+        .put(&url_scope)
+        .headers(auth_headers.clone())
+        .json(&req)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let scope_root = res.json::<ScopeResponse>().await?;
+    assert!(scope_root.claims_at_root);
+
+    // The mapped attribute must now be a top-level claim and must NOT appear nested
+    // under `custom` (the only custom mapping on this token is root-promoted).
+    let token = get_token_set().await;
+    let bytes = extract_raw_claims(&token.access_token);
+    let raw = serde_json::from_slice::<Value>(&bytes).unwrap();
+    assert_eq!(
+        raw.get("cust1").unwrap(),
+        &Value::String("Some String".to_string())
+    );
+    assert!(
+        raw.get("custom").is_none(),
+        "no nested `custom` object expected when the only mapping is root-promoted"
+    );
+    // It must also round-trip through the typed claims into `custom_flattened`.
+    let claims = serde_json::from_slice::<JwtAccessClaims>(&bytes).unwrap();
+    assert!(claims.custom.is_none());
+    let flat = claims
+        .custom_flattened
+        .expect("root-promoted attribute must be present in custom_flattened");
+    assert_eq!(
+        flat.get("cust1").unwrap(),
+        &Value::String("Some String".to_string())
+    );
+
+    // Restore nested behavior so the remainder of the test observes `custom.*` again.
+    let req = ScopeRequest {
+        scope: "cust_scope".to_string(),
+        attr_include_access: Some(vec!["cust1".to_string()]),
+        attr_include_id: Some(vec!["cust1".to_string()]),
+        claims_at_root: false,
+    };
+    let res = client
+        .put(&url_scope)
+        .headers(auth_headers.clone())
+        .json(&req)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
 
     // modify the custom attr and change its name
     let cust_attr_mod = UserAttrConfigRequest {

--- a/src/data/src/entity/scopes.rs
+++ b/src/data/src/entity/scopes.rs
@@ -24,8 +24,10 @@ pub struct Scope {
     pub attr_include_access: Option<String>,
     // Custom user attributes as CSV to include in the id token
     pub attr_include_id: Option<String>,
-    // TODO this could be used to try(!) to insert claims at the token root instead of at `custom`.
-    // pub claims_at_root: bool,
+    /// If `true`, the mapped custom attributes are emitted at the token root
+    /// (flattened) instead of nested under `custom`. Only meaningful for custom
+    /// scopes; a collision with a reserved claim fails token issuance.
+    pub claims_at_root: bool,
 }
 
 // CRUD
@@ -61,16 +63,21 @@ impl Scope {
         let attr_include_access = Self::clean_up_attrs(scope_req.attr_include_access, &attrs);
         let attr_include_id = Self::clean_up_attrs(scope_req.attr_include_id, &attrs);
 
+        // `claims_at_root` is only meaningful for custom scopes; normalize it so
+        // the stored data can never request root emission for a default OIDC scope.
+        let claims_at_root = scope_req.claims_at_root && Scope::is_custom(&scope_req.scope);
+
         let new_scope = Scope {
             id: new_store_id(),
             name: scope_req.scope,
             attr_include_access,
             attr_include_id,
+            claims_at_root,
         };
 
         let sql = r#"
-INSERT INTO scopes (id, name, attr_include_access, attr_include_id)
-VALUES ($1, $2, $3, $4)"#;
+INSERT INTO scopes (id, name, attr_include_access, attr_include_id, claims_at_root)
+VALUES ($1, $2, $3, $4, $5)"#;
 
         if is_hiqlite() {
             DB::hql()
@@ -80,7 +87,8 @@ VALUES ($1, $2, $3, $4)"#;
                         &new_scope.id,
                         &new_scope.name,
                         &new_scope.attr_include_access,
-                        &new_scope.attr_include_id
+                        &new_scope.attr_include_id,
+                        new_scope.claims_at_root
                     ),
                 )
                 .await?;
@@ -92,6 +100,7 @@ VALUES ($1, $2, $3, $4)"#;
                     &new_scope.name,
                     &new_scope.attr_include_access,
                     &new_scope.attr_include_id,
+                    &new_scope.claims_at_root,
                 ],
             )
             .await?;
@@ -259,11 +268,13 @@ VALUES ($1, $2, $3, $4)"#;
         debug!(?attr_include_access);
         debug!(?attr_include_id);
 
+        let claims_at_root = scope_req.claims_at_root && Scope::is_custom(&scope_req.scope);
         let new_scope = Scope {
             id: scope.id.clone(),
             name: scope_req.scope,
             attr_include_access,
             attr_include_id,
+            claims_at_root,
         };
 
         if is_hiqlite() {
@@ -278,12 +289,13 @@ VALUES ($1, $2, $3, $4)"#;
             txn.push((
                 r#"
 UPDATE scopes
-SET name = $1, attr_include_access = $2, attr_include_id = $3
-WHERE id = $4"#,
+SET name = $1, attr_include_access = $2, attr_include_id = $3, claims_at_root = $4
+WHERE id = $5"#,
                 params!(
                     &new_scope.name,
                     &new_scope.attr_include_access,
                     &new_scope.attr_include_id,
+                    new_scope.claims_at_root,
                     &new_scope.id
                 ),
             ));
@@ -305,12 +317,13 @@ WHERE id = $4"#,
                 &txn,
                 r#"
 UPDATE scopes
-SET name = $1, attr_include_access = $2, attr_include_id = $3
-WHERE id = $4"#,
+SET name = $1, attr_include_access = $2, attr_include_id = $3, claims_at_root = $4
+WHERE id = $5"#,
                 &[
                     &new_scope.name,
                     &new_scope.attr_include_access,
                     &new_scope.attr_include_id,
+                    &new_scope.claims_at_root,
                     &new_scope.id,
                 ],
             )
@@ -460,6 +473,7 @@ impl From<Scope> for ScopeResponse {
             name: value.name,
             attr_include_access,
             attr_include_id,
+            claims_at_root: value.claims_at_root,
         }
     }
 }

--- a/src/data/src/migration/bootstrap/scopes.rs
+++ b/src/data/src/migration/bootstrap/scopes.rs
@@ -1,4 +1,5 @@
 use crate::database::DB;
+use crate::entity::scopes::Scope as ScopeEntity;
 use crate::entity::user_attr::UserAttrConfigEntity;
 use crate::migration::bootstrap::bootstrap_data;
 use crate::migration::bootstrap::types::Scope;
@@ -38,8 +39,8 @@ VALUES ($1, $2, $3, $4, $5)"#;
 
         // `claims_at_root` is only meaningful for custom scopes; normalize it so a
         // default OIDC scope can never be stored as requesting root emission.
-        let claims_at_root = scope.claims_at_root.unwrap_or(false)
-            && crate::entity::scopes::Scope::is_custom(&scope.name);
+        let claims_at_root =
+            scope.claims_at_root.unwrap_or(false) && ScopeEntity::is_custom(&scope.name);
 
         let id = scope.id.unwrap_or_else(new_store_id);
 

--- a/src/data/src/migration/bootstrap/scopes.rs
+++ b/src/data/src/migration/bootstrap/scopes.rs
@@ -19,8 +19,8 @@ pub async fn bootstrap() -> Result<(), ErrorResponse> {
         .collect::<Vec<_>>();
 
     let sql = r#"
-INSERT INTO scopes (id, name, attr_include_access, attr_include_id)
-VALUES ($1, $2, $3, $4)"#;
+INSERT INTO scopes (id, name, attr_include_access, attr_include_id, claims_at_root)
+VALUES ($1, $2, $3, $4, $5)"#;
 
     for scope in scopes {
         let attr_include_access = build_attrs(
@@ -36,19 +36,36 @@ VALUES ($1, $2, $3, $4)"#;
             "attr_include_id",
         );
 
+        // `claims_at_root` is only meaningful for custom scopes; normalize it so a
+        // default OIDC scope can never be stored as requesting root emission.
+        let claims_at_root = scope.claims_at_root.unwrap_or(false)
+            && crate::entity::scopes::Scope::is_custom(&scope.name);
+
         let id = scope.id.unwrap_or_else(new_store_id);
 
         if is_hiqlite() {
             DB::hql()
                 .execute(
                     sql,
-                    params!(id, scope.name, attr_include_access, attr_include_id),
+                    params!(
+                        id,
+                        scope.name,
+                        attr_include_access,
+                        attr_include_id,
+                        claims_at_root
+                    ),
                 )
                 .await?;
         } else {
             DB::pg_execute(
                 sql,
-                &[&id, &scope.name, &attr_include_access, &attr_include_id],
+                &[
+                    &id,
+                    &scope.name,
+                    &attr_include_access,
+                    &attr_include_id,
+                    &claims_at_root,
+                ],
             )
             .await?;
         }

--- a/src/data/src/migration/bootstrap/types.rs
+++ b/src/data/src/migration/bootstrap/types.rs
@@ -72,6 +72,10 @@ pub struct Scope {
     /// `[UserAttribute.name]`s that should be included in the `id_token` if this scope is
     /// requested.
     pub attr_include_id: Option<Vec<String>>,
+    /// If `true`, this scope's mapped custom attributes are emitted at the token root
+    /// (flattened) instead of nested under `custom`. Only honored for custom scopes.
+    /// Defaults to `false`.
+    pub claims_at_root: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/jwt/src/claims.rs
+++ b/src/jwt/src/claims.rs
@@ -131,8 +131,12 @@ pub struct JwtAccessClaims<'a> {
     pub groups: Option<Vec<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
-    // #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    // pub custom_flattened: Option<HashMap<String, serde_json::Value>>,
+    /// Custom user attributes promoted to the token root, driven by the per-scope
+    /// `claims_at_root` flag. Flattened, so each entry becomes a top-level claim
+    /// instead of nesting under `custom`. Issuance MUST fail if any key here
+    /// collides with a reserved claim; see [`validate_no_reserved_collision`].
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub custom_flattened: Option<HashMap<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -174,10 +178,103 @@ pub struct JwtIdClaims<'a> {
     pub groups: Option<Vec<String>>, // TODO change to borrowed data when everything works
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
+    /// See [`JwtAccessClaims::custom_flattened`].
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub custom_flattened: Option<HashMap<String, serde_json::Value>>,
     #[serde(borrow, skip_serializing_if = "Option::is_none")]
     pub webid: Option<Cow<'a, str>>,
     #[serde(borrow, skip_serializing_if = "Option::is_none")]
     pub zoneinfo: Option<&'a str>,
+}
+
+/// JWT claim names that Rauthy may emit at the token root: the registered claims
+/// from RFC 7519, the OIDC core / standard claims, and Rauthy's own top-level
+/// fields on the access and id tokens.
+///
+/// A custom attribute promoted to the token root (per-scope `claims_at_root`) MUST
+/// NOT reuse any of these names, otherwise the produced token would carry a
+/// duplicate / shadowed key. This list is a first line of defense and is
+/// intentionally **not** exhaustive (see issue #1595): the authoritative guarantee
+/// is [`validate_no_reserved_collision`] failing issuance on a collision rather
+/// than ever silently shadowing a claim.
+pub const RESERVED_ROOT_CLAIMS: &[&str] = &[
+    // RFC 7519 registered claims
+    "iss",
+    "sub",
+    "aud",
+    "exp",
+    "nbf",
+    "iat",
+    "jti",
+    // OIDC core (id token) claims
+    "auth_time",
+    "nonce",
+    "acr",
+    "amr",
+    "azp",
+    "at_hash",
+    "c_hash",
+    "sid",
+    // OIDC standard claims
+    "name",
+    "given_name",
+    "family_name",
+    "middle_name",
+    "nickname",
+    "preferred_username",
+    "profile",
+    "picture",
+    "website",
+    "email",
+    "email_verified",
+    "gender",
+    "birthdate",
+    "zoneinfo",
+    "locale",
+    "phone_number",
+    "phone_number_verified",
+    "address",
+    "updated_at",
+    // Rauthy top-level fields (access / id tokens)
+    "typ",
+    "scope",
+    "did",
+    "cnf",
+    "allowed_origins",
+    "roles",
+    "groups",
+    "custom",
+    "webid",
+];
+
+/// Ensures no key of a flattened, root-promoted custom claim map collides with a
+/// [`RESERVED_ROOT_CLAIMS`] name. On collision, returns an error listing the
+/// offending keys so the misconfigured scope can be fixed; the token is never
+/// issued with a shadowed claim.
+pub fn validate_no_reserved_collision(
+    flattened: &HashMap<String, serde_json::Value>,
+) -> Result<(), ErrorResponse> {
+    let mut collisions = flattened
+        .keys()
+        .filter(|k| RESERVED_ROOT_CLAIMS.contains(&k.as_str()))
+        .map(|k| k.as_str())
+        .collect::<Vec<_>>();
+
+    if collisions.is_empty() {
+        return Ok(());
+    }
+
+    // sort for a stable, debuggable error message
+    collisions.sort_unstable();
+    Err(ErrorResponse::new(
+        ErrorResponseType::Internal,
+        format!(
+            "Custom attribute(s) {collisions:?} are configured for root emission \
+             (scope `claims_at_root`) but collide with reserved JWT claims. The \
+             token was not issued to avoid shadowing a registered claim. Disable \
+             `claims_at_root` for the affected scope or rename the attribute(s)."
+        ),
+    ))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -264,5 +361,199 @@ impl JwtAmrValue {
             Self::Pwd => "pwd",
             Self::Mfa => "mfa",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        JwtAccessClaims, JwtCommonClaims, JwtIdClaims, JwtTokenType, validate_no_reserved_collision,
+    };
+    use serde_json::json;
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+
+    fn common() -> JwtCommonClaims<'static> {
+        JwtCommonClaims {
+            iat: 1_700_000_000,
+            nbf: 1_700_000_000,
+            exp: 1_700_003_600,
+            iss: "https://auth.example.com",
+            jti: Some("jti123"),
+            aud: Cow::Borrowed("client-id"),
+            sub: Some("user-id"),
+            typ: JwtTokenType::Bearer,
+            azp: "client-id",
+            scope: Some(Cow::Borrowed("openid profile oap")),
+            did: None,
+            cnf: None,
+        }
+    }
+
+    // (c) Collision against a reserved claim must fail to issue, naming the offenders.
+    #[test]
+    fn collision_check_passes_clean_and_fails_on_reserved() {
+        let mut clean = HashMap::new();
+        clean.insert("oap_user_id".to_string(), json!("u1"));
+        clean.insert("oap_org_id".to_string(), json!("o1"));
+        assert!(validate_no_reserved_collision(&clean).is_ok());
+
+        let mut bad = HashMap::new();
+        bad.insert("email".to_string(), json!("x@y.z")); // reserved
+        bad.insert("sub".to_string(), json!("spoofed")); // reserved
+        bad.insert("oap_user_id".to_string(), json!("u1")); // fine
+        let err = validate_no_reserved_collision(&bad).unwrap_err();
+        assert!(err.message.contains("email"), "must name `email`");
+        assert!(err.message.contains("sub"), "must name `sub`");
+        assert!(
+            !err.message.contains("oap_user_id"),
+            "must not flag a non-reserved key"
+        );
+    }
+
+    // (b) Flatten vs nested both serialize: flattened keys at root, nested under `custom`.
+    #[test]
+    fn access_token_flattened_at_root_nested_under_custom() {
+        let mut flattened = HashMap::new();
+        flattened.insert("oap_user_id".to_string(), json!("u-123"));
+        flattened.insert("platform_role".to_string(), json!("admin"));
+        let mut nested = HashMap::new();
+        nested.insert("department".to_string(), json!("eng"));
+
+        let claims = JwtAccessClaims {
+            common: common(),
+            allowed_origins: None,
+            email: Some("a@b.c"),
+            email_verified: Some(true),
+            roles: None,
+            groups: None,
+            custom: Some(nested),
+            custom_flattened: Some(flattened),
+        };
+
+        let v = serde_json::to_value(&claims).unwrap();
+        // flattened entries become top-level claims
+        assert_eq!(v["oap_user_id"], json!("u-123"));
+        assert_eq!(v["platform_role"], json!("admin"));
+        // nested entries stay under `custom`, never at root
+        assert_eq!(v["custom"]["department"], json!("eng"));
+        assert!(v.get("department").is_none());
+        // reserved / common claims are unaffected
+        assert_eq!(v["iss"], json!("https://auth.example.com"));
+        assert_eq!(v["email"], json!("a@b.c"));
+    }
+
+    // (b) Round-trip via `from_slice` (mirrors token introspection in `token_info.rs`):
+    // borrowed deserialization still works, and the greedy flatten map must NOT absorb
+    // reserved / known root claims.
+    #[test]
+    fn access_token_round_trips_without_leaking_reserved() {
+        let mut flattened = HashMap::new();
+        flattened.insert("oap_user_id".to_string(), json!("u-123"));
+        let mut nested = HashMap::new();
+        nested.insert("department".to_string(), json!("eng"));
+
+        let claims = JwtAccessClaims {
+            common: common(),
+            allowed_origins: None,
+            email: Some("a@b.c"),
+            email_verified: Some(true),
+            roles: None,
+            groups: None,
+            custom: Some(nested),
+            custom_flattened: Some(flattened),
+        };
+
+        let bytes = serde_json::to_vec(&claims).unwrap();
+        let back = serde_json::from_slice::<JwtAccessClaims>(&bytes).unwrap();
+
+        let cf = back.custom_flattened.expect("custom_flattened recovered");
+        assert_eq!(cf.get("oap_user_id").unwrap(), &json!("u-123"));
+        for reserved in [
+            "iss",
+            "sub",
+            "aud",
+            "exp",
+            "nbf",
+            "iat",
+            "jti",
+            "email",
+            "email_verified",
+            "custom",
+            "scope",
+            "azp",
+            "typ",
+        ] {
+            assert!(
+                !cf.contains_key(reserved),
+                "custom_flattened leaked reserved claim `{reserved}`"
+            );
+        }
+        let c = back.custom.expect("custom recovered");
+        assert_eq!(c.get("department").unwrap(), &json!("eng"));
+        // borrowed fields survived flatten-based deserialization
+        assert_eq!(back.email, Some("a@b.c"));
+        assert_eq!(back.common.iss, "https://auth.example.com");
+    }
+
+    // (b) Same guarantees for the id token.
+    #[test]
+    fn id_token_flattened_round_trips() {
+        let mut flattened = HashMap::new();
+        flattened.insert("oap_org_slug".to_string(), json!("acme"));
+        let mut nested = HashMap::new();
+        nested.insert("department".to_string(), json!("eng"));
+
+        let claims = JwtIdClaims {
+            common: common(),
+            amr: vec!["pwd"],
+            auth_time: 1_700_000_000,
+            at_hash: "hash",
+            sid: None,
+            email: None,
+            email_verified: None,
+            preferred_username: None,
+            given_name: None,
+            family_name: None,
+            address: None,
+            birthdate: None,
+            picture: None,
+            locale: None,
+            nonce: None,
+            phone_number: None,
+            phone_number_verified: None,
+            roles: vec![],
+            groups: None,
+            custom: Some(nested),
+            custom_flattened: Some(flattened),
+            webid: None,
+            zoneinfo: None,
+        };
+
+        let v = serde_json::to_value(&claims).unwrap();
+        assert_eq!(v["oap_org_slug"], json!("acme"));
+        assert_eq!(v["custom"]["department"], json!("eng"));
+
+        let bytes = serde_json::to_vec(&claims).unwrap();
+        let back = serde_json::from_slice::<JwtIdClaims>(&bytes).unwrap();
+        let cf = back
+            .custom_flattened
+            .expect("id custom_flattened recovered");
+        assert_eq!(cf.get("oap_org_slug").unwrap(), &json!("acme"));
+        for reserved in ["amr", "auth_time", "at_hash", "custom", "iss", "exp"] {
+            assert!(
+                !cf.contains_key(reserved),
+                "id custom_flattened leaked reserved claim `{reserved}`"
+            );
+        }
+    }
+
+    // (a) No custom value can produce shadowed JSON: a flattened map carrying a reserved
+    // key is rejected before it can ever be serialized into a token.
+    #[test]
+    fn flattened_reserved_key_is_rejected_before_emit() {
+        let mut flattened = HashMap::new();
+        flattened.insert("groups".to_string(), json!(["forged-admin"]));
+        assert!(validate_no_reserved_collision(&flattened).is_err());
     }
 }

--- a/src/jwt/src/claims.rs
+++ b/src/jwt/src/claims.rs
@@ -254,17 +254,23 @@ pub const RESERVED_ROOT_CLAIMS: &[&str] = &[
 pub fn validate_no_reserved_collision(
     flattened: &HashMap<String, serde_json::Value>,
 ) -> Result<(), ErrorResponse> {
+    // Hot path: this runs on every token issuance, so avoid any allocation in the
+    // overwhelmingly common no-collision case. `.any()` short-circuits and collects
+    // nothing.
+    if !flattened
+        .keys()
+        .any(|k| RESERVED_ROOT_CLAIMS.contains(&k.as_str()))
+    {
+        return Ok(());
+    }
+
+    // Cold path: a scope is misconfigured. Only now do we allocate to collect the
+    // full set of offenders, sorted for a stable, debuggable error message.
     let mut collisions = flattened
         .keys()
         .filter(|k| RESERVED_ROOT_CLAIMS.contains(&k.as_str()))
         .map(|k| k.as_str())
         .collect::<Vec<_>>();
-
-    if collisions.is_empty() {
-        return Ok(());
-    }
-
-    // sort for a stable, debuggable error message
     collisions.sort_unstable();
     Err(ErrorResponse::new(
         ErrorResponseType::Internal,

--- a/src/service/src/token_set.rs
+++ b/src/service/src/token_set.rs
@@ -16,6 +16,7 @@ use rauthy_data::rauthy_config::RauthyConfig;
 use rauthy_error::{ErrorResponse, ErrorResponseType};
 use rauthy_jwt::claims::{
     JwtAccessClaims, JwtAmrValue, JwtCommonClaims, JwtIdClaims, JwtTokenType,
+    validate_no_reserved_collision,
 };
 use rauthy_jwt::token::JwtToken;
 use ring::digest;
@@ -196,25 +197,39 @@ impl TokenSet {
             roles,
             groups,
             custom: None,
+            custom_flattened: None,
         };
 
         if let Some((cust, user_attrs)) = scope_customs {
             let user_attrs = user_attrs.as_ref().unwrap();
-            let mut attr = HashMap::with_capacity(cust.len());
+            // Attributes of scopes flagged `claims_at_root` go to the token root
+            // (flattened); all others stay nested under `custom`. Routing is
+            // per-scope, so a single token can mix nested and root-level claims.
+            let mut nested = HashMap::new();
+            let mut flattened = HashMap::new();
             for c in cust {
                 if let Some(csv) = &c.attr_include_access {
-                    let scopes = csv.split(',');
-                    for cust_name in scopes {
+                    let target = if c.claims_at_root {
+                        &mut flattened
+                    } else {
+                        &mut nested
+                    };
+                    for cust_name in csv.split(',') {
                         if let Some(value) = user_attrs.get(cust_name) {
                             let json = serde_json::from_slice(value.as_slice())
                                 .expect("Converting cust user id attr to json");
-                            attr.insert(cust_name.to_string(), json);
-                        };
+                            target.insert(cust_name.to_string(), json);
+                        }
                     }
                 }
             }
-            if !attr.is_empty() {
-                claims_new_impl.custom = Some(attr.clone());
+            if !nested.is_empty() {
+                claims_new_impl.custom = Some(nested);
+            }
+            if !flattened.is_empty() {
+                // Fail issuance rather than emit a token that shadows a reserved claim.
+                validate_no_reserved_collision(&flattened)?;
+                claims_new_impl.custom_flattened = Some(flattened);
             }
         }
 
@@ -295,6 +310,7 @@ impl TokenSet {
             roles: user.get_roles(),
             groups: None,
             custom: None,
+            custom_flattened: None,
             webid,
             zoneinfo: None,
         };
@@ -349,21 +365,32 @@ impl TokenSet {
 
         if let Some((cust, user_attrs)) = scope_customs {
             let user_attrs = user_attrs.as_ref().unwrap();
-            let mut attr = HashMap::with_capacity(cust.len());
+            // See `build_access_token`: per-scope routing to root vs nested `custom`.
+            let mut nested = HashMap::new();
+            let mut flattened = HashMap::new();
             for c in cust {
                 if let Some(csv) = &c.attr_include_id {
-                    let scopes = csv.split(',');
-                    for cust_name in scopes {
+                    let target = if c.claims_at_root {
+                        &mut flattened
+                    } else {
+                        &mut nested
+                    };
+                    for cust_name in csv.split(',') {
                         if let Some(value) = user_attrs.get(cust_name) {
                             let json = serde_json::from_slice(value.as_slice())
                                 .expect("Converting cust user id attr to json");
-                            attr.insert(cust_name.to_string(), json);
-                        };
+                            target.insert(cust_name.to_string(), json);
+                        }
                     }
                 }
             }
-            if !attr.is_empty() {
-                claims.custom = Some(attr);
+            if !nested.is_empty() {
+                claims.custom = Some(nested);
+            }
+            if !flattened.is_empty() {
+                // Fail issuance rather than emit a token that shadows a reserved claim.
+                validate_no_reserved_collision(&flattened)?;
+                claims.custom_flattened = Some(flattened);
             }
         }
 


### PR DESCRIPTION
## Summary

Resolves #1595 (builds on the merged migration #1596).

Adds an opt-in, **per-custom-scope** `claims_at_root` flag that promotes a scope's mapped attributes to the JWT root (flattened) instead of nesting them under `custom`. This is the per-scope design from the #1595 thread, not a global/unconditional switch.

## Collision safety (the core of this PR)

`#[serde(flatten)]` does **not** reject duplicate keys at serialize time; it would emit both and silently shadow. So detection is proactive and runs *before* the token is built: if a root-promoted attribute name collides with a reserved/registered claim (RFC 7519 + OIDC core + Rauthy's own top-level fields), **issuance fails** with a clear, logged error rather than ever shadowing a claim. The reserved list (`RESERVED_ROOT_CLAIMS`) is a first line of defense and is explicitly non-exhaustive: no maintained blacklist.

## What's included

- **Claims**: `custom_flattened` on `JwtAccessClaims` / `JwtIdClaims`; `validate_no_reserved_collision()`.
- **Token build**: per-scope routing to root vs nested `custom`; fail-to-issue on collision. A single token can mix nested and root-level claims.
- **Scopes**: `claims_at_root` threaded through CRUD (hiqlite + postgres) and declarative bootstrap; normalized to `false` for non-custom scopes so a default OIDC scope can never request root emission.
- **API types**: `ScopeRequest` (serde default for back-compat) + `ScopeResponse`.
- **Admin UI**: per-scope toggle on custom-scope edit with a persistent warning (root emission may break on future protocol/feature changes; the admin owns collision correctness), linking the IANA JWT Claims Registry.

## Tests

- **Unit** (`jwt/src/claims.rs`): flat-vs-nested serialization; borrowed round-trip via `from_slice` (mirrors token introspection in `token_info.rs`) proving the greedy flatten map never absorbs reserved claims; collision then fail-to-issue.
- **E2E** (`zza_handler_cust_attrs.rs`): flip a mapped scope to `claims_at_root` and assert the attribute is emitted at the token root and absent from `custom`.

## Notes

- Cross-scope same-attribute promotion is intentionally *not* a collision: user attributes are global (keyed by name), so two scopes promoting the same attribute resolve to the identical value (idempotent); failing it would break legitimate configs. Only reserved-claim collisions fail issuance.
- Real-world motivation: OIDC clients that read custom claims only at the token root (e.g. Immich, the original thread motivation).
- Non-English i18n strings use an English fallback for the two new keys; translations welcome.

Local verification: `cargo check --workspace --tests`, clippy (no new warnings), `cargo fmt --check`, and the jwt unit tests all pass; `svelte-check` is clean for the touched frontend files.
