### PR TITLE
feat(api-keys): allow API keys to manage API keys

### DIFF
--- a/frontend/src/api/types/api_keys.ts
+++ b/frontend/src/api/types/api_keys.ts
@@ -11,7 +11,8 @@ export type AccessGroup =
     | 'Scopes'
     | 'UserAttributes'
     | 'Users'
-    | 'AuthProviders';
+    | 'AuthProviders'
+    | 'ApiKeys';
 export type AccessRight = 'read' | 'create' | 'update' | 'delete';
 
 export interface ApiKeyAccess {

--- a/frontend/src/lib/admin/api_keys/ApiKeyMatrix.svelte
+++ b/frontend/src/lib/admin/api_keys/ApiKeyMatrix.svelte
@@ -33,6 +33,7 @@
         ['UserAttributes', false, false, false, false],
         ['Users', false, false, false, false],
         ['AuthProviders', false, false, false, false],
+        ['ApiKeys', false, false, false, false],
     ]);
 
     $effect(() => {
@@ -80,6 +81,9 @@
                         break;
                     case 'AuthProviders':
                         idx = 12;
+                        break;
+                    case 'ApiKeys':
+                        idx = 13;
                         break;
                 }
                 if (idx === undefined) {

--- a/src/api/src/api_keys.rs
+++ b/src/api/src/api_keys.rs
@@ -3,7 +3,7 @@ use actix_web::web::Json;
 use actix_web::{HttpResponse, delete, get, post, put, web};
 use mime_guess::mime::TEXT_PLAIN_UTF_8;
 use rauthy_api_types::api_keys::{ApiKeyRequest, ApiKeyResponse, ApiKeysResponse};
-use rauthy_data::entity::api_keys::ApiKeyEntity;
+use rauthy_data::entity::api_keys::{AccessGroup, AccessRights, ApiKeyEntity};
 use rauthy_error::{ErrorResponse, ErrorResponseType};
 use validator::Validate;
 
@@ -23,7 +23,7 @@ use validator::Validate;
 )]
 #[get("/api_keys")]
 pub async fn get_api_keys(principal: ReqPrincipal) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::ApiKeys, AccessRights::Read)?;
 
     let entities = ApiKeyEntity::find_all().await?;
     let mut keys = Vec::with_capacity(entities.len());
@@ -55,7 +55,7 @@ pub async fn post_api_key(
     principal: ReqPrincipal,
     Json(payload): Json<ApiKeyRequest>,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::ApiKeys, AccessRights::Create)?;
     payload.validate()?;
 
     let access = payload.access.into_iter().map(|a| a.into()).collect();
@@ -87,7 +87,7 @@ pub async fn put_api_key(
     name: web::Path<String>,
     Json(payload): Json<ApiKeyRequest>,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::ApiKeys, AccessRights::Update)?;
     payload.validate()?;
 
     let name = name.into_inner();
@@ -123,7 +123,7 @@ pub async fn delete_api_key(
     principal: ReqPrincipal,
     name: web::Path<String>,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::ApiKeys, AccessRights::Delete)?;
 
     let name = name.into_inner();
     ApiKeyEntity::delete(&name).await?;
@@ -188,7 +188,7 @@ pub async fn put_api_key_secret(
     principal: ReqPrincipal,
     name: web::Path<String>,
 ) -> Result<HttpResponse, ErrorResponse> {
-    principal.validate_admin_session()?;
+    principal.validate_api_key_or_admin_session(AccessGroup::ApiKeys, AccessRights::Update)?;
 
     let name = name.into_inner();
     let secret = ApiKeyEntity::generate_secret(&name).await?;

--- a/src/api_types/src/api_keys.rs
+++ b/src/api_types/src/api_keys.rs
@@ -5,6 +5,7 @@ use validator::Validate;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 pub enum AccessGroup {
+    ApiKeys,
     Blacklist,
     Clients,
     Events,

--- a/src/api_types/src/api_keys.rs
+++ b/src/api_types/src/api_keys.rs
@@ -5,7 +5,6 @@ use validator::Validate;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema)]
 pub enum AccessGroup {
-    ApiKeys,
     Blacklist,
     Clients,
     Events,
@@ -19,6 +18,7 @@ pub enum AccessGroup {
     Users,
     Pam,
     AuthProviders,
+    ApiKeys,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, ToSchema)]

