### PR TITLE
fix(clients): restrict client id validation for non-ephemeral clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,25 @@ clients cannot set their own claims.
 
 [#1604](https://github.com/sebadob/rauthy/pull/1604)
 
+#### Stricter Client ID validation
+
+Client IDs for manually managed clients are now validated against the stricter pattern
+`^[a-zA-Z0-9._\-]{2,256}$`, which matches the existing Admin UI restriction. This applies when
+creating a client via the API and when bootstrapping clients from JSON files. Ephemeral clients are
+unaffected and may still use a full URI as their ID.
+
+Previously, the backend accepted URI-shaped IDs on these paths, even though such a client cannot be
+managed in the Admin UI and behaves completely differently depending on whether ephemeral clients
+are enabled. Existing clients with such an ID keep working and can still be updated, since the ID for
+an update is taken from the URL path; only creating or bootstrapping a new client with such an ID is
+now rejected.
+
+As part of this, the redundant `id` field was removed from the client update request body. It was a
+leftover from an older API version: on update the ID is always taken from the URL path and could
+never be changed, so the field had no effect, and any `id` still sent in the body is now ignored.
+
+[#1605](https://github.com/sebadob/rauthy/pull/1605)
+
 ### Bugfix
 
 - The Postgres migration `v24__cust_attrs_token_root.sql` was named with a lowercase `v` and was

--- a/book/src/work/ephemeral_clients.md
+++ b/book/src/work/ephemeral_clients.md
@@ -11,6 +11,13 @@ Just to make clear what I am talking about, a high level comparison of these dif
 **Static clients** are the ones that you register and configure via the Admin UI. These are the most efficient and
 secure ones. They require less work in the backend and exist inside the Rauthy database.
 
+```admonish note
+Static client IDs (via the Admin UI, the API, or bootstrapping) are restricted to
+`^[a-zA-Z0-9._\-]{2,256}$`. Only ephemeral clients use a full URI as their ID, since that URI is the
+location their client document is fetched from. A static client therefore never needs a URI-shaped
+ID.
+```
+
 Then there is OIDC **Dynamic Client Registration** (DCR), which is an OIDC extension that Rauthy supports as well. If a
 downstream application has support for this feature, it can self-register a client, which then can be used for the
 login afterward. This sound very nice in the beginning, but brings quite a few problems:

--- a/frontend/src/api/types/clients.ts
+++ b/frontend/src/api/types/clients.ts
@@ -33,8 +33,6 @@ export interface ScimClientRequestResponse {
 }
 
 export interface UpdateClientRequest {
-    /// Validation: PATTERN_CLIENT_ID
-    id: string;
     /// Validation: PATTERN_CLIENT_NAME
     name?: string;
     confidential: boolean;

--- a/frontend/src/lib/admin/clients/ClientConfig.svelte
+++ b/frontend/src/lib/admin/clients/ClientConfig.svelte
@@ -51,7 +51,6 @@
     let err = $state('');
     let success = $state(false);
 
-    let id = $state(client.id);
     let name: string = $state(client.name || '');
     let enabled = $state(client.enabled);
     let confidential = $state(client.confidential);
@@ -123,7 +122,6 @@
 
     $effect(() => {
         if (client.id) {
-            id = client.id;
             name = client.name || '';
             enabled = client.enabled;
             forceMfa = client.force_mfa;
@@ -204,7 +202,6 @@
         err = '';
 
         let payload: UpdateClientRequest = {
-            id,
             name: name || undefined,
             enabled,
             confidential,

--- a/src/api_types/src/clients.rs
+++ b/src/api_types/src/clients.rs
@@ -1,7 +1,8 @@
 use crate::cust_validation::*;
 use crate::oidc::JwkKeyPairAlg;
 use rauthy_common::regex::{
-    RE_CLIENT_ID, RE_CLIENT_NAME, RE_GROUPS, RE_SCOPE_SPACE, RE_TOKEN_ENDPOINT_AUTH_METHOD, RE_URI,
+    RE_CLIENT_ID, RE_CLIENT_ID_STRICT, RE_CLIENT_NAME, RE_GROUPS, RE_SCOPE_SPACE,
+    RE_TOKEN_ENDPOINT_AUTH_METHOD, RE_URI,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -117,11 +118,8 @@ pub struct EphemeralClientRequest {
 #[derive(Validate, Deserialize, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct NewClientRequest {
-    /// Validation: `^[a-z0-9-_/]{2,128}$`
-    #[validate(regex(
-        path = "*RE_CLIENT_ID",
-        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
-    ))]
+    /// Validation: `^[a-zA-Z0-9._\-]{2,256}$`
+    #[validate(regex(path = "*RE_CLIENT_ID_STRICT", code = "^[a-zA-Z0-9._\\-]{2,256}$"))]
     pub id: String,
     /// Validation: None - will not be deserialized
     #[serde(skip_deserializing)]
@@ -142,12 +140,6 @@ pub struct NewClientRequest {
 #[derive(Deserialize, Validate, ToSchema)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 pub struct UpdateClientRequest {
-    /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$`
-    #[validate(regex(
-        path = "*RE_CLIENT_ID",
-        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
-    ))]
-    pub id: String,
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,128}`
     #[validate(regex(path = "*RE_CLIENT_NAME", code = "[a-zA-Z0-9À-ɏ-\\s]{2,128}"))]
     pub name: Option<String>,

--- a/src/bin/src/init_static_vars.rs
+++ b/src/bin/src/init_static_vars.rs
@@ -143,6 +143,7 @@ pub fn trigger() {
     if vars.ephemeral_clients.enable {
         let _ = *RE_CLIENT_ID;
     }
+    let _ = *RE_CLIENT_ID_STRICT;
     let _ = *RE_CLIENT_NAME;
     let _ = *RE_CODE_CHALLENGE;
     let _ = *RE_CODE_VERIFIER;

--- a/src/bin/tests/handler_auth.rs
+++ b/src/bin/tests/handler_auth.rs
@@ -263,7 +263,6 @@ async fn test_authorization_code_flow() -> Result<(), Box<dyn Error>> {
 
     // disable pkce for the init client
     let mut update_client = UpdateClientRequest {
-        id: CLIENT_ID.to_string(),
         name: Some("Init Client".to_string()),
         confidential: true,
         redirect_uris: vec!["http://localhost:3000/oidc/callback".to_string()],

--- a/src/bin/tests/handler_scopes.rs
+++ b/src/bin/tests/handler_scopes.rs
@@ -59,7 +59,6 @@ async fn test_scopes() -> Result<(), Box<dyn Error>> {
     default_scopes.push(new_scope.scope.clone());
 
     let update_client = UpdateClientRequest {
-        id: init_client.id,
         name: init_client.name,
         confidential: init_client.confidential,
         redirect_uris: init_client.redirect_uris,

--- a/src/bin/tests/zza_handler_cust_attrs.rs
+++ b/src/bin/tests/zza_handler_cust_attrs.rs
@@ -112,7 +112,6 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
     let mut default_scopes = c.default_scopes;
     default_scopes.push("cust_scope".to_string());
     let client_req = UpdateClientRequest {
-        id: c.id,
         name: c.name,
         confidential: c.confidential,
         redirect_uris: c.redirect_uris,

--- a/src/bin/tests/zzd_handler_clients.rs
+++ b/src/bin/tests/zzd_handler_clients.rs
@@ -148,6 +148,24 @@ async fn test_clients() -> Result<(), Box<dyn Error>> {
     // S256 code challenge by default for better security
     assert_eq!(client.challenges.as_ref().unwrap().get(0).unwrap(), "S256");
 
+    // a URL-shaped id must be rejected for manually managed (non-ephemeral) clients:
+    // these are restricted to `RE_CLIENT_ID_STRICT`, only ephemeral clients may use a URI id.
+    let url_id_client = NewClientRequest {
+        id: "https://connector.example.com/oauth/client.json".to_string(),
+        secret: None,
+        name: Some("URL Id Client".to_string()),
+        confidential: true,
+        redirect_uris: vec!["http://test.client.io/callback".to_string()],
+        post_logout_redirect_uris: None,
+    };
+    let res = reqwest::Client::new()
+        .post(&url)
+        .headers(auth_headers.clone())
+        .json(&url_id_client)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 400);
+
     // modify the client
     let mut redirect_uris = client.redirect_uris;
     redirect_uris.push("http://test.client.io/callback123".to_string());
@@ -158,7 +176,6 @@ async fn test_clients() -> Result<(), Box<dyn Error>> {
     flows_enabled.push("password".to_string());
 
     let update_client = UpdateClientRequest {
-        id: client.id.clone(),
         name: None,
         confidential: false,
         redirect_uris: redirect_uris.clone(),

--- a/src/common/src/regex.rs
+++ b/src/common/src/regex.rs
@@ -21,6 +21,11 @@ pub static RE_CITY: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9À-ÿ-\s]{0,48}$").unwrap());
 pub static RE_CLIENT_ID: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,256}$").unwrap());
+// Stricter pattern for manually managed (non-ephemeral) clients. Mirrors the admin UI's
+// `PATTERN_CLIENT_ID_NEW`: alphanumeric plus `.`, `_`, `-`, so a client id can never be a URI.
+// Ephemeral clients keep using `RE_CLIENT_ID`, which still allows full URI ids.
+pub static RE_CLIENT_ID_STRICT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._\-]{2,256}$").unwrap());
 pub static RE_CLIENT_NAME: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[a-zA-Z0-9À-ɏ-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{2,128}$").unwrap()
 });

--- a/src/data/src/migration/bootstrap/types.rs
+++ b/src/data/src/migration/bootstrap/types.rs
@@ -165,11 +165,8 @@ pub struct ApiKeyAccess {
 
 #[derive(Debug, Deserialize, Validate)]
 pub struct Client {
-    /// Validation: `^[a-z0-9-_/]{2,128}$`
-    #[validate(regex(
-        path = "*RE_CLIENT_ID",
-        code = "^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]{2,256}$"
-    ))]
+    /// Validation: `^[a-zA-Z0-9._\-]{2,256}$`
+    #[validate(regex(path = "*RE_CLIENT_ID_STRICT", code = "^[a-zA-Z0-9._\\-]{2,256}$"))]
     pub id: String,
     /// Validation: `[a-zA-Z0-9À-ÿ-\\s]{2,128}`
     #[validate(regex(path = "*RE_CLIENT_NAME", code = "[a-zA-Z0-9À-ɏ-\\s]{2,128}"))]

--- a/src/service/src/client.rs
+++ b/src/service/src/client.rs
@@ -10,12 +10,6 @@ pub async fn update_client(
     client_req: UpdateClientRequest,
 ) -> Result<(Client, Option<(ClientScim, bool)>), ErrorResponse> {
     let mut client = Client::find(id).await?;
-    if client.id != client_req.id {
-        return Err(ErrorResponse::new(
-            ErrorResponseType::BadRequest,
-            "The 'id' cannot be changed",
-        ));
-    }
 
     client.name = client_req.name;
     if client_req.confidential {


### PR DESCRIPTION
Follows up on the discussion in #1559 / #1562. As discussed there (https://github.com/sebadob/rauthy/pull/1559#issuecomment-4689605960), the proper fix is server-side: the Admin UI already restricts client IDs to `^[a-zA-Z0-9._\-]{2,256}$` after #1572, but the API and bootstrapping still accept URI-shaped IDs via the minimal client requests. That lets a client into the DB that the Admin UI cannot manage and that behaves completely differently depending on whether ephemeral clients are enabled.

This restricts the manually managed (non-ephemeral) creation paths to the same pattern the UI uses, so a URI-shaped ID can no longer enter the DB through them.

### Changes

- New `RE_CLIENT_ID_STRICT` regex (`^[a-zA-Z0-9._\-]{2,256}$`), byte-identical to the UI's `PATTERN_CLIENT_ID_NEW`.
- Applied to `NewClientRequest.id` and the bootstrap `Client.id`.
- `EphemeralClientRequest` and every flow/lookup path keep using `RE_CLIENT_ID` (the full URI pattern), since ephemeral / CIMD / Solid clients legitimately use a URI as their ID.
- Removed the redundant `id` field from `UpdateClientRequest` (per review): the ID is always taken from the URL path on update and could never be changed, so the body field only fed a now-removed equality check. Existing clients with a legacy URI-shaped ID therefore stay manageable (updatable via their path) rather than being locked out.
- Test: creating a client with a URI-shaped ID returns `400`.
- CHANGELOG entry and a short note in the ephemeral-clients book page clarifying the ID distinction.

Thanks to @BorisTyshkevich for surfacing this in #1559; this takes the server-side route from that thread, which should make the Admin UI encoding change there unnecessary for new clients.
