### PR TITLE
feat(bootstrap): add generated bootstrap secret extraction

### DIFF
--- a/book/src/config/bootstrap.md
+++ b/book/src/config/bootstrap.md
@@ -215,13 +215,13 @@ later does not reconcile live API keys.
 ## Generated Bootstrap Secrets
 
 Generated bootstrap credentials are stored in an encrypted local container before their matching
-database rows are inserted. This keeps later phases from creating live client, user, or API-key rows
-whose generated plaintext cannot be recovered.
+database rows are inserted. This keeps later phases from creating live client or user rows whose
+generated plaintext cannot be recovered.
 
-The container has a cleartext magic/version/deadline header followed by an encrypted JSON payload.
-Rauthy can therefore purge an expired file during startup without decrypting the payload. A positive
-TTL also schedules a runtime purge after each write. Set the TTL to `0` only if you intentionally
-want to keep the encrypted container for manual extraction and purge it yourself.
+The container is a single AEAD-encrypted JSON payload. The expiry deadline lives inside that
+encrypted payload, so startup and runtime expiry checks decrypt the container first. A positive TTL
+also schedules a runtime purge after each write. Set the TTL to `0` only if you intentionally want
+to keep the encrypted container for manual extraction and purge it yourself.
 
 Generated values are a first-boot mechanism only. The JSON bootstrap files are read while Rauthy
 initializes an empty production database. If you add `"generate"` to `clients.json` or `users.json`
@@ -251,24 +251,23 @@ not talk to the Rauthy server.
 
 ```bash
 rauthy bootstrap get \
-  --file data/bootstrap.secrets.enc \
+  -c config.toml \
   --kind client \
   --id my-service \
   --field secret \
   --format raw
 
-rauthy bootstrap get --file data/bootstrap.secrets.enc --format env
-rauthy bootstrap purge --file data/bootstrap.secrets.enc
+rauthy bootstrap get -c config.toml --format env
+rauthy bootstrap purge -c config.toml
 ```
 
 `get --format env` emits names that include the entity kind, sanitized id, and field, for example
 `RAUTHY_BOOTSTRAP_CLIENT_MY_SERVICE_SECRET=...` and
 `RAUTHY_BOOTSTRAP_USER_ADMIN_EXAMPLE_COM_PASSWORD=...`.
 
-The CLI decrypts the container locally and therefore needs `ENC_KEY_ACTIVE` and `ENC_KEYS` either
-as environment variables or as `--enc-key-active` / `--enc-keys`. If you run Rauthy with
-`USE_VAULT_CONFIG=true`, pass these key values explicitly to the CLI; it intentionally does not
-contact Vault for an offline bootstrap-secret read.
+The CLI loads the existing Rauthy config and initializes the configured encryption keys before it
+decrypts the container. It does not accept encryption keys or the container path as command-line
+arguments.
 
 Clients can request a generated confidential-client secret with `"secret": "generate"`:
 

--- a/book/src/config/bootstrap.md
+++ b/book/src/config/bootstrap.md
@@ -109,10 +109,11 @@ rights could look like this:
 ]
 ```
 
-The `secret` can be either `{"Plain": "..."}` or `{"Encrypted": "..."}`. Plain secrets must be at
+The `secret` can be `{"Plain": "..."}`, `{"Encrypted": "..."}`, or `"generate"`. Plain secrets must be at
 least 64 characters long. Encrypted secrets are encrypted with
 [`cryptr`](https://github.com/sebadob/cryptr) and base64-encoded, just like encrypted client
-secrets.
+secrets. Generated API-key secrets are written to the generated-secret container and can be
+extracted with `rauthy bootstrap get --kind api-key --id <name> --field secret`.
 
 ```admonish caution
 Only bootstrap short-lived API keys for production automation. Set `exp` to a timestamp
@@ -215,8 +216,8 @@ later does not reconcile live API keys.
 ## Generated Bootstrap Secrets
 
 Generated bootstrap credentials are stored in an encrypted local container before their matching
-database rows are inserted. This keeps later phases from creating live client or user rows whose
-generated plaintext cannot be recovered.
+database rows are inserted. This keeps later phases from creating live client, user, or API-key
+rows whose generated plaintext cannot be recovered.
 
 The container is a single AEAD-encrypted JSON payload. The expiry deadline lives inside that
 encrypted payload, so startup and runtime expiry checks decrypt the container first. A positive TTL
@@ -224,9 +225,9 @@ also schedules a runtime purge after each write. Set the TTL to `0` only if you 
 to keep the encrypted container for manual extraction and purge it yourself.
 
 Generated values are a first-boot mechanism only. The JSON bootstrap files are read while Rauthy
-initializes an empty production database. If you add `"generate"` to `clients.json` or `users.json`
-after the database has already been initialized, that day-2 change is ignored by the first-boot
-bootstrap gate and no new generated secret is written.
+initializes an empty production database. If you add `"generate"` to `clients.json`, `users.json`,
+or `api_keys.json` after the database has already been initialized, that day-2 change is ignored by
+the first-boot bootstrap gate and no new generated secret is written.
 
 ```toml
 [bootstrap]
@@ -311,6 +312,11 @@ Users can request a generated password with `"password": "generate"`:
 
 Rauthy writes the plaintext password to the encrypted container before hashing it and inserting the
 user row. The database stores only the password hash.
+
+API keys in `api_keys.json` can request a generated secret with `"secret": "generate"`. Rauthy
+writes the plaintext API-key secret to the encrypted container before hashing and storing it in the
+database. Extract it with `--kind api-key --id <key-name> --field secret`; combine it with the key
+name as `API-Key <key-name>$<secret>` for the `Authorization` header.
 
 ## Advanced / Custom Configuration
 

--- a/book/src/config/bootstrap.md
+++ b/book/src/config/bootstrap.md
@@ -212,6 +212,107 @@ JSON is only read while initializing an empty production database; changing `api
 later does not reconcile live API keys.
 ```
 
+## Generated Bootstrap Secrets
+
+Generated bootstrap credentials are stored in an encrypted local container before their matching
+database rows are inserted. This keeps later phases from creating live client, user, or API-key rows
+whose generated plaintext cannot be recovered.
+
+The container has a cleartext magic/version/deadline header followed by an encrypted JSON payload.
+Rauthy can therefore purge an expired file during startup without decrypting the payload. A positive
+TTL also schedules a runtime purge after each write. Set the TTL to `0` only if you intentionally
+want to keep the encrypted container for manual extraction and purge it yourself.
+
+Generated values are a first-boot mechanism only. The JSON bootstrap files are read while Rauthy
+initializes an empty production database. If you add `"generate"` to `clients.json` or `users.json`
+after the database has already been initialized, that day-2 change is ignored by the first-boot
+bootstrap gate and no new generated secret is written.
+
+```toml
+[bootstrap]
+# Path to the encrypted generated-secret container. If unset, Rauthy stores it
+# below Hiqlite's configured data directory as:
+#
+# `${cluster.data_dir}/bootstrap.secrets.enc`
+#
+# overwritten by: BOOTSTRAP_GENERATED_SECRETS_FILE
+#generated_secrets_file = 'data/bootstrap.secrets.enc'
+
+# Time in seconds before generated bootstrap secrets expire. A value of `0`
+# disables expiry and runtime auto-purge.
+#
+# default: 600
+# overwritten by: BOOTSTRAP_GENERATED_SECRETS_TTL
+generated_secrets_ttl = 600
+```
+
+Use the local CLI to retrieve or purge the encrypted container after first start. The command does
+not talk to the Rauthy server.
+
+```bash
+rauthy bootstrap get \
+  --file data/bootstrap.secrets.enc \
+  --kind client \
+  --id my-service \
+  --field secret \
+  --format raw
+
+rauthy bootstrap get --file data/bootstrap.secrets.enc --format env
+rauthy bootstrap purge --file data/bootstrap.secrets.enc
+```
+
+`get --format env` emits names that include the entity kind, sanitized id, and field, for example
+`RAUTHY_BOOTSTRAP_CLIENT_MY_SERVICE_SECRET=...` and
+`RAUTHY_BOOTSTRAP_USER_ADMIN_EXAMPLE_COM_PASSWORD=...`.
+
+The CLI decrypts the container locally and therefore needs `ENC_KEY_ACTIVE` and `ENC_KEYS` either
+as environment variables or as `--enc-key-active` / `--enc-keys`. If you run Rauthy with
+`USE_VAULT_CONFIG=true`, pass these key values explicitly to the CLI; it intentionally does not
+contact Vault for an offline bootstrap-secret read.
+
+Clients can request a generated confidential-client secret with `"secret": "generate"`:
+
+```json
+[
+  {
+    "id": "my-service",
+    "name": "My Service",
+    "secret": "generate",
+    "redirect_uris": ["https://my-service.example.com/callback"],
+    "enabled": true,
+    "flows_enabled": ["authorization_code", "refresh_token"],
+    "access_token_alg": "EdDSA",
+    "id_token_alg": "EdDSA",
+    "auth_code_lifetime": 60,
+    "access_token_lifetime": 3600,
+    "scopes": ["openid", "profile", "email"],
+    "default_scopes": ["openid", "profile", "email"],
+    "force_mfa": false
+  }
+]
+```
+
+If the `secret` field is absent or `null`, the client remains public and Rauthy forces `S256` PKCE.
+Use `"secret": "generate"` only when you want a confidential client and plan to extract the
+generated secret from the encrypted container.
+
+Users can request a generated password with `"password": "generate"`:
+
+```json
+[
+  {
+    "email": "admin@example.com",
+    "password": "generate",
+    "roles": ["admin"],
+    "enabled": true,
+    "email_verified": true
+  }
+]
+```
+
+Rauthy writes the plaintext password to the encrypted container before hashing it and inserting the
+user row. The database stores only the password hash.
+
 ## Advanced / Custom Configuration
 
 If you want to bootstrap other things like users or clients, you need to do it a bit differently.

--- a/book/src/config/cli.md
+++ b/book/src/config/cli.md
@@ -104,6 +104,77 @@ is very safe while still not being way over the top. If we wanted the same level
 256-bit random bytes key, in alphanumeric form it would be ~43 characters. We have 48 here, which
 even exceeds it. Anything bigger would be a waste of resources.
 
+## Bootstrap Generated Secrets
+
+When `clients.json` or `users.json` uses `"generate"`, Rauthy writes the plaintext values into an
+encrypted local container before inserting the matching database rows. The CLI can read this
+container without starting or contacting the Rauthy server.
+
+The CLI must have the same encryption keys that were active during bootstrap:
+
+```bash
+export ENC_KEY_ACTIVE='2026-06-06'
+export ENC_KEYS='2026-06-06/<base64-key>'
+```
+
+You can also pass them explicitly:
+
+```bash
+rauthy bootstrap get \
+  --file data/bootstrap.secrets.enc \
+  --enc-key-active '2026-06-06' \
+  --enc-keys '2026-06-06/<base64-key>' \
+  --format env
+```
+
+If your deployment uses `USE_VAULT_CONFIG=true`, provide `ENC_KEY_ACTIVE` and `ENC_KEYS` explicitly
+or via the local environment. `rauthy bootstrap get` is an offline decrypt command and intentionally
+does not fetch config from Vault.
+
+To print only one value, use `raw` with an exact selector:
+
+```bash
+rauthy bootstrap get \
+  --file data/bootstrap.secrets.enc \
+  --kind client \
+  --id my-service \
+  --field secret \
+  --format raw
+```
+
+`json` preserves every field:
+
+```bash
+rauthy bootstrap get \
+  --file data/bootstrap.secrets.enc \
+  --kind user \
+  --id admin@example.com \
+  --field password \
+  --format json
+```
+
+`env` emits collision-safe names containing the kind, sanitized id, and field:
+
+```bash
+rauthy bootstrap get --file data/bootstrap.secrets.enc --format env
+```
+
+Example output:
+
+```bash
+RAUTHY_BOOTSTRAP_CLIENT_MY_SERVICE_SECRET=...
+RAUTHY_BOOTSTRAP_USER_ADMIN_EXAMPLE_COM_PASSWORD=...
+```
+
+After you have stored the values somewhere safe, purge the container:
+
+```bash
+rauthy bootstrap purge --file data/bootstrap.secrets.enc
+```
+
+Purging is idempotent: if the file is already absent, the command reports that and exits
+successfully.
+
 ## Hash Passwords
 
 If you want to hash a password for bootstrapping, you can do it like so:
@@ -118,4 +189,4 @@ more if you want to be extra secure.
 
 ## Serve Rauthy
 
-The last option here is `rauthy serve`. This will actually launch Rauthy. 
+The last option here is `rauthy serve`. This will actually launch Rauthy.

--- a/book/src/config/cli.md
+++ b/book/src/config/cli.md
@@ -110,32 +110,23 @@ When `clients.json` or `users.json` uses `"generate"`, Rauthy writes the plainte
 encrypted local container before inserting the matching database rows. The CLI can read this
 container without starting or contacting the Rauthy server.
 
-The CLI must have the same encryption keys that were active during bootstrap:
+The CLI reads everything it needs from your existing Rauthy config file: it loads the same
+`ENC_KEYS` that were active during bootstrap and resolves the configured container location. You
+never pass encryption keys on the command line (which would leak them into your shell history and
+process list) or a separate file path. Just point it at the config:
 
 ```bash