--- a/src/bin/tests/handler_api_keys.rs
+++ b/src/bin/tests/handler_api_keys.rs
@@ -62,6 +62,75 @@ async fn test_api_keys() -> Result<(), Box<dyn Error>> {
     let body = res.json::<Vec<Group>>().await?;
     assert!(!body.is_empty());
 
+    // the groups-only API key must not manage API keys
+    let res = client
+        .get(&url)
+        .header(AUTHORIZATION, &key_header)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+    // create an API-key manager key and use it to manage another key
+    let manager_payload = ApiKeyRequest {
+        name: "api-key-manager".to_string(),
+        exp: None,
+        access: vec![ApiKeyAccess {
+            group: AccessGroup::ApiKeys,
+            access_rights: vec![
+                AccessRights::Read,
+                AccessRights::Create,
+                AccessRights::Update,
+                AccessRights::Delete,
+            ],
+        }],
+    };
+    let res = client
+        .post(&url)
+        .headers(auth_headers.clone())
+        .json(&manager_payload)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+    let manager_secret = res.text().await?;
+    let manager_header = format!("API-Key {}", manager_secret);
+
+    let managed_payload = ApiKeyRequest {
+        name: "api-key-managed".to_string(),
+        exp: None,
+        access: vec![ApiKeyAccess {
+            group: AccessGroup::Groups,
+            access_rights: vec![AccessRights::Read],
+        }],
+    };
+    let res = client
+        .post(&url)
+        .header(AUTHORIZATION, &manager_header)
+        .json(&managed_payload)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+    let managed_secret = res.text().await?;
+    assert!(managed_secret.starts_with(&managed_payload.name));
+
+    let managed_secret_url = format!("{}/{}/secret", url, managed_payload.name);
+    let res = client
+        .put(&managed_secret_url)
+        .header(AUTHORIZATION, &manager_header)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+    let rotated_secret = res.text().await?;
+    assert!(rotated_secret.starts_with(&managed_payload.name));
+    assert_ne!(managed_secret, rotated_secret);
+
+    let managed_url = format!("{}/{}", url, managed_payload.name);
+    let res = client
+        .delete(&managed_url)
+        .header(AUTHORIZATION, &manager_header)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
     // we should NOT be able to create a new group
     let new_group = GroupRequest {
         group: "api_key_test_group".to_string(),

--- a/src/data/src/entity/api_keys.rs
+++ b/src/data/src/entity/api_keys.rs
@@ -304,7 +304,6 @@ impl ApiKeyEntity {
 // run into deserialization issues!
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum AccessGroup {
-    ApiKeys,
     Blacklist,
     Clients,
     Events,
@@ -318,6 +317,7 @@ pub enum AccessGroup {
     Users,
     Pam,
     AuthProviders,
+    ApiKeys,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -420,7 +420,6 @@ impl From<ApiKey> for ApiKeyResponse {
 impl From<AccessGroup> for rauthy_api_types::api_keys::AccessGroup {
     fn from(value: AccessGroup) -> Self {
         match value {
-            AccessGroup::ApiKeys => Self::ApiKeys,
             AccessGroup::Blacklist => Self::Blacklist,
             AccessGroup::Clients => Self::Clients,
             AccessGroup::Events => Self::Events,
@@ -434,6 +433,7 @@ impl From<AccessGroup> for rauthy_api_types::api_keys::AccessGroup {
             AccessGroup::Users => Self::Users,
             AccessGroup::Pam => Self::Pam,
             AccessGroup::AuthProviders => Self::AuthProviders,
+            AccessGroup::ApiKeys => Self::ApiKeys,
         }
     }
 }
@@ -465,7 +465,6 @@ impl From<ApiKeyAccess> for rauthy_api_types::api_keys::ApiKeyAccess {
 impl From<rauthy_api_types::api_keys::AccessGroup> for AccessGroup {
     fn from(value: rauthy_api_types::api_keys::AccessGroup) -> Self {
         match value {
-            rauthy_api_types::api_keys::AccessGroup::ApiKeys => Self::ApiKeys,
             rauthy_api_types::api_keys::AccessGroup::Blacklist => Self::Blacklist,
             rauthy_api_types::api_keys::AccessGroup::Clients => Self::Clients,
             rauthy_api_types::api_keys::AccessGroup::Events => Self::Events,
@@ -479,6 +478,7 @@ impl From<rauthy_api_types::api_keys::AccessGroup> for AccessGroup {
             rauthy_api_types::api_keys::AccessGroup::Users => Self::Users,
             rauthy_api_types::api_keys::AccessGroup::Pam => Self::Pam,
             rauthy_api_types::api_keys::AccessGroup::AuthProviders => Self::AuthProviders,
+            rauthy_api_types::api_keys::AccessGroup::ApiKeys => Self::ApiKeys,
         }
     }
 }

--- a/src/data/src/entity/api_keys.rs
+++ b/src/data/src/entity/api_keys.rs
@@ -304,6 +304,7 @@ impl ApiKeyEntity {
 // run into deserialization issues!
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum AccessGroup {
+    ApiKeys,
     Blacklist,
     Clients,
     Events,
@@ -419,6 +420,7 @@ impl From<ApiKey> for ApiKeyResponse {
 impl From<AccessGroup> for rauthy_api_types::api_keys::AccessGroup {
     fn from(value: AccessGroup) -> Self {
         match value {
+            AccessGroup::ApiKeys => Self::ApiKeys,
             AccessGroup::Blacklist => Self::Blacklist,
             AccessGroup::Clients => Self::Clients,
             AccessGroup::Events => Self::Events,
@@ -463,6 +465,7 @@ impl From<ApiKeyAccess> for rauthy_api_types::api_keys::ApiKeyAccess {
 impl From<rauthy_api_types::api_keys::AccessGroup> for AccessGroup {
     fn from(value: rauthy_api_types::api_keys::AccessGroup) -> Self {
         match value {
+            rauthy_api_types::api_keys::AccessGroup::ApiKeys => Self::ApiKeys,
             rauthy_api_types::api_keys::AccessGroup::Blacklist => Self::Blacklist,
             rauthy_api_types::api_keys::AccessGroup::Clients => Self::Clients,
             rauthy_api_types::api_keys::AccessGroup::Events => Self::Events,


### PR DESCRIPTION
## feat(api-keys): allow API keys to manage API keys

Adds a new `AccessGroup::ApiKeys` variant and gates the API key CRUD endpoints
with `validate_api_key_or_admin_session()` instead of requiring a full admin session.

This is part of the work towards https://github.com/sebadob/rauthy/issues/1584
(RFC: advanced bootstrap config). The generated-secret container that this builds
on was introduced in https://github.com/sebadob/rauthy/pull/1599.

### Changes

- **api_types**: Add `AccessGroup::ApiKeys` variant (appended to end of enum
  to preserve bincode variant indices)
- **entity**: Same variant + all `From` conversions
- **handlers**: `validate_admin_session()` → `validate_api_key_or_admin_session()`
  on all 5 API key endpoints (GET/POST/PUT/DELETE + secret rotation)
- **tests**: Full coverage — verifies isolation (groups-only key cannot manage
  API keys) and delegation (a key with `ApiKeys` access can CRUD other keys)