### PR TITLE
feat(api-keys): allow API-key auth for upstream provider endpoints (#1554)

### DIFF
--- a/frontend/src/api/types/api_keys.ts
+++ b/frontend/src/api/types/api_keys.ts
@@ -10,7 +10,8 @@ export type AccessGroup =
     | 'Sessions'
     | 'Scopes'
     | 'UserAttributes'
-    | 'Users';
+    | 'Users'
+    | 'AuthProviders';
 export type AccessRight = 'read' | 'create' | 'update' | 'delete';
 
 export interface ApiKeyAccess {

--- a/frontend/src/lib/admin/api_keys/ApiKeyMatrix.svelte
+++ b/frontend/src/lib/admin/api_keys/ApiKeyMatrix.svelte
@@ -32,6 +32,7 @@
         ['Scopes', false, false, false, false],
         ['UserAttributes', false, false, false, false],
         ['Users', false, false, false, false],
+        ['AuthProviders', false, false, false, false],
     ]);
 
     $effect(() => {
@@ -76,6 +77,9 @@
                         break;
                     case 'Users':
                         idx = 11;
+                        break;
+                    case 'AuthProviders':
+                        idx = 12;
                         break;
                 }
                 if (idx === undefined) {

--- a/src/api/src/auth_providers.rs
+++ b/src/api/src/auth_providers.rs
@@ -11,6 +11,7 @@ use rauthy_api_types::auth_providers::{ProviderLookupResponse, ProviderResponse}
 use rauthy_api_types::generic::LogoParams;
 use rauthy_api_types::users::{UserResponse, WebauthnLoginResponse};
 use rauthy_common::constants::{HEADER_JSON, PROVIDER_ATPROTO};
+use rauthy_data::entity::api_keys::{AccessGroup, AccessRights};
 use rauthy_data::entity::auth_providers::{
     AuthProvider, AuthProviderLinkCookie, AuthProviderTemplate,
 };
@@ -40,7 +41,7 @@ use validator::Validate;
 )]
 #[post("/providers")]
 pub async fn post_providers(principal: ReqPrincipal) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Read)?;
 
     let providers = AuthProvider::find_all().await?;
     let mut resp = Vec::with_capacity(providers.len());
@@ -71,7 +72,8 @@ pub async fn post_provider(
     Json(payload): Json<ProviderRequest>,
     principal: ReqPrincipal,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal
+        .validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Create)?;
     payload.validate()?;
 
     if payload.issuer == PROVIDER_ATPROTO {
@@ -118,7 +120,7 @@ pub async fn post_provider_lookup(
     Json(payload): Json<ProviderLookupRequest>,
     principal: ReqPrincipal,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Read)?;
     payload.validate()?;
 
     let resp = AuthProvider::lookup_config(&payload).await?;
@@ -291,7 +293,8 @@ pub async fn put_provider(
     Json(payload): Json<ProviderRequest>,
     principal: ReqPrincipal,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal
+        .validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Update)?;
     payload.validate()?;
 
     if !payload.use_pkce && payload.client_secret.is_none() {
@@ -330,7 +333,8 @@ pub async fn delete_provider(
     id: web::Path<String>,
     principal: ReqPrincipal,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal
+        .validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Delete)?;
 
     AuthProvider::delete(&id.into_inner()).await?;
     Ok(HttpResponse::Ok().finish())
@@ -360,7 +364,7 @@ pub async fn get_provider_delete_safe(
     id: web::Path<String>,
     principal: ReqPrincipal,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Read)?;
 
     let linked_users = AuthProvider::find_linked_users(&id.into_inner()).await?;
     if linked_users.is_empty() {
@@ -428,7 +432,8 @@ pub async fn put_provider_img(
     principal: ReqPrincipal,
     mut payload: actix_multipart::Multipart,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal
+        .validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Update)?;
     content_len_limit(&req, 10)?;
 
     // we only accept a single field from the Multipart upload -> no looping here
@@ -486,7 +491,8 @@ pub async fn delete_provider_img(
     id: web::Path<String>,
     principal: ReqPrincipal,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal
+        .validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Delete)?;
 
     Logo::delete(&id.into_inner(), &LogoType::AuthProvider).await?;
     Ok(HttpResponse::Ok().finish())

--- a/src/api/src/auth_providers.rs
+++ b/src/api/src/auth_providers.rs
@@ -491,8 +491,11 @@ pub async fn delete_provider_img(
     id: web::Path<String>,
     principal: ReqPrincipal,
 ) -> Result<HttpResponse, ErrorResponse> {
+    // Clearing the logo only mutates the provider's image, it does not remove the
+    // provider, so it maps to `Update` (mirroring `put_provider_img`). `Delete` is
+    // reserved for removing the provider entity itself.
     principal
-        .validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Delete)?;
+        .validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::Update)?;
 
     Logo::delete(&id.into_inner(), &LogoType::AuthProvider).await?;
     Ok(HttpResponse::Ok().finish())

--- a/src/api_types/src/api_keys.rs
+++ b/src/api_types/src/api_keys.rs
@@ -17,6 +17,7 @@ pub enum AccessGroup {
     UserAttributes,
     Users,
     Pam,
+    AuthProviders,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/src/bin/tests/handler_api_keys.rs
+++ b/src/bin/tests/handler_api_keys.rs
@@ -98,6 +98,48 @@ async fn test_api_keys() -> Result<(), Box<dyn Error>> {
         .await?;
     assert_eq!(res.status(), StatusCode::OK);
 
+    // issue #1554: an API key with `AuthProviders` access can reach the upstream
+    // provider endpoints, which used to be admin-session-only.
+    payload.access = vec![ApiKeyAccess {
+        group: AccessGroup::AuthProviders,
+        access_rights: vec![AccessRights::Read],
+    }];
+    let res = client
+        .put(&url_put)
+        .headers(auth_headers.clone())
+        .json(&payload)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // listing providers is `POST /providers` (an admin route, now API-key accessible)
+    let url_providers = format!("{}/providers", get_backend_url());
+    let res = client
+        .post(&url_providers)
+        .header(AUTHORIZATION, &key_header)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // without `AuthProviders` access, the same call is forbidden
+    payload.access = vec![ApiKeyAccess {
+        group: AccessGroup::Groups,
+        access_rights: vec![AccessRights::Read],
+    }];
+    let res = client
+        .put(&url_put)
+        .headers(auth_headers.clone())
+        .json(&payload)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+    let res = client
+        .post(&url_providers)
+        .header(AUTHORIZATION, &key_header)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
     // let our key expire
     let exp_ts = Utc::now().sub(chrono::Duration::seconds(1)).timestamp();
     payload.exp = Some(exp_ts);

--- a/src/data/src/entity/api_keys.rs
+++ b/src/data/src/entity/api_keys.rs
@@ -316,6 +316,7 @@ pub enum AccessGroup {
     UserAttributes,
     Users,
     Pam,
+    AuthProviders,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -430,6 +431,7 @@ impl From<AccessGroup> for rauthy_api_types::api_keys::AccessGroup {
             AccessGroup::UserAttributes => Self::UserAttributes,
             AccessGroup::Users => Self::Users,
             AccessGroup::Pam => Self::Pam,
+            AccessGroup::AuthProviders => Self::AuthProviders,
         }
     }
 }
@@ -473,6 +475,7 @@ impl From<rauthy_api_types::api_keys::AccessGroup> for AccessGroup {
             rauthy_api_types::api_keys::AccessGroup::UserAttributes => Self::UserAttributes,
             rauthy_api_types::api_keys::AccessGroup::Users => Self::Users,
             rauthy_api_types::api_keys::AccessGroup::Pam => Self::Pam,
+            rauthy_api_types::api_keys::AccessGroup::AuthProviders => Self::AuthProviders,
         }
     }
 }
@@ -498,5 +501,53 @@ impl From<rauthy_api_types::api_keys::ApiKeyAccess> for ApiKeyAccess {
                 .map(|ar| ar.into())
                 .collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AccessGroup, AccessRights, ApiKey, ApiKeyAccess};
+
+    // `AccessGroup` is bincode-serialized by variant index for storage, so new
+    // variants must be appended (see the note above the enum). These tests guard the
+    // `AuthProviders` variant added for issue #1554.
+    #[test]
+    fn auth_providers_round_trips_between_layers() {
+        let api: rauthy_api_types::api_keys::AccessGroup = AccessGroup::AuthProviders.into();
+        assert_eq!(api, rauthy_api_types::api_keys::AccessGroup::AuthProviders);
+        let back: AccessGroup = api.into();
+        assert_eq!(back, AccessGroup::AuthProviders);
+    }
+
+    #[test]
+    fn validate_access_honors_auth_providers() {
+        let key = ApiKey {
+            name: "k".to_string(),
+            secret: vec![],
+            created: 0,
+            expires: None,
+            access: vec![ApiKeyAccess {
+                group: AccessGroup::AuthProviders,
+                access_rights: vec![AccessRights::Read, AccessRights::Create],
+            }],
+        };
+        assert!(
+            key.validate_access(&AccessGroup::AuthProviders, &AccessRights::Read)
+                .is_ok()
+        );
+        assert!(
+            key.validate_access(&AccessGroup::AuthProviders, &AccessRights::Create)
+                .is_ok()
+        );
+        // a right that was not granted
+        assert!(
+            key.validate_access(&AccessGroup::AuthProviders, &AccessRights::Delete)
+                .is_err()
+        );
+        // a different group entirely
+        assert!(
+            key.validate_access(&AccessGroup::Clients, &AccessRights::Read)
+                .is_err()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Resolves #1554.

Upstream auth provider management (`/providers/*`) was restricted to an admin session, so it could not be driven by an API key or declarative bootstrapping. This adds an `AuthProviders` variant to `AccessGroup` and switches the admin-management provider routes to `validate_api_key_or_admin_session(...)`, mirroring how `groups` / `roles` / `users` already work.

## Changes

- **`AccessGroup`**: new `AuthProviders` variant on both the api-types enum and the data-entity enum, plus the two `From` conversions between them. The entity enum is **bincode-serialized by variant index** for storage, so the new variant is appended last (per the existing note above the enum) to avoid breaking already-stored API keys.
- **Provider handlers** (`auth_providers.rs`): the eight admin-management routes now use `validate_api_key_or_admin_session(AccessGroup::AuthProviders, AccessRights::…)`:
  - `Read`: list providers, config lookup, delete-safe check
  - `Create`: create provider
  - `Update`: update provider, upload logo
  - `Delete`: delete provider, delete logo

  The login-flow / public routes (`login`, `callback`, `link`, `minimal`, image GET) are intentionally left untouched.
- **Admin UI**: `AuthProviders` added to the API-key access matrix (`ApiKeyMatrix.svelte`) and the `AccessGroup` TS type.

## Tests

- **Unit** (`entity/api_keys.rs`): `AuthProviders` round-trips between the entity and api-types `AccessGroup`, and `validate_access` honors it (granted rights pass, ungranted/other-group fail).
- **E2E** (`handler_api_keys.rs`): an API key granted `AuthProviders: [read]` can call `POST /providers`, and the same call is `403` once that access is removed.

Local verification: `cargo check --workspace --tests`, clippy (no new warnings), `cargo fmt --check`, `prettier -c`, and the unit tests all pass; `svelte-check` is clean for the touched files.