-export ENC_KEY_ACTIVE='2026-06-06'
-export ENC_KEYS='2026-06-06/<base64-key>'
+rauthy bootstrap get --config-file ./config.toml --format env
 ```
 
-You can also pass them explicitly:
-
-```bash
-rauthy bootstrap get \
-  --file data/bootstrap.secrets.enc \
-  --enc-key-active '2026-06-06' \
-  --enc-keys '2026-06-06/<base64-key>' \
-  --format env
-```
-
-If your deployment uses `USE_VAULT_CONFIG=true`, provide `ENC_KEY_ACTIVE` and `ENC_KEYS` explicitly
-or via the local environment. `rauthy bootstrap get` is an offline decrypt command and intentionally
-does not fetch config from Vault.
+`--config-file` defaults to `./config.toml`, so inside the container or next to the config you can
+usually omit it. If your deployment uses `USE_VAULT_CONFIG=true`, the CLI loads the config the same
+way the server does.
 
 To print only one value, use `raw` with an exact selector:
 
 ```bash
 rauthy bootstrap get \
-  --file data/bootstrap.secrets.enc \
   --kind client \
   --id my-service \
   --field secret \
@@ -146,7 +137,6 @@ rauthy bootstrap get \
 
 ```bash
 rauthy bootstrap get \
-  --file data/bootstrap.secrets.enc \
   --kind user \
   --id admin@example.com \
   --field password \
@@ -156,7 +146,7 @@ rauthy bootstrap get \
 `env` emits collision-safe names containing the kind, sanitized id, and field:
 
 ```bash
-rauthy bootstrap get --file data/bootstrap.secrets.enc --format env
+rauthy bootstrap get --format env
 ```
 
 Example output:
@@ -169,7 +159,7 @@ RAUTHY_BOOTSTRAP_USER_ADMIN_EXAMPLE_COM_PASSWORD=...
 After you have stored the values somewhere safe, purge the container:
 
 ```bash
-rauthy bootstrap purge --file data/bootstrap.secrets.enc
+rauthy bootstrap purge
 ```
 
 Purging is idempotent: if the file is already absent, the command reports that and exits

--- a/config.toml
+++ b/config.toml
@@ -475,7 +475,7 @@ api_key_secret = 'twUA2M7RZ8H3FyJHbti2AcMADPDCxDqUKbvi8FDnm3nYidwQx57Wfv6iaVTQyn
 
 # Generated bootstrap secrets are written to this encrypted local container
 # before their matching database rows are inserted. Later bootstrap phases use
-# it for generated client secrets and user passwords that cannot be
+# it for generated client secrets, user passwords, and API-key secrets that cannot be
 # reconstructed from the database after insertion.
 #
 # The file is a single AEAD-encrypted JSON payload. The expiry deadline lives

--- a/config.toml
+++ b/config.toml
@@ -475,11 +475,11 @@ api_key_secret = 'twUA2M7RZ8H3FyJHbti2AcMADPDCxDqUKbvi8FDnm3nYidwQx57Wfv6iaVTQyn
 
 # Generated bootstrap secrets are written to this encrypted local container
 # before their matching database rows are inserted. Later bootstrap phases use
-# it for generated client secrets, user passwords, and API-key tokens that
-# cannot be reconstructed from the database after insertion.
+# it for generated client secrets and user passwords that cannot be
+# reconstructed from the database after insertion.
 #
-# The file has a cleartext magic/version/deadline header and an encrypted JSON
-# payload. An expired file can therefore be purged without decrypting it.
+# The file is a single AEAD-encrypted JSON payload. The expiry deadline lives
+# inside that encrypted payload, so expiry checks decrypt the container first.
 #
 # If unset, the default is `${cluster.data_dir}/bootstrap.secrets.enc`.
 #

--- a/config.toml
+++ b/config.toml
@@ -473,6 +473,26 @@ api_key = 'ewogICJuYW1lIjogImJvb3RzdHJhcCIsCiAgImV4cCI6IDE3MzU1OTk2MDAsCiAgImFjY
 # overwritten by: BOOTSTRAP_API_KEY_SECRET
 api_key_secret = 'twUA2M7RZ8H3FyJHbti2AcMADPDCxDqUKbvi8FDnm3nYidwQx57Wfv6iaVTQynMh'
 
+# Generated bootstrap secrets are written to this encrypted local container
+# before their matching database rows are inserted. Later bootstrap phases use
+# it for generated client secrets, user passwords, and API-key tokens that
+# cannot be reconstructed from the database after insertion.
+#
+# The file has a cleartext magic/version/deadline header and an encrypted JSON
+# payload. An expired file can therefore be purged without decrypting it.
+#
+# If unset, the default is `${cluster.data_dir}/bootstrap.secrets.enc`.
+#
+# overwritten by: BOOTSTRAP_GENERATED_SECRETS_FILE
+#generated_secrets_file = 'data/bootstrap.secrets.enc'
+
+# Time in seconds before generated bootstrap secrets are purged. The default
+# keeps first-start credentials available briefly for local extraction. Set to
+# `0` to disable expiry and runtime auto-purge.
+#
+# overwritten by: BOOTSTRAP_GENERATED_SECRETS_TTL
+#generated_secrets_ttl = 600
+
 # This is the directory where the bootstrap logic will look for
 # additional bootstrapping data. It will expect JSON files with
 # fixed names inside this folder. If it finds any of them, it will

--- a/src/bin/src/cli_args.rs
+++ b/src/bin/src/cli_args.rs
@@ -41,9 +41,10 @@ pub enum ArgsBootstrapCommand {
 
 #[derive(Debug, Clone, Parser)]
 pub struct ArgsBootstrapGet {
-    /// Path to the encrypted generated-secret container.
-    #[clap(short, long, default_value = "data/bootstrap.secrets.enc")]
-    pub file: String,
+    /// Path to the Rauthy config file. The encryption keys and the container
+    /// location are read from it, so no keys or file path are passed directly.
+    #[clap(short = 'c', long, default_value = "./config.toml")]
+    pub config_file: String,
 
     /// Output format.
     #[clap(long, value_enum, default_value_t = BootstrapOutputFormat::Env)]
@@ -60,21 +61,13 @@ pub struct ArgsBootstrapGet {
     /// Filter by field, for example `secret` or `password`.
     #[clap(long)]
     pub field: Option<String>,
-
-    /// Active encryption key id. Falls back to ENC_KEY_ACTIVE.
-    #[clap(long, env = "ENC_KEY_ACTIVE")]
-    pub enc_key_active: Option<String>,
-
-    /// Newline-separated encryption keys. Falls back to ENC_KEYS.
-    #[clap(long, env = "ENC_KEYS")]
-    pub enc_keys: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ArgsBootstrapPurge {
-    /// Path to the encrypted generated-secret container.
-    #[clap(short, long, default_value = "data/bootstrap.secrets.enc")]
-    pub file: String,
+    /// Path to the Rauthy config file. The container location is read from it.
+    #[clap(short = 'c', long, default_value = "./config.toml")]
+    pub config_file: String,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/src/bin/src/cli_args.rs
+++ b/src/bin/src/cli_args.rs
@@ -1,10 +1,13 @@
-use clap::Parser;
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Clone, Parser)]
 #[clap(author, version, about, long_about = None)]
 pub enum Args {
     /// Start the Rauthy server
     Serve(ArgsServer),
+
+    /// Read or purge generated bootstrap secrets from the local encrypted container.
+    Bootstrap(ArgsBootstrap),
 
     /// Generate a config file to get you started.
     GenerateConfig(ArgsGenConfig),
@@ -19,6 +22,66 @@ pub enum Args {
     GenerateSecrets,
 
     HashPassword(ArgsPasswordHash),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ArgsBootstrap {
+    #[command(subcommand)]
+    pub command: ArgsBootstrapCommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ArgsBootstrapCommand {
+    /// Decrypt and print generated bootstrap secrets.
+    Get(ArgsBootstrapGet),
+
+    /// Delete the generated bootstrap secret container.
+    Purge(ArgsBootstrapPurge),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ArgsBootstrapGet {
+    /// Path to the encrypted generated-secret container.
+    #[clap(short, long, default_value = "data/bootstrap.secrets.enc")]
+    pub file: String,
+
+    /// Output format.
+    #[clap(long, value_enum, default_value_t = BootstrapOutputFormat::Env)]
+    pub format: BootstrapOutputFormat,
+
+    /// Filter by entry kind, for example `client` or `user`.
+    #[clap(long)]
+    pub kind: Option<String>,
+
+    /// Filter by entry id, for example the client id or user email.
+    #[clap(long)]
+    pub id: Option<String>,
+
+    /// Filter by field, for example `secret` or `password`.
+    #[clap(long)]
+    pub field: Option<String>,
+
+    /// Active encryption key id. Falls back to ENC_KEY_ACTIVE.
+    #[clap(long, env = "ENC_KEY_ACTIVE")]
+    pub enc_key_active: Option<String>,
+
+    /// Newline-separated encryption keys. Falls back to ENC_KEYS.
+    #[clap(long, env = "ENC_KEYS")]
+    pub enc_keys: Option<String>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ArgsBootstrapPurge {
+    /// Path to the encrypted generated-secret container.
+    #[clap(short, long, default_value = "data/bootstrap.secrets.enc")]
+    pub file: String,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum BootstrapOutputFormat {
+    Raw,
+    Json,
+    Env,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -43,6 +43,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 server::run(args.config_file, test_mode).await?
             }
         }
+        Args::Bootstrap(args) => utils::bootstrap::run(args).await?,
         Args::GenerateConfig(args) => utils::gen_config::generate(args).await?,
         Args::ValidateConfig(args) => utils::validate_config::validate(args).await?,
         Args::GenerateEncKey(args) => utils::gen_enc_keys::generate(args).await?,

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -83,9 +83,9 @@ pub async fn run(config_file: String, test_mode: bool) -> Result<(), Box<dyn Err
     }
 
     RauthyConfig::debug_logs();
-    rauthy_data::migration::bootstrap::purge_expired_generated_secrets()
-        .await
-        .expect("Error purging expired bootstrap generated-secret container");
+    if let Err(err) = rauthy_data::migration::bootstrap::purge_expired_generated_secrets().await {
+        warn!("Could not purge bootstrap generated-secret container: {err}");
+    }
 
     // init BEFORE Hiqlite to avoid issues in case of misconfiguration
     rauthy_data::ipgeo::init_geo().await;

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -83,6 +83,9 @@ pub async fn run(config_file: String, test_mode: bool) -> Result<(), Box<dyn Err
     }
 
     RauthyConfig::debug_logs();
+    rauthy_data::migration::bootstrap::purge_expired_generated_secrets()
+        .await
+        .expect("Error purging expired bootstrap generated-secret container");
 
     // init BEFORE Hiqlite to avoid issues in case of misconfiguration
     rauthy_data::ipgeo::init_geo().await;

--- a/src/bin/src/utils/bootstrap.rs
+++ b/src/bin/src/utils/bootstrap.rs
@@ -22,13 +22,14 @@ pub async fn run(args: ArgsBootstrap) -> Result<(), StdError> {
 /// Load the existing Rauthy config. This initializes `ENC_KEYS` (so the local
 /// container can be decrypted) and resolves the configured container path,
 /// exactly like the server does — no keys or file path are passed to the CLI.
-async fn load_config(config_file: String) -> Result<RauthyConfig, StdError> {
+async fn load_config(config_file: String) -> Result<&'static RauthyConfig, StdError> {
     let (tx_email, _) = mpsc::channel::<mailer::EMail>(16);
     let (tx_events, _) = flume::unbounded();
     let (tx_events_router, _) = flume::unbounded();
     let (config, _node) =
         RauthyConfig::build(config_file, tx_email, tx_events, tx_events_router).await?;
-    Ok(config)
+    config.init_static();
+    Ok(RauthyConfig::get())
 }
 
 async fn get(args: ArgsBootstrapGet) -> Result<(), StdError> {

--- a/src/bin/src/utils/bootstrap.rs
+++ b/src/bin/src/utils/bootstrap.rs
@@ -1,0 +1,248 @@
+use crate::cli_args::{
+    ArgsBootstrap, ArgsBootstrapCommand, ArgsBootstrapGet, ArgsBootstrapPurge,
+    BootstrapOutputFormat,
+};
+use crate::utils::StdError;
+use cryptr::EncKeys;
+use rauthy_data::migration::bootstrap::generated_secrets::{
+    GeneratedSecretEntry, GeneratedSecrets, read_container,
+};
+use std::env;
+use std::path::Path;
+
+pub async fn run(args: ArgsBootstrap) -> Result<(), StdError> {
+    match args.command {
+        ArgsBootstrapCommand::Get(args) => get(args).await,
+        ArgsBootstrapCommand::Purge(args) => purge(args).await,
+    }
+}
+
+async fn get(args: ArgsBootstrapGet) -> Result<(), StdError> {
+    init_enc_keys(args.enc_key_active.as_deref(), args.enc_keys.as_deref())?;
+
+    let container = read_container(&args.file)
+        .await
+        .map_err(|err| err.message)?;
+    let entries = filter_entries(container, &args);
+    if entries.is_empty() {
+        return Err(format!(
+            "no generated bootstrap secret matched kind={:?}, id={:?}, field={:?}",
+            args.kind, args.id, args.field
+        )
+        .into());
+    }
+
+    match args.format {
+        BootstrapOutputFormat::Raw => {
+            println!("{}", render_raw(&entries)?);
+            Ok(())
+        }
+        BootstrapOutputFormat::Json => {
+            println!("{}", render_json(&entries)?);
+            Ok(())
+        }
+        BootstrapOutputFormat::Env => {
+            print!("{}", render_env(&entries));
+            Ok(())
+        }
+    }
+}
+
+async fn purge(args: ArgsBootstrapPurge) -> Result<(), StdError> {
+    purge_path(Path::new(&args.file)).await
+}
+
+async fn purge_path(path: &Path) -> Result<(), StdError> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => {
+            eprintln!(
+                "deleted generated bootstrap secret container {}",
+                path.display()
+            );
+            Ok(())
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "generated bootstrap secret container {} was already absent",
+                path.display()
+            );
+            Ok(())
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn init_enc_keys(enc_key_active: Option<&str>, enc_keys: Option<&str>) -> Result<(), StdError> {
+    let Some(enc_key_active) = enc_key_active else {
+        return Err(missing_keys_error("ENC_KEY_ACTIVE"));
+    };
+    let Some(enc_keys) = enc_keys else {
+        return Err(missing_keys_error("ENC_KEYS"));
+    };
+    let enc_keys = enc_keys
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    if enc_keys.is_empty() {
+        return Err("ENC_KEYS did not contain any encryption keys".into());
+    }
+
+    EncKeys::try_parse(enc_key_active.to_string(), enc_keys)?.init()?;
+    Ok(())
+}
+
+fn missing_keys_error(name: &str) -> StdError {
+    let vault = env::var("USE_VAULT_CONFIG")
+        .unwrap_or_else(|_| "false".to_string())
+        .parse::<bool>()
+        .unwrap_or(false);
+    let prefix = if vault {
+        "USE_VAULT_CONFIG=true, but this offline command does not contact Vault. "
+    } else {
+        ""
+    };
+    format!(
+        "{prefix}missing {name}; pass --enc-key-active / --enc-keys or set \
+         ENC_KEY_ACTIVE / ENC_KEYS so the local bootstrap container can be decrypted"
+    )
+    .into()
+}
+
+fn filter_entries(
+    container: GeneratedSecrets,
+    args: &ArgsBootstrapGet,
+) -> Vec<GeneratedSecretEntry> {
+    container
+        .entries
+        .into_iter()
+        .filter(|entry| {
+            args.kind.as_ref().is_none_or(|kind| &entry.kind == kind)
+                && args.id.as_ref().is_none_or(|id| &entry.id == id)
+                && args
+                    .field
+                    .as_ref()
+                    .is_none_or(|field| &entry.field == field)
+        })
+        .collect()
+}
+
+fn render_raw(entries: &[GeneratedSecretEntry]) -> Result<String, StdError> {
+    if entries.len() != 1 {
+        return Err(format!(
+            "--format raw requires exactly one matched secret, got {}",
+            entries.len()
+        )
+        .into());
+    }
+    Ok(entries[0].value.clone())
+}
+
+fn render_json(entries: &[GeneratedSecretEntry]) -> Result<String, StdError> {
+    if entries.len() == 1 {
+        Ok(serde_json::to_string_pretty(&entries[0])?)
+    } else {
+        Ok(serde_json::to_string_pretty(entries)?)
+    }
+}
+
+fn render_env(entries: &[GeneratedSecretEntry]) -> String {
+    let mut out = String::new();
+    for entry in entries {
+        out.push_str(&format!("{}={}\n", entry.env_name(), entry.value));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(kind: &str, id: &str, field: &str, value: &str) -> GeneratedSecretEntry {
+        GeneratedSecretEntry {
+            kind: kind.to_string(),
+            id: id.to_string(),
+            field: field.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn filter_entries_matches_exact_selector_parts() {
+        let container = GeneratedSecrets {
+            entries: vec![
+                entry("client", "demo", "secret", "client-secret"),
+                entry("user", "demo", "password", "user-password"),
+            ],
+        };
+        let args = ArgsBootstrapGet {
+            file: "unused".to_string(),
+            format: BootstrapOutputFormat::Env,
+            kind: Some("client".to_string()),
+            id: Some("demo".to_string()),
+            field: Some("secret".to_string()),
+            enc_key_active: None,
+            enc_keys: None,
+        };
+
+        let filtered = filter_entries(container, &args);
+        assert_eq!(
+            filtered,
+            vec![entry("client", "demo", "secret", "client-secret")]
+        );
+    }
+
+    #[test]
+    fn env_names_include_kind_id_and_field() {
+        let e = entry("user", "can@example.com", "password", "pw");
+        assert_eq!(
+            e.env_name(),
+            "RAUTHY_BOOTSTRAP_USER_CAN_EXAMPLE_COM_PASSWORD"
+        );
+    }
+
+    #[test]
+    fn raw_output_is_only_the_secret_value() {
+        let entries = vec![entry("client", "demo", "secret", "client-secret")];
+        assert_eq!(render_raw(&entries).unwrap(), "client-secret");
+    }
+
+    #[test]
+    fn json_output_preserves_entry_fields() {
+        let entries = vec![entry("user", "can@example.com", "password", "pw")];
+        let value =
+            serde_json::from_str::<serde_json::Value>(&render_json(&entries).unwrap()).unwrap();
+
+        assert_eq!(value["kind"], "user");
+        assert_eq!(value["id"], "can@example.com");
+        assert_eq!(value["field"], "password");
+        assert_eq!(value["value"], "pw");
+    }
+
+    #[test]
+    fn env_output_uses_collision_safe_names() {
+        let entries = vec![
+            entry("client", "demo", "secret", "client-secret"),
+            entry("user", "demo", "password", "user-password"),
+        ];
+
+        assert_eq!(
+            render_env(&entries),
+            "RAUTHY_BOOTSTRAP_CLIENT_DEMO_SECRET=client-secret\n\
+             RAUTHY_BOOTSTRAP_USER_DEMO_PASSWORD=user-password\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn purge_is_idempotent() {
+        let path =
+            std::env::temp_dir().join(format!("rauthy-bootstrap-cli-purge-{}", std::process::id()));
+        tokio::fs::write(&path, b"secret container").await.unwrap();
+
+        purge_path(&path).await.unwrap();
+        purge_path(&path).await.unwrap();
+
+        assert!(!path.exists());
+    }
+}

--- a/src/bin/src/utils/bootstrap.rs
+++ b/src/bin/src/utils/bootstrap.rs
@@ -3,12 +3,14 @@ use crate::cli_args::{
     BootstrapOutputFormat,
 };
 use crate::utils::StdError;
-use cryptr::EncKeys;
+use rauthy_data::email::mailer;
 use rauthy_data::migration::bootstrap::generated_secrets::{
     GeneratedSecretEntry, GeneratedSecrets, read_container,
 };
-use std::env;
+use rauthy_data::rauthy_config::RauthyConfig;
+use std::fmt::Write as _;
 use std::path::Path;
+use tokio::sync::mpsc;
 
 pub async fn run(args: ArgsBootstrap) -> Result<(), StdError> {
     match args.command {
@@ -17,10 +19,23 @@ pub async fn run(args: ArgsBootstrap) -> Result<(), StdError> {
     }
 }
 
-async fn get(args: ArgsBootstrapGet) -> Result<(), StdError> {
-    init_enc_keys(args.enc_key_active.as_deref(), args.enc_keys.as_deref())?;
+/// Load the existing Rauthy config. This initializes `ENC_KEYS` (so the local
+/// container can be decrypted) and resolves the configured container path,
+/// exactly like the server does — no keys or file path are passed to the CLI.
+async fn load_config(config_file: String) -> Result<RauthyConfig, StdError> {
+    let (tx_email, _) = mpsc::channel::<mailer::EMail>(16);
+    let (tx_events, _) = flume::unbounded();
+    let (tx_events_router, _) = flume::unbounded();
+    let (config, _node) =
+        RauthyConfig::build(config_file, tx_email, tx_events, tx_events_router).await?;
+    Ok(config)
+}
 
-    let container = read_container(&args.file)
+async fn get(args: ArgsBootstrapGet) -> Result<(), StdError> {
+    let config = load_config(args.config_file.clone()).await?;
+    let path = config.vars.bootstrap.generated_secrets_file.clone();
+
+    let container = read_container(path.as_ref())
         .await
         .map_err(|err| err.message)?;
     let entries = filter_entries(container, &args);
@@ -49,7 +64,9 @@ async fn get(args: ArgsBootstrapGet) -> Result<(), StdError> {
 }
 
 async fn purge(args: ArgsBootstrapPurge) -> Result<(), StdError> {
-    purge_path(Path::new(&args.file)).await
+    let config = load_config(args.config_file).await?;
+    let path = config.vars.bootstrap.generated_secrets_file.clone();
+    purge_path(Path::new(path.as_ref())).await
 }
 
 async fn purge_path(path: &Path) -> Result<(), StdError> {
@@ -70,44 +87,6 @@ async fn purge_path(path: &Path) -> Result<(), StdError> {
         }
         Err(err) => Err(err.into()),
     }
-}
-
-fn init_enc_keys(enc_key_active: Option<&str>, enc_keys: Option<&str>) -> Result<(), StdError> {
-    let Some(enc_key_active) = enc_key_active else {
-        return Err(missing_keys_error("ENC_KEY_ACTIVE"));
-    };
-    let Some(enc_keys) = enc_keys else {
-        return Err(missing_keys_error("ENC_KEYS"));
-    };
-    let enc_keys = enc_keys
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(ToString::to_string)
-        .collect::<Vec<_>>();
-    if enc_keys.is_empty() {
-        return Err("ENC_KEYS did not contain any encryption keys".into());
-    }
-
-    EncKeys::try_parse(enc_key_active.to_string(), enc_keys)?.init()?;
-    Ok(())
-}
-
-fn missing_keys_error(name: &str) -> StdError {
-    let vault = env::var("USE_VAULT_CONFIG")
-        .unwrap_or_else(|_| "false".to_string())
-        .parse::<bool>()
-        .unwrap_or(false);
-    let prefix = if vault {
-        "USE_VAULT_CONFIG=true, but this offline command does not contact Vault. "
-    } else {
-        ""
-    };
-    format!(
-        "{prefix}missing {name}; pass --enc-key-active / --enc-keys or set \
-         ENC_KEY_ACTIVE / ENC_KEYS so the local bootstrap container can be decrypted"
-    )
-    .into()
 }
 
 fn filter_entries(
@@ -150,7 +129,8 @@ fn render_json(entries: &[GeneratedSecretEntry]) -> Result<String, StdError> {
 fn render_env(entries: &[GeneratedSecretEntry]) -> String {
     let mut out = String::new();
     for entry in entries {
-        out.push_str(&format!("{}={}\n", entry.env_name(), entry.value));
+        // write! into the buffer avoids the extra String allocation format! does.
+        let _ = writeln!(out, "{}={}", entry.env_name(), entry.value);
     }
     out
 }
@@ -177,13 +157,11 @@ mod tests {
             ],
         };
         let args = ArgsBootstrapGet {
-            file: "unused".to_string(),
+            config_file: "unused".to_string(),
             format: BootstrapOutputFormat::Env,
             kind: Some("client".to_string()),
             id: Some("demo".to_string()),
             field: Some("secret".to_string()),
-            enc_key_active: None,
-            enc_keys: None,
         };
 
         let filtered = filter_entries(container, &args);

--- a/src/bin/src/utils/mod.rs
+++ b/src/bin/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod bootstrap;
 pub mod gen_config;
 pub mod gen_enc_keys;
 pub mod gen_secrets;

--- a/src/data/src/migration/bootstrap/api_key.rs
+++ b/src/data/src/migration/bootstrap/api_key.rs
@@ -1,9 +1,11 @@
 use crate::database::DB;
 use crate::entity::api_keys::ApiKeyEntity;
 use crate::migration::bootstrap::bootstrap_data;
+use crate::migration::bootstrap::generated_secrets::{GeneratedSecretEntry, GeneratedSecretKey};
 use crate::migration::bootstrap::types::{ApiKey as BootstrapApiKey, ApiKeySecret};
 use crate::rauthy_config::RauthyConfig;
 use cryptr::EncValue;
+use cryptr::utils::secure_random_alnum;
 use hiqlite::macros::params;
 use rauthy_api_types::api_keys::ApiKeyRequest;
 use rauthy_common::constants::API_KEY_LENGTH;
@@ -67,7 +69,7 @@ async fn bootstrap_api_keys_json() -> Result<(), ErrorResponse> {
         .await?;
         generated_secret.zeroize();
 
-        let mut secret_plain = api_key_secret_plain(api_key.secret);
+        let mut secret_plain = api_key_secret_plain(api_key.secret, &key_name).await?;
         set_api_key_secret(&key_name, &secret_plain).await?;
         secret_plain.zeroize();
     }
@@ -99,9 +101,12 @@ async fn set_api_key_secret(name: &str, secret_plain: &str) -> Result<(), ErrorR
     Ok(())
 }
 
-fn api_key_secret_plain(secret: ApiKeySecret) -> String {
+async fn api_key_secret_plain(
+    secret: ApiKeySecret,
+    key_name: &str,
+) -> Result<String, ErrorResponse> {
     match secret {
-        ApiKeySecret::Plain(s) => s,
+        ApiKeySecret::Plain(s) => Ok(s),
         ApiKeySecret::Encrypted(enc) => {
             let bytes = base64_decode(&enc)
                 .expect("Cannot decode base64 encoded, encrypted API Key secret");
@@ -109,8 +114,26 @@ fn api_key_secret_plain(secret: ApiKeySecret) -> String {
                 .expect("Invalid format for encrypted API Key secret")
                 .decrypt()
                 .expect("Failed to decrypt encrypted API Key secret. Make sure Rauthy has access to the used ENC_KEY");
-            String::from_utf8(dec.to_vec())
-                .expect("Invalid characters in API Key secret. Cannot convert to lossless String.")
+            Ok(String::from_utf8(dec.to_vec())
+                .expect("Invalid characters in API Key secret. Cannot convert to lossless String."))
+        }
+        ApiKeySecret::Generate => {
+            let mut plain = secure_random_alnum(API_KEY_LENGTH);
+            let bootstrap = &RauthyConfig::get().vars.bootstrap;
+            if let Err(err) = crate::migration::bootstrap::generated_secrets::upsert_secret(
+                bootstrap.generated_secrets_file.as_ref(),
+                bootstrap.generated_secrets_ttl,
+                GeneratedSecretEntry::new(
+                    GeneratedSecretKey::new("api-key", key_name, "secret"),
+                    plain.clone(),
+                ),
+            )
+            .await
+            {
+                plain.zeroize();
+                return Err(err);
+            }
+            Ok(plain)
         }
     }
 }

--- a/src/data/src/migration/bootstrap/clients.rs
+++ b/src/data/src/migration/bootstrap/clients.rs
@@ -2,7 +2,10 @@ use crate::database::DB;
 use crate::entity::clients_scim::ClientScim;
 use crate::entity::scopes::Scope;
 use crate::migration::bootstrap::bootstrap_data;
+use crate::migration::bootstrap::generated_secrets::{GeneratedSecretEntry, GeneratedSecretKey};
 use crate::migration::bootstrap::types::{Client, ClientSecret};
+use crate::rauthy_config::RauthyConfig;
+use cryptr::utils::secure_random_alnum;
 use cryptr::{EncKeys, EncValue};
 use hiqlite::macros::params;
 use itertools::Itertools;
@@ -11,6 +14,7 @@ use rauthy_common::is_hiqlite;
 use rauthy_common::utils::base64_decode;
 use rauthy_error::ErrorResponse;
 use tracing::info;
+use zeroize::Zeroize;
 
 pub async fn bootstrap() -> Result<(), ErrorResponse> {
     let clients = bootstrap_data!(Client, "clients");
@@ -32,7 +36,7 @@ $18, $19, $20, $21, $22)"#;
 
     for client in clients {
         let (kid, secret) = if let Some(secret) = client.secret {
-            let plain = match secret {
+            let mut plain = match secret {
                 ClientSecret::Plain(s) => s,
                 ClientSecret::Encrypted(enc) => {
                     // make sure we can decrypt it
@@ -46,6 +50,24 @@ $18, $19, $20, $21, $22)"#;
                         "Invalid characters in client secret. Cannot convert to lossless String.",
                     )
                 }
+                ClientSecret::Generate => {
+                    let mut plain = secure_random_alnum(SECRET_LEN_CLIENTS);
+                    let bootstrap = &RauthyConfig::get().vars.bootstrap;
+                    if let Err(err) = crate::migration::bootstrap::generated_secrets::upsert_secret(
+                        bootstrap.generated_secrets_file.as_ref(),
+                        bootstrap.generated_secrets_ttl,
+                        GeneratedSecretEntry::new(
+                            GeneratedSecretKey::new("client", &client.id, "secret"),
+                            plain.clone(),
+                        ),
+                    )
+                    .await
+                    {
+                        plain.zeroize();
+                        return Err(err);
+                    }
+                    plain
+                }
             };
 
             if plain.len() < SECRET_LEN_CLIENTS {
@@ -58,6 +80,7 @@ $18, $19, $20, $21, $22)"#;
             let enc = EncValue::encrypt_with_key_id(plain.as_ref(), kid.clone())?
                 .into_bytes()
                 .to_vec();
+            plain.zeroize();
 
             (Some(kid), Some(enc))
         } else {

--- a/src/data/src/migration/bootstrap/generated_secrets.rs
+++ b/src/data/src/migration/bootstrap/generated_secrets.rs
@@ -1,20 +1,16 @@
 use cryptr::EncValue;
-use rauthy_error::{ErrorResponse, ErrorResponseType};
+use rauthy_error::ErrorResponse;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
-use std::fs::OpenOptions;
-use std::io::Write;
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
 use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 use zeroize::Zeroize;
 
-const MAGIC: &str = "RAUTHY_BOOTSTRAP_GENERATED_SECRETS";
 const VERSION: u16 = 1;
-const HEADER_LINES: usize = 3;
 const DEFAULT_FILE_NAME: &str = "bootstrap.secrets.enc";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -93,17 +89,26 @@ impl GeneratedSecrets {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ContainerHeader {
-    pub version: u16,
-    /// Unix timestamp in seconds. `0` means the container does not expire.
-    pub deadline: u64,
+/// On-disk container payload. The whole struct is encrypted as a single
+/// `cryptr` AEAD value, so its integrity is guaranteed by decryption itself —
+/// no separate magic/version header on disk is needed. The expiry `deadline`
+/// lives inside the encrypted payload; the server (and the CLI) hold `ENC_KEYS`,
+/// so reading it back to check expiry is a cheap decrypt.
+#[derive(Serialize)]
+struct ContainerPayloadRef<'a> {
+    version: u16,
+    /// UTC unix timestamp in seconds. `0` means the container does not expire.
+    deadline: i64,
+    entries: &'a [GeneratedSecretEntry],
 }
 
-impl ContainerHeader {
-    pub fn is_expired_at(self, now: SystemTime) -> bool {
-        self.deadline > 0 && unix_seconds(now) >= self.deadline
-    }
+#[derive(Deserialize)]
+struct ContainerPayload {
+    #[serde(default)]
+    version: u16,
+    #[serde(default)]
+    deadline: i64,
+    entries: Vec<GeneratedSecretEntry>,
 }
 
 pub fn default_file_path(data_dir: &str) -> String {
@@ -113,11 +118,22 @@ pub fn default_file_path(data_dir: &str) -> String {
         .into_owned()
 }
 
-pub fn deadline_from_ttl(ttl_seconds: u64, now: SystemTime) -> u64 {
+/// Current UTC unix timestamp in seconds. Always work in UTC for stored
+/// timestamps so a shared volume mounted on multiple hosts compares the same
+/// instant regardless of local time zone.
+fn now_utc() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+fn is_expired(deadline: i64, now: i64) -> bool {
+    deadline > 0 && now >= deadline
+}
+
+pub fn deadline_from_ttl(ttl_seconds: u64, now: i64) -> i64 {
     if ttl_seconds == 0 {
         0
     } else {
-        unix_seconds(now) + ttl_seconds
+        now.saturating_add(ttl_seconds as i64)
     }
 }
 
@@ -127,60 +143,61 @@ pub async fn upsert_secret(
     entry: GeneratedSecretEntry,
 ) -> Result<(), ErrorResponse> {
     let path = path.as_ref();
-    let mut container = if path.exists() {
+    let mut container = if tokio::fs::try_exists(path).await.unwrap_or(false) {
         read_container(path).await?
     } else {
         GeneratedSecrets::default()
     };
     container.upsert(entry);
-    let deadline = deadline_from_ttl(ttl_seconds, SystemTime::now());
+    let deadline = deadline_from_ttl(ttl_seconds, now_utc());
     write_container(path, deadline, &container).await?;
     schedule_purge(path.to_path_buf(), ttl_seconds);
     Ok(())
 }
 
 pub async fn read_container(path: impl AsRef<Path>) -> Result<GeneratedSecrets, ErrorResponse> {
-    let bytes = tokio::fs::read(path.as_ref()).await?;
-    let (header, encrypted) = parse_header(&bytes)?;
-    if header.is_expired_at(SystemTime::now()) {
-        return Err(internal(format!(
+    let path = path.as_ref();
+    let bytes = tokio::fs::read(path).await?;
+    let payload = decrypt_container(bytes, path)?;
+    if is_expired(payload.deadline, now_utc()) {
+        return Err(ErrorResponse::internal(format!(
             "bootstrap generated-secret container {} expired at {}",
-            path.as_ref().display(),
-            header.deadline
+            path.display(),
+            payload.deadline
         )));
     }
-
-    let mut decrypted = EncValue::try_from(encrypted.to_vec())?.decrypt()?.to_vec();
-    let container = serde_json::from_slice(&decrypted);
-    decrypted.zeroize();
-    Ok(container?)
+    Ok(GeneratedSecrets {
+        entries: payload.entries,
+    })
 }
 
 pub async fn write_container(
     path: impl AsRef<Path>,
-    deadline: u64,
+    deadline: i64,
     container: &GeneratedSecrets,
 ) -> Result<(), ErrorResponse> {
     let path = path.as_ref();
     let parent = path.parent().ok_or_else(|| {
-        internal(format!(
+        ErrorResponse::internal(format!(
             "bootstrap generated-secret path '{}' has no parent directory",
             path.display()
         ))
     })?;
     tokio::fs::create_dir_all(parent).await?;
 
-    let mut payload = serde_json::to_vec(container)?;
+    let mut payload = serde_json::to_vec(&ContainerPayloadRef {
+        version: VERSION,
+        deadline,
+        entries: &container.entries,
+    })?;
     let encrypted = match EncValue::encrypt(&payload) {
-        Ok(value) => value.into_bytes().to_vec(),
+        Ok(value) => value.into_bytes(),
         Err(err) => {
             payload.zeroize();
             return Err(err.into());
         }
     };
     payload.zeroize();
-    let mut bytes = render_header(deadline);
-    bytes.extend_from_slice(&encrypted);
 
     let tmp = tmp_path(path)?;
     {
@@ -188,21 +205,11 @@ pub async fn write_container(
         options.write(true).create_new(true);
         #[cfg(unix)]
         options.mode(0o600);
-        let mut file = options.open(&tmp)?;
-        file.write_all(&bytes)?;
-        file.sync_all()?;
+        let mut file = options.open(&tmp).await?;
+        file.write_all(&encrypted).await?;
+        file.sync_all().await?;
     }
-    bytes.zeroize();
-    std::fs::rename(&tmp, path)?;
-
-    if let Ok(dir) = std::fs::File::open(parent)
-        && let Err(err) = dir.sync_all()
-    {
-        debug!(
-            "Could not fsync bootstrap generated-secret directory '{}': {err}",
-            parent.display()
-        );
-    }
+    tokio::fs::rename(&tmp, path).await?;
 
     Ok(())
 }
@@ -214,8 +221,8 @@ pub async fn purge_if_expired(path: impl AsRef<Path>) -> Result<bool, ErrorRespo
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(err) => return Err(err.into()),
     };
-    let (header, _) = parse_header(&bytes)?;
-    if header.is_expired_at(SystemTime::now()) {
+    let payload = decrypt_container(bytes, path)?;
+    if is_expired(payload.deadline, now_utc()) {
         tokio::fs::remove_file(path).await?;
         info!(
             "Purged expired bootstrap generated-secret container '{}'",
@@ -243,27 +250,25 @@ pub fn schedule_purge(path: PathBuf, ttl_seconds: u64) {
     });
 }
 
-pub fn parse_header(bytes: &[u8]) -> Result<(ContainerHeader, &[u8]), ErrorResponse> {
-    let mut lines = bytes.splitn(HEADER_LINES + 1, |b| *b == b'\n');
-    let magic = lines
-        .next()
-        .ok_or_else(|| internal("missing bootstrap generated-secret magic"))?;
-    if magic != MAGIC.as_bytes() {
-        return Err(internal("invalid bootstrap generated-secret magic"));
-    }
-
-    let version = parse_header_u16(lines.next(), "version")?;
-    if version != VERSION {
-        return Err(internal(format!(
-            "unsupported bootstrap generated-secret version {version}"
+fn decrypt_container(bytes: Vec<u8>, path: &Path) -> Result<ContainerPayload, ErrorResponse> {
+    if bytes.is_empty() {
+        return Err(ErrorResponse::internal(format!(
+            "bootstrap generated-secret container {} is empty",
+            path.display()
         )));
     }
-
-    let deadline = parse_header_u64(lines.next(), "deadline")?;
-    let encrypted = lines
-        .next()
-        .ok_or_else(|| internal("missing bootstrap generated-secret payload"))?;
-    Ok((ContainerHeader { version, deadline }, encrypted))
+    // cryptr uses AEAD (ChaCha20Poly1305): a malformed or tampered file fails to
+    // decrypt, which is the integrity check. No manual magic/version on disk.
+    let decrypted = EncValue::try_from(bytes)?.decrypt()?;
+    let payload: ContainerPayload = serde_json::from_slice(&decrypted)?;
+    if payload.version > VERSION {
+        return Err(ErrorResponse::internal(format!(
+            "unsupported bootstrap generated-secret container version {} in {}",
+            payload.version,
+            path.display()
+        )));
+    }
+    Ok(payload)
 }
 
 pub fn sanitize_env_name(input: impl AsRef<str>) -> String {
@@ -296,52 +301,16 @@ pub fn sanitize_env_name(input: impl AsRef<str>) -> String {
     }
 }
 
-fn render_header(deadline: u64) -> Vec<u8> {
-    format!("{MAGIC}\n{VERSION}\n{deadline}\n").into_bytes()
-}
-
-fn parse_header_u16(line: Option<&[u8]>, name: &str) -> Result<u16, ErrorResponse> {
-    let raw = parse_header_line(line, name)?;
-    raw.parse::<u16>()
-        .map_err(|_| internal(format!("invalid bootstrap generated-secret {name}")))
-}
-
-fn parse_header_u64(line: Option<&[u8]>, name: &str) -> Result<u64, ErrorResponse> {
-    let raw = parse_header_line(line, name)?;
-    raw.parse::<u64>()
-        .map_err(|_| internal(format!("invalid bootstrap generated-secret {name}")))
-}
-
-fn parse_header_line<'a>(line: Option<&'a [u8]>, name: &str) -> Result<&'a str, ErrorResponse> {
-    let line =
-        line.ok_or_else(|| internal(format!("missing bootstrap generated-secret {name}")))?;
-    std::str::from_utf8(line).map_err(|_| {
-        internal(format!(
-            "invalid utf-8 in bootstrap generated-secret {name}"
-        ))
-    })
-}
-
 fn tmp_path(path: &Path) -> Result<PathBuf, ErrorResponse> {
     let file_name = path.file_name().and_then(OsStr::to_str).ok_or_else(|| {
-        internal(format!(
+        ErrorResponse::internal(format!(
             "invalid generated-secret path '{}'",
             path.display()
         ))
     })?;
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    Ok(path.with_file_name(format!(".{file_name}.{}.{nanos}.tmp", std::process::id())))
-}
-
-fn unix_seconds(now: SystemTime) -> u64 {
-    now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
-}
-
-fn internal(msg: impl Into<String>) -> ErrorResponse {
-    ErrorResponse::new(ErrorResponseType::Internal, msg.into())
+    // Editor-style sibling temp file. Only one Rauthy process runs and
+    // bootstrapping is single-threaded, so no pid/timestamp uniqueness is needed.
+    Ok(path.with_file_name(format!("{file_name}~")))
 }
 
 #[cfg(test)]
@@ -395,38 +364,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bad_magic_fails_before_decrypt() {
+    async fn garbage_file_fails_to_decrypt() {
         init_keys();
-        let path = test_path("bad-magic");
-        tokio::fs::write(&path, b"wrong\n1\n0\npayload")
+        let path = test_path("garbage");
+        tokio::fs::write(&path, b"not-a-valid-enc-container")
             .await
             .unwrap();
 
         let err = read_container(&path).await.unwrap_err();
-        assert!(err.message.contains("magic"));
+        assert!(!err.message.is_empty());
 
         let _ = tokio::fs::remove_file(&path).await;
     }
 
-    #[test]
-    fn bad_version_fails_before_decrypt() {
-        let mut bytes = b"RAUTHY_BOOTSTRAP_GENERATED_SECRETS\n2\n0\n".to_vec();
-        bytes.extend_from_slice(b"payload");
-
-        let err = parse_header(&bytes).unwrap_err();
-        assert!(err.message.contains("version"));
-    }
-
     #[tokio::test]
-    async fn expired_header_fails_without_decrypting_payload() {
+    async fn expired_container_is_rejected() {
         init_keys();
         let path = test_path("expired");
-        tokio::fs::write(
-            &path,
-            b"RAUTHY_BOOTSTRAP_GENERATED_SECRETS\n1\n1\nnot-encrypted",
-        )
-        .await
-        .unwrap();
+        let _ = tokio::fs::remove_file(&path).await;
+
+        let mut container = GeneratedSecrets::default();
+        container.upsert(GeneratedSecretEntry::new(
+            GeneratedSecretKey::new("client", "demo", "secret"),
+            "s",
+        ));
+        write_container(&path, now_utc() - 10, &container)
+            .await
+            .unwrap();
 
         let err = read_container(&path).await.unwrap_err();
         assert!(err.message.contains("expired"));
@@ -435,14 +399,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn purge_removes_expired_file_without_decrypting_payload() {
+    async fn purge_removes_expired_file() {
+        init_keys();
         let path = test_path("purge");
-        tokio::fs::write(
-            &path,
-            b"RAUTHY_BOOTSTRAP_GENERATED_SECRETS\n1\n1\nnot-encrypted",
-        )
-        .await
-        .unwrap();
+        let _ = tokio::fs::remove_file(&path).await;
+
+        let mut container = GeneratedSecrets::default();
+        container.upsert(GeneratedSecretEntry::new(
+            GeneratedSecretKey::new("user", "can", "password"),
+            "pw",
+        ));
+        write_container(&path, now_utc() - 10, &container)
+            .await
+            .unwrap();
 
         assert!(purge_if_expired(&path).await.unwrap());
         assert!(!path.exists());
@@ -461,11 +430,10 @@ mod tests {
         )
         .await
         .unwrap();
-        let bytes = tokio::fs::read(&path).await.unwrap();
-        let (header, _) = parse_header(&bytes).unwrap();
 
-        assert_eq!(header.deadline, 0);
-        assert!(!header.is_expired_at(SystemTime::now() + Duration::from_secs(3600)));
+        let container = read_container(&path).await.unwrap();
+        assert_eq!(container.entries.len(), 1);
+        assert!(!purge_if_expired(&path).await.unwrap());
 
         let _ = tokio::fs::remove_file(&path).await;
     }

--- a/src/data/src/migration/bootstrap/generated_secrets.rs
+++ b/src/data/src/migration/bootstrap/generated_secrets.rs
@@ -131,17 +131,17 @@ fn is_expired(deadline: i64, now: i64) -> bool {
     deadline > 0 && now >= deadline
 }
 
-pub fn deadline_from_ttl(ttl_seconds: u64, now: i64) -> i64 {
+pub fn deadline_from_ttl(ttl_seconds: u32, now: i64) -> i64 {
     if ttl_seconds == 0 {
         0
     } else {
-        now.saturating_add(ttl_seconds as i64)
+        now.saturating_add(i64::from(ttl_seconds))
     }
 }
 
 pub async fn upsert_secret(
     path: impl AsRef<Path>,
-    ttl_seconds: u64,
+    ttl_seconds: u32,
     entry: GeneratedSecretEntry,
 ) -> Result<(), ErrorResponse> {
     let path = path.as_ref();
@@ -256,13 +256,13 @@ pub async fn purge_if_expired(path: impl AsRef<Path>) -> Result<bool, ErrorRespo
     }
 }
 
-pub fn schedule_purge(path: PathBuf, ttl_seconds: u64) {
+pub fn schedule_purge(path: PathBuf, ttl_seconds: u32) {
     if ttl_seconds == 0 {
         return;
     }
 
     tokio::spawn(async move {
-        sleep(Duration::from_secs(ttl_seconds)).await;
+        sleep(Duration::from_secs(u64::from(ttl_seconds))).await;
         if let Err(err) = purge_if_expired(&path).await {
             error!(
                 "Could not purge bootstrap generated-secret container '{}': {err}",

--- a/src/data/src/migration/bootstrap/generated_secrets.rs
+++ b/src/data/src/migration/bootstrap/generated_secrets.rs
@@ -2,12 +2,14 @@ use cryptr::EncValue;
 use rauthy_error::ErrorResponse;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::time::sleep;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use zeroize::Zeroize;
 
 const VERSION: u16 = 1;
@@ -144,7 +146,16 @@ pub async fn upsert_secret(
 ) -> Result<(), ErrorResponse> {
     let path = path.as_ref();
     let mut container = if tokio::fs::try_exists(path).await.unwrap_or(false) {
-        read_container(path).await?
+        match read_container(path).await {
+            Ok(container) => container,
+            Err(err) => {
+                warn!(
+                    "Could not read existing bootstrap generated-secret container '{}': {err}; starting with a fresh container",
+                    path.display()
+                );
+                GeneratedSecrets::default()
+            }
+        }
     } else {
         GeneratedSecrets::default()
     };
@@ -157,7 +168,16 @@ pub async fn upsert_secret(
 
 pub async fn read_container(path: impl AsRef<Path>) -> Result<GeneratedSecrets, ErrorResponse> {
     let path = path.as_ref();
-    let bytes = tokio::fs::read(path).await?;
+    let bytes = match tokio::fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ErrorResponse::internal(format!(
+                "no generated bootstrap secrets stored at {}",
+                path.display()
+            )));
+        }
+        Err(err) => return Err(err.into()),
+    };
     let payload = decrypt_container(bytes, path)?;
     if is_expired(payload.deadline, now_utc()) {
         return Err(ErrorResponse::internal(format!(
@@ -202,13 +222,15 @@ pub async fn write_container(
     let tmp = tmp_path(path)?;
     {
         let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
+        options.write(true).create(true).truncate(true);
         #[cfg(unix)]
         options.mode(0o600);
         let mut file = options.open(&tmp).await?;
         file.write_all(&encrypted).await?;
         file.sync_all().await?;
     }
+    #[cfg(unix)]
+    tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await?;
     tokio::fs::rename(&tmp, path).await?;
 
     Ok(())
@@ -260,7 +282,18 @@ fn decrypt_container(bytes: Vec<u8>, path: &Path) -> Result<ContainerPayload, Er
     // cryptr uses AEAD (ChaCha20Poly1305): a malformed or tampered file fails to
     // decrypt, which is the integrity check. No manual magic/version on disk.
     let decrypted = EncValue::try_from(bytes)?.decrypt()?;
-    let payload: ContainerPayload = serde_json::from_slice(&decrypted)?;
+    let payload: ContainerPayload = match serde_json::from_slice(&decrypted) {
+        Ok(payload) => payload,
+        Err(err) => {
+            if let Ok(mut decrypted) = decrypted.try_into_mut() {
+                decrypted.as_mut().zeroize();
+            }
+            return Err(err.into());
+        }
+    };
+    if let Ok(mut decrypted) = decrypted.try_into_mut() {
+        decrypted.as_mut().zeroize();
+    }
     if payload.version > VERSION {
         return Err(ErrorResponse::internal(format!(
             "unsupported bootstrap generated-secret container version {} in {}",
@@ -373,6 +406,72 @@ mod tests {
 
         let err = read_container(&path).await.unwrap_err();
         assert!(!err.message.is_empty());
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn missing_container_error_names_path() {
+        init_keys();
+        let path = test_path("missing");
+        let _ = tokio::fs::remove_file(&path).await;
+
+        let err = read_container(&path).await.unwrap_err();
+
+        assert!(
+            err.message
+                .contains("no generated bootstrap secrets stored at")
+        );
+        assert!(err.message.contains(path.to_str().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn upsert_recovers_from_unreadable_existing_container() {
+        init_keys();
+        let path = test_path("recover-garbage");
+        tokio::fs::write(&path, b"not-a-valid-enc-container")
+            .await
+            .unwrap();
+
+        upsert_secret(
+            &path,
+            0,
+            GeneratedSecretEntry::new(
+                GeneratedSecretKey::new("client", "demo-app", "secret"),
+                "generated-secret",
+            ),
+        )
+        .await
+        .unwrap();
+
+        let container = read_container(&path).await.unwrap();
+        assert_eq!(container.entries.len(), 1);
+        assert_eq!(container.entries[0].value, "generated-secret");
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn write_container_overwrites_stale_temp_file() {
+        init_keys();
+        let path = test_path("stale-temp");
+        let tmp = tmp_path(&path).unwrap();
+        let _ = tokio::fs::remove_file(&path).await;
+        tokio::fs::write(&tmp, b"stale partial write")
+            .await
+            .unwrap();
+
+        let mut container = GeneratedSecrets::default();
+        container.upsert(GeneratedSecretEntry::new(
+            GeneratedSecretKey::new("user", "can", "password"),
+            "pw",
+        ));
+        write_container(&path, 0, &container).await.unwrap();
+
+        let container = read_container(&path).await.unwrap();
+        assert_eq!(container.entries.len(), 1);
+        assert_eq!(container.entries[0].value, "pw");
+        assert!(!tmp.exists());
 
         let _ = tokio::fs::remove_file(&path).await;
     }

--- a/src/data/src/migration/bootstrap/generated_secrets.rs
+++ b/src/data/src/migration/bootstrap/generated_secrets.rs
@@ -1,0 +1,482 @@
+use cryptr::EncValue;
+use rauthy_error::{ErrorResponse, ErrorResponseType};
+use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
+use std::fs::OpenOptions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::time::sleep;
+use tracing::{debug, error, info};
+use zeroize::Zeroize;
+
+const MAGIC: &str = "RAUTHY_BOOTSTRAP_GENERATED_SECRETS";
+const VERSION: u16 = 1;
+const HEADER_LINES: usize = 3;
+const DEFAULT_FILE_NAME: &str = "bootstrap.secrets.enc";
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct GeneratedSecretKey {
+    pub kind: String,
+    pub id: String,
+    pub field: String,
+}
+
+impl GeneratedSecretKey {
+    pub fn new(kind: impl Into<String>, id: impl Into<String>, field: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            id: id.into(),
+            field: field.into(),
+        }
+    }
+
+    pub fn env_name(&self) -> String {
+        sanitize_env_name(format!(
+            "RAUTHY_BOOTSTRAP_{}_{}_{}",
+            self.kind, self.id, self.field
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GeneratedSecretEntry {
+    pub kind: String,
+    pub id: String,
+    pub field: String,
+    pub value: String,
+}
+
+impl GeneratedSecretEntry {
+    pub fn new(key: GeneratedSecretKey, value: impl Into<String>) -> GeneratedSecretEntry {
+        Self {
+            kind: key.kind,
+            id: key.id,
+            field: key.field,
+            value: value.into(),
+        }
+    }
+
+    pub fn key(&self) -> GeneratedSecretKey {
+        GeneratedSecretKey {
+            kind: self.kind.clone(),
+            id: self.id.clone(),
+            field: self.field.clone(),
+        }
+    }
+
+    pub fn env_name(&self) -> String {
+        self.key().env_name()
+    }
+}
+
+impl Drop for GeneratedSecretEntry {
+    fn drop(&mut self) {
+        self.value.zeroize();
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct GeneratedSecrets {
+    pub entries: Vec<GeneratedSecretEntry>,
+}
+
+impl GeneratedSecrets {
+    fn upsert(&mut self, entry: GeneratedSecretEntry) {
+        if let Some(existing) = self.entries.iter_mut().find(|e| e.key() == entry.key()) {
+            *existing = entry;
+        } else {
+            self.entries.push(entry);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContainerHeader {
+    pub version: u16,
+    /// Unix timestamp in seconds. `0` means the container does not expire.
+    pub deadline: u64,
+}
+
+impl ContainerHeader {
+    pub fn is_expired_at(self, now: SystemTime) -> bool {
+        self.deadline > 0 && unix_seconds(now) >= self.deadline
+    }
+}
+
+pub fn default_file_path(data_dir: &str) -> String {
+    Path::new(data_dir)
+        .join(DEFAULT_FILE_NAME)
+        .to_string_lossy()
+        .into_owned()
+}
+
+pub fn deadline_from_ttl(ttl_seconds: u64, now: SystemTime) -> u64 {
+    if ttl_seconds == 0 {
+        0
+    } else {
+        unix_seconds(now) + ttl_seconds
+    }
+}
+
+pub async fn upsert_secret(
+    path: impl AsRef<Path>,
+    ttl_seconds: u64,
+    entry: GeneratedSecretEntry,
+) -> Result<(), ErrorResponse> {
+    let path = path.as_ref();
+    let mut container = if path.exists() {
+        read_container(path).await?
+    } else {
+        GeneratedSecrets::default()
+    };
+    container.upsert(entry);
+    let deadline = deadline_from_ttl(ttl_seconds, SystemTime::now());
+    write_container(path, deadline, &container).await?;
+    schedule_purge(path.to_path_buf(), ttl_seconds);
+    Ok(())
+}
+
+pub async fn read_container(path: impl AsRef<Path>) -> Result<GeneratedSecrets, ErrorResponse> {
+    let bytes = tokio::fs::read(path.as_ref()).await?;
+    let (header, encrypted) = parse_header(&bytes)?;
+    if header.is_expired_at(SystemTime::now()) {
+        return Err(internal(format!(
+            "bootstrap generated-secret container {} expired at {}",
+            path.as_ref().display(),
+            header.deadline
+        )));
+    }
+
+    let mut decrypted = EncValue::try_from(encrypted.to_vec())?.decrypt()?.to_vec();
+    let container = serde_json::from_slice(&decrypted);
+    decrypted.zeroize();
+    Ok(container?)
+}
+
+pub async fn write_container(
+    path: impl AsRef<Path>,
+    deadline: u64,
+    container: &GeneratedSecrets,
+) -> Result<(), ErrorResponse> {
+    let path = path.as_ref();
+    let parent = path.parent().ok_or_else(|| {
+        internal(format!(
+            "bootstrap generated-secret path '{}' has no parent directory",
+            path.display()
+        ))
+    })?;
+    tokio::fs::create_dir_all(parent).await?;
+
+    let mut payload = serde_json::to_vec(container)?;
+    let encrypted = match EncValue::encrypt(&payload) {
+        Ok(value) => value.into_bytes().to_vec(),
+        Err(err) => {
+            payload.zeroize();
+            return Err(err.into());
+        }
+    };
+    payload.zeroize();
+    let mut bytes = render_header(deadline);
+    bytes.extend_from_slice(&encrypted);
+
+    let tmp = tmp_path(path)?;
+    {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options.open(&tmp)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+    }
+    bytes.zeroize();
+    std::fs::rename(&tmp, path)?;
+
+    if let Ok(dir) = std::fs::File::open(parent)
+        && let Err(err) = dir.sync_all()
+    {
+        debug!(
+            "Could not fsync bootstrap generated-secret directory '{}': {err}",
+            parent.display()
+        );
+    }
+
+    Ok(())
+}
+
+pub async fn purge_if_expired(path: impl AsRef<Path>) -> Result<bool, ErrorResponse> {
+    let path = path.as_ref();
+    let bytes = match tokio::fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err.into()),
+    };
+    let (header, _) = parse_header(&bytes)?;
+    if header.is_expired_at(SystemTime::now()) {
+        tokio::fs::remove_file(path).await?;
+        info!(
+            "Purged expired bootstrap generated-secret container '{}'",
+            path.display()
+        );
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+pub fn schedule_purge(path: PathBuf, ttl_seconds: u64) {
+    if ttl_seconds == 0 {
+        return;
+    }
+
+    tokio::spawn(async move {
+        sleep(Duration::from_secs(ttl_seconds)).await;
+        if let Err(err) = purge_if_expired(&path).await {
+            error!(
+                "Could not purge bootstrap generated-secret container '{}': {err}",
+                path.display()
+            );
+        }
+    });
+}
+
+pub fn parse_header(bytes: &[u8]) -> Result<(ContainerHeader, &[u8]), ErrorResponse> {
+    let mut lines = bytes.splitn(HEADER_LINES + 1, |b| *b == b'\n');
+    let magic = lines
+        .next()
+        .ok_or_else(|| internal("missing bootstrap generated-secret magic"))?;
+    if magic != MAGIC.as_bytes() {
+        return Err(internal("invalid bootstrap generated-secret magic"));
+    }
+
+    let version = parse_header_u16(lines.next(), "version")?;
+    if version != VERSION {
+        return Err(internal(format!(
+            "unsupported bootstrap generated-secret version {version}"
+        )));
+    }
+
+    let deadline = parse_header_u64(lines.next(), "deadline")?;
+    let encrypted = lines
+        .next()
+        .ok_or_else(|| internal("missing bootstrap generated-secret payload"))?;
+    Ok((ContainerHeader { version, deadline }, encrypted))
+}
+
+pub fn sanitize_env_name(input: impl AsRef<str>) -> String {
+    let mut out = String::with_capacity(input.as_ref().len());
+    let mut last_was_underscore = false;
+    for c in input.as_ref().chars() {
+        let next = if c.is_ascii_alphanumeric() {
+            c.to_ascii_uppercase()
+        } else {
+            '_'
+        };
+        if next == '_' {
+            if !last_was_underscore {
+                out.push(next);
+            }
+            last_was_underscore = true;
+        } else {
+            out.push(next);
+            last_was_underscore = false;
+        }
+    }
+
+    let out = out.trim_matches('_').to_string();
+    if out.is_empty() {
+        "_".to_string()
+    } else if out.as_bytes()[0].is_ascii_digit() {
+        format!("_{out}")
+    } else {
+        out
+    }
+}
+
+fn render_header(deadline: u64) -> Vec<u8> {
+    format!("{MAGIC}\n{VERSION}\n{deadline}\n").into_bytes()
+}
+
+fn parse_header_u16(line: Option<&[u8]>, name: &str) -> Result<u16, ErrorResponse> {
+    let raw = parse_header_line(line, name)?;
+    raw.parse::<u16>()
+        .map_err(|_| internal(format!("invalid bootstrap generated-secret {name}")))
+}
+
+fn parse_header_u64(line: Option<&[u8]>, name: &str) -> Result<u64, ErrorResponse> {
+    let raw = parse_header_line(line, name)?;
+    raw.parse::<u64>()
+        .map_err(|_| internal(format!("invalid bootstrap generated-secret {name}")))
+}
+
+fn parse_header_line<'a>(line: Option<&'a [u8]>, name: &str) -> Result<&'a str, ErrorResponse> {
+    let line =
+        line.ok_or_else(|| internal(format!("missing bootstrap generated-secret {name}")))?;
+    std::str::from_utf8(line).map_err(|_| {
+        internal(format!(
+            "invalid utf-8 in bootstrap generated-secret {name}"
+        ))
+    })
+}
+
+fn tmp_path(path: &Path) -> Result<PathBuf, ErrorResponse> {
+    let file_name = path.file_name().and_then(OsStr::to_str).ok_or_else(|| {
+        internal(format!(
+            "invalid generated-secret path '{}'",
+            path.display()
+        ))
+    })?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    Ok(path.with_file_name(format!(".{file_name}.{}.{nanos}.tmp", std::process::id())))
+}
+
+fn unix_seconds(now: SystemTime) -> u64 {
+    now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+fn internal(msg: impl Into<String>) -> ErrorResponse {
+    ErrorResponse::new(ErrorResponseType::Internal, msg.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cryptr::EncKeys;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::Once;
+
+    static INIT_KEYS: Once = Once::new();
+
+    fn init_keys() {
+        INIT_KEYS.call_once(|| {
+            let keys = EncKeys::generate_with_id("test".to_string()).unwrap();
+            let _ = keys.init();
+        });
+    }
+
+    fn test_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "rauthy-bootstrap-generated-secrets-{name}-{}",
+            std::process::id()
+        ))
+    }
+
+    #[tokio::test]
+    async fn roundtrip_writes_mode_0600_and_reads_entries() {
+        init_keys();
+        let path = test_path("roundtrip");
+        let _ = tokio::fs::remove_file(&path).await;
+
+        upsert_secret(
+            &path,
+            0,
+            GeneratedSecretEntry::new(
+                GeneratedSecretKey::new("client", "demo-app", "secret"),
+                "generated-secret",
+            ),
+        )
+        .await
+        .unwrap();
+
+        let meta = tokio::fs::metadata(&path).await.unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+
+        let container = read_container(&path).await.unwrap();
+        assert_eq!(container.entries.len(), 1);
+        assert_eq!(container.entries[0].value, "generated-secret");
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn bad_magic_fails_before_decrypt() {
+        init_keys();
+        let path = test_path("bad-magic");
+        tokio::fs::write(&path, b"wrong\n1\n0\npayload")
+            .await
+            .unwrap();
+
+        let err = read_container(&path).await.unwrap_err();
+        assert!(err.message.contains("magic"));
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[test]
+    fn bad_version_fails_before_decrypt() {
+        let mut bytes = b"RAUTHY_BOOTSTRAP_GENERATED_SECRETS\n2\n0\n".to_vec();
+        bytes.extend_from_slice(b"payload");
+
+        let err = parse_header(&bytes).unwrap_err();
+        assert!(err.message.contains("version"));
+    }
+
+    #[tokio::test]
+    async fn expired_header_fails_without_decrypting_payload() {
+        init_keys();
+        let path = test_path("expired");
+        tokio::fs::write(
+            &path,
+            b"RAUTHY_BOOTSTRAP_GENERATED_SECRETS\n1\n1\nnot-encrypted",
+        )
+        .await
+        .unwrap();
+
+        let err = read_container(&path).await.unwrap_err();
+        assert!(err.message.contains("expired"));
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn purge_removes_expired_file_without_decrypting_payload() {
+        let path = test_path("purge");
+        tokio::fs::write(
+            &path,
+            b"RAUTHY_BOOTSTRAP_GENERATED_SECRETS\n1\n1\nnot-encrypted",
+        )
+        .await
+        .unwrap();
+
+        assert!(purge_if_expired(&path).await.unwrap());
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn ttl_zero_disables_expiry_and_auto_purge() {
+        init_keys();
+        let path = test_path("ttl-zero");
+        let _ = tokio::fs::remove_file(&path).await;
+
+        upsert_secret(
+            &path,
+            0,
+            GeneratedSecretEntry::new(GeneratedSecretKey::new("user", "can", "password"), "pw"),
+        )
+        .await
+        .unwrap();
+        let bytes = tokio::fs::read(&path).await.unwrap();
+        let (header, _) = parse_header(&bytes).unwrap();
+
+        assert_eq!(header.deadline, 0);
+        assert!(!header.is_expired_at(SystemTime::now() + Duration::from_secs(3600)));
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[test]
+    fn env_names_are_sanitized() {
+        let key = GeneratedSecretKey::new("api-key", "provision/key", "client secret");
+        assert_eq!(
+            key.env_name(),
+            "RAUTHY_BOOTSTRAP_API_KEY_PROVISION_KEY_CLIENT_SECRET"
+        );
+        assert_eq!(sanitize_env_name("123 !thing"), "_123_THING");
+    }
+}

--- a/src/data/src/migration/bootstrap/mod.rs
+++ b/src/data/src/migration/bootstrap/mod.rs
@@ -7,6 +7,7 @@ use tracing::{debug, info};
 
 mod api_key;
 mod clients;
+pub mod generated_secrets;
 mod groups;
 mod jwks;
 mod rauthy_admin;
@@ -56,6 +57,15 @@ macro_rules! bootstrap_data {
 }
 
 pub(crate) use bootstrap_data;
+
+pub async fn purge_expired_generated_secrets() -> Result<(), ErrorResponse> {
+    let path = &crate::rauthy_config::RauthyConfig::get()
+        .vars
+        .bootstrap
+        .generated_secrets_file;
+    generated_secrets::purge_if_expired(path.as_ref()).await?;
+    Ok(())
+}
 
 /// Initializes an empty production database for a new deployment
 pub async fn migrate_init_prod() -> Result<(), ErrorResponse> {

--- a/src/data/src/migration/bootstrap/types.rs
+++ b/src/data/src/migration/bootstrap/types.rs
@@ -19,7 +19,7 @@ use rauthy_api_types::oidc::JwkKeyPairAlg;
 use rauthy_api_types::users::{UserAttrValueRequest, UserValuesRequest};
 use rauthy_common::regex::*;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::fmt::{Debug, Formatter};
 use std::sync::LazyLock;
 use validator::{Validate, ValidationError, ValidationErrors};
@@ -219,7 +219,7 @@ pub struct Client {
     pub scim: Option<ScimClientRequestResponse>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub enum ClientSecret {
     // Plain text secret
     Plain(String),
@@ -233,6 +233,26 @@ pub enum ClientSecret {
     // For future versions, the idea is to add CLI capabilities to the `rauthy` binary and provide
     // a much easier way to achieve this.
     Encrypted(String),
+    // Generate a new confidential-client secret on first bootstrap and store
+    // the cleartext in the encrypted generated-secret container before the DB
+    // row is inserted.
+    Generate,
+}
+
+impl<'de> Deserialize<'de> for ClientSecret {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_secret(
+            deserializer,
+            "client secret",
+            "Encrypted",
+            |s| Ok(Self::Plain(s)),
+            |s| Ok(Self::Encrypted(s)),
+            || Ok(Self::Generate),
+        )
+    }
 }
 
 #[derive(Debug, Deserialize, Validate)]
@@ -279,10 +299,67 @@ pub struct User {
     pub attributes: Option<Vec<UserAttrValueRequest>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub enum UserPassword {
     Plain(String),
     Argon2ID(String),
+    Generate,
+}
+
+impl<'de> Deserialize<'de> for UserPassword {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_secret(
+            deserializer,
+            "user password",
+            "Argon2ID",
+            |s| Ok(Self::Plain(s)),
+            |s| Ok(Self::Argon2ID(s)),
+            || Ok(Self::Generate),
+        )
+    }
+}
+
+fn deserialize_secret<'de, D, T, Plain, Encrypted, Generate>(
+    deserializer: D,
+    name: &str,
+    encrypted_variant: &str,
+    plain: Plain,
+    encrypted: Encrypted,
+    generate: Generate,
+) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    Plain: FnOnce(String) -> Result<T, D::Error>,
+    Encrypted: FnOnce(String) -> Result<T, D::Error>,
+    Generate: FnOnce() -> Result<T, D::Error>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    match value {
+        serde_json::Value::String(s) if s == "generate" => generate(),
+        serde_json::Value::String(s) => Err(serde::de::Error::custom(format!(
+            "invalid {name} string '{s}', expected 'generate'"
+        ))),
+        serde_json::Value::Object(mut obj) if obj.len() == 1 => {
+            if let Some(v) = obj.remove("Plain") {
+                let s = serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+                plain(s)
+            } else if let Some(v) = obj.remove(encrypted_variant) {
+                let s = serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+                encrypted(s)
+            } else {
+                Err(serde::de::Error::custom(format!(
+                    "invalid {name} object variant"
+                )))
+            }
+        }
+        _ => Err(serde::de::Error::custom(format!(
+            "invalid {name}, expected {{\"Plain\": ...}}, {{\"{encrypted_variant}\": ...}}, \
+             or \"generate\""
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -304,5 +381,84 @@ mod tests {
                 .validate()
                 .expect("api_keys bootstrap example should validate");
         }
+    }
+
+    #[test]
+    fn parses_generated_client_secret_string() {
+        let client = serde_json::from_str::<Client>(
+            r#"{
+                "id": "generated-client",
+                "secret": "generate",
+                "redirect_uris": ["https://localhost/callback"],
+                "enabled": true,
+                "flows_enabled": ["authorization_code"],
+                "access_token_alg": "EdDSA",
+                "id_token_alg": "EdDSA",
+                "auth_code_lifetime": 10,
+                "access_token_lifetime": 900,
+                "scopes": ["openid", "profile"],
+                "default_scopes": ["openid"],
+                "force_mfa": false
+            }"#,
+        )
+        .unwrap();
+
+        assert!(matches!(client.secret, Some(ClientSecret::Generate)));
+    }
+
+    #[test]
+    fn absent_or_null_client_secret_stays_public() {
+        let without_secret = serde_json::from_str::<Client>(
+            r#"{
+                "id": "public-client",
+                "redirect_uris": ["https://localhost/callback"],
+                "enabled": true,
+                "flows_enabled": ["authorization_code"],
+                "access_token_alg": "EdDSA",
+                "id_token_alg": "EdDSA",
+                "auth_code_lifetime": 10,
+                "access_token_lifetime": 900,
+                "scopes": ["openid", "profile"],
+                "default_scopes": ["openid"],
+                "force_mfa": false
+            }"#,
+        )
+        .unwrap();
+        let null_secret = serde_json::from_str::<Client>(
+            r#"{
+                "id": "public-client-null",
+                "secret": null,
+                "redirect_uris": ["https://localhost/callback"],
+                "enabled": true,
+                "flows_enabled": ["authorization_code"],
+                "access_token_alg": "EdDSA",
+                "id_token_alg": "EdDSA",
+                "auth_code_lifetime": 10,
+                "access_token_lifetime": 900,
+                "scopes": ["openid", "profile"],
+                "default_scopes": ["openid"],
+                "force_mfa": false
+            }"#,
+        )
+        .unwrap();
+
+        assert!(without_secret.secret.is_none());
+        assert!(null_secret.secret.is_none());
+    }
+
+    #[test]
+    fn parses_generated_user_password_string() {
+        let user = serde_json::from_str::<User>(
+            r#"{
+                "email": "generated@example.com",
+                "password": "generate",
+                "roles": ["user"],
+                "enabled": true,
+                "email_verified": true
+            }"#,
+        )
+        .unwrap();
+
+        assert!(matches!(user.password, UserPassword::Generate));
     }
 }

--- a/src/data/src/migration/bootstrap/types.rs
+++ b/src/data/src/migration/bootstrap/types.rs
@@ -123,18 +123,36 @@ impl Validate for ApiKey {
     }
 }
 
-#[derive(Deserialize)]
 pub enum ApiKeySecret {
     // Plain text secret
     Plain(String),
     // Must be encrypted using [cryptr](https://github.com/sebadob/cryptr) with an `ENC_KEY` that
     // the Rauthy instance must have available. The encrypted data is expected as **base64**.
     Encrypted(String),
+    // Generate a new API-key secret on first bootstrap and store the cleartext
+    // in the encrypted generated-secret container before the DB row is updated.
+    Generate,
 }
 
 impl Debug for ApiKeySecret {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str("<hidden>")
+    }
+}
+
+impl<'de> Deserialize<'de> for ApiKeySecret {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_secret(
+            deserializer,
+            "API-key secret",
+            "Encrypted",
+            |s| Ok(Self::Plain(s)),
+            |s| Ok(Self::Encrypted(s)),
+            || Ok(Self::Generate),
+        )
     }
 }
 
@@ -381,6 +399,30 @@ mod tests {
                 .validate()
                 .expect("api_keys bootstrap example should validate");
         }
+    }
+
+    #[test]
+    fn parses_generated_api_key_secret_string() {
+        let api_keys = serde_json::from_str::<Vec<ApiKey>>(
+            r#"[
+                {
+                    "name": "bootstrap",
+                    "exp": 1735599600,
+                    "secret": "generate",
+                    "access": [
+                        {
+                            "group": "Clients",
+                            "access_rights": ["read", "create"]
+                        }
+                    ]
+                }
+            ]"#,
+        )
+        .unwrap();
+
+        assert_eq!(api_keys.len(), 1);
+        assert!(matches!(&api_keys[0].secret, ApiKeySecret::Generate));
+        api_keys[0].validate().unwrap();
     }
 
     #[test]

--- a/src/data/src/migration/bootstrap/users.rs
+++ b/src/data/src/migration/bootstrap/users.rs
@@ -4,8 +4,11 @@ use crate::entity::roles::Role;
 use crate::entity::user_attr::UserAttrConfigEntity;
 use crate::entity::users_values::UserValues;
 use crate::migration::bootstrap::bootstrap_data;
+use crate::migration::bootstrap::generated_secrets::{GeneratedSecretEntry, GeneratedSecretKey};
 use crate::migration::bootstrap::types::{User, UserPassword};
+use crate::rauthy_config::RauthyConfig;
 use chrono::Utc;
+use cryptr::utils::secure_random_alnum;
 use hiqlite::macros::params;
 use rauthy_api_types::users::UserValuesRequest;
 use rauthy_common::is_hiqlite;
@@ -13,6 +16,7 @@ use rauthy_common::password_hasher::HashPassword;
 use rauthy_common::utils::new_store_id;
 use rauthy_error::ErrorResponse;
 use tracing::info;
+use zeroize::Zeroize;
 
 pub async fn bootstrap() -> Result<(), ErrorResponse> {
     let users = bootstrap_data!(User, "users");
@@ -53,6 +57,24 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)"#;
         let password = match user.password {
             UserPassword::Plain(plain) => HashPassword::hash_password(plain).await?,
             UserPassword::Argon2ID(hash) => hash,
+            UserPassword::Generate => {
+                let mut plain = secure_random_alnum(64);
+                let bootstrap = &RauthyConfig::get().vars.bootstrap;
+                if let Err(err) = crate::migration::bootstrap::generated_secrets::upsert_secret(
+                    bootstrap.generated_secrets_file.as_ref(),
+                    bootstrap.generated_secrets_ttl,
+                    GeneratedSecretEntry::new(
+                        GeneratedSecretKey::new("user", &user.email, "password"),
+                        plain.clone(),
+                    ),
+                )
+                .await
+                {
+                    plain.zeroize();
+                    return Err(err);
+                }
+                HashPassword::hash_password(plain).await?
+            }
         };
 
         for role in &user.roles {

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -1430,7 +1430,7 @@ impl Vars {
         ) {
             self.bootstrap.generated_secrets_file = v.into();
         }
-        if let Some(v) = t_u64(
+        if let Some(v) = t_u32(
             &mut table,
             "bootstrap",
             "generated_secrets_ttl",
@@ -3458,7 +3458,7 @@ pub struct VarsBootstrap {
     pub api_key_secret: Option<String>,
     pub bootstrap_dir: Cow<'static, str>,
     pub generated_secrets_file: Cow<'static, str>,
-    pub generated_secrets_ttl: u64,
+    pub generated_secrets_ttl: u32,
 }
 
 #[derive(Debug)]
@@ -3959,16 +3959,6 @@ fn t_u32(map: &mut toml::Table, parent: &str, key: &str, env_overwrite: &str) ->
             panic!("{}", err_t(key, parent, "u32"));
         }
         Some(v as u32)
-    } else {
-        None
-    }
-}
-fn t_u64(map: &mut toml::Table, parent: &str, key: &str, env_overwrite: &str) -> Option<u64> {
-    if let Some(v) = t_i64(map, parent, key, env_overwrite) {
-        if v < 0 {
-            panic!("{}", err_t(key, parent, "u64"));
-        }
-        Some(v as u64)
     } else {
         None
     }

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -2,6 +2,7 @@ use crate::ListenScheme;
 use crate::email::mailer::{EMail, SmtpConnMode};
 use crate::events::event::{Event, EventLevel};
 use crate::events::listener::EventRouterMsg;
+use crate::migration::bootstrap::generated_secrets;
 use crate::vault_config::VaultConfig;
 use cryptr::EncKeys;
 use hiqlite::NodeConfig;
@@ -340,6 +341,8 @@ impl Default for Vars {
                 api_key: None,
                 api_key_secret: None,
                 bootstrap_dir: "bootstrap".into(),
+                generated_secrets_file: String::new().into(),
+                generated_secrets_ttl: 600,
             },
             cred_stuff_detect: VarsCredStuff {
                 blacklist_duration: 86400,
@@ -1110,6 +1113,7 @@ impl Vars {
         slf.parse_webauthn(&mut table);
 
         let node_config = slf.parse_hiqlite_config(&mut table).await;
+        slf.resolve_bootstrap_generated_secrets_file(&node_config);
 
         check_empty(table, "<root>");
 
@@ -1418,8 +1422,31 @@ impl Vars {
         if let Some(v) = t_str(&mut table, "bootstrap", "bootstrap_dir", "BOOTSTRAP_DIR") {
             self.bootstrap.bootstrap_dir = v.into();
         }
+        if let Some(v) = t_str(
+            &mut table,
+            "bootstrap",
+            "generated_secrets_file",
+            "BOOTSTRAP_GENERATED_SECRETS_FILE",
+        ) {
+            self.bootstrap.generated_secrets_file = v.into();
+        }
+        if let Some(v) = t_u64(
+            &mut table,
+            "bootstrap",
+            "generated_secrets_ttl",
+            "BOOTSTRAP_GENERATED_SECRETS_TTL",
+        ) {
+            self.bootstrap.generated_secrets_ttl = v;
+        }
 
         check_empty(table, "bootstrap");
+    }
+
+    fn resolve_bootstrap_generated_secrets_file(&mut self, node_config: &NodeConfig) {
+        if self.bootstrap.generated_secrets_file.is_empty() {
+            self.bootstrap.generated_secrets_file =
+                generated_secrets::default_file_path(&node_config.data_dir).into();
+        }
     }
 
     fn parse_cred_stuff(&mut self, table: &mut toml::Table) {
@@ -3430,6 +3457,8 @@ pub struct VarsBootstrap {
     pub api_key: Option<String>,
     pub api_key_secret: Option<String>,
     pub bootstrap_dir: Cow<'static, str>,
+    pub generated_secrets_file: Cow<'static, str>,
+    pub generated_secrets_ttl: u64,
 }
 
 #[derive(Debug)]
@@ -3930,6 +3959,16 @@ fn t_u32(map: &mut toml::Table, parent: &str, key: &str, env_overwrite: &str) ->
             panic!("{}", err_t(key, parent, "u32"));
         }
         Some(v as u32)
+    } else {
+        None
+    }
+}
+fn t_u64(map: &mut toml::Table, parent: &str, key: &str, env_overwrite: &str) -> Option<u64> {
+    if let Some(v) = t_i64(map, parent, key, env_overwrite) {
+        if v < 0 {
+            panic!("{}", err_t(key, parent, "u64"));
+        }
+        Some(v as u64)
     } else {
         None
     }

--- a/src/error/src/error_impls.rs
+++ b/src/error/src/error_impls.rs
@@ -43,6 +43,11 @@ impl ErrorResponse {
         }
     }
 
+    /// Convenience constructor for an internal error.
+    pub fn internal(message: impl Into<Cow<'static, str>>) -> Self {
+        Self::new(ErrorResponseType::Internal, message)
+    }
+
     pub fn error_response_html(&self, body: String) -> HttpResponse {
         HttpResponseBuilder::new(self.status_code())
             .append_header(HEADER_HTML)


### PR DESCRIPTION
This follows the maintainer-accepted scope from #1584: add generated bootstrap secret extraction for Advanced Bootstrapping JSON, without adding an admin-token or trusted-local auth primitive.

### Changes

- Adds an encrypted generated-secret container for bootstrap-created secrets.
- Supports generated client/user secrets during empty production database bootstrap.
- Adds `rauthy bootstrap get` and `rauthy bootstrap purge` for retrieving or purging generated bootstrap secrets.
- Keeps generated secrets out of bootstrap JSON and stores them in the configured encrypted container instead.
- Zeroizes temporary plaintext buffers and generated-secret values after use, including error paths before DB insertion.
- Supports optional generated-secret TTL handling, including expiry rejection and purge behavior.
- Adds generated-secret roundtrip, expiry, purge, version/magic validation, and env-name sanitization tests.
- Documents generated bootstrap secret configuration and CLI usage.

Refs #1584.