### PR TITLE
feat(clients): per-client allowed_aaguids allow-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+#### Per-Client Allowed AAGUIDs
+
+Clients can now define an optional allow-list of authenticator AAGUIDs
+(`allowed_aaguids`, canonical UUID form) via the Admin UI and the client API. This is the
+storage and management layer for restricting a client to specific hardware
+authenticators; an empty / missing list applies no restriction. Enforcement during the
+WebAuthn attestation ceremony is a planned follow-up.
+
+[#1619](https://github.com/sebadob/rauthy/pull/1619)
+
 ## v0.36.0
 
 ### Breaking

--- a/frontend/src/api/types/clients.ts
+++ b/frontend/src/api/types/clients.ts
@@ -74,6 +74,10 @@ export interface UpdateClientRequest {
     /// Audiences always added to this client's tokens, independent of any request.
     /// Validation: PATTERN_URI
     default_aud?: string[];
+    /// Allow-list of authenticator AAGUIDs (canonical dashed UUID form) accepted for
+    /// hardware-attested sessions with this client.
+    /// Validation: PATTERN_AAGUID
+    allowed_aaguids?: string[];
     scim?: ScimClientRequestResponse;
 }
 
@@ -107,6 +111,7 @@ export interface ClientResponse {
     claims_at_root: boolean;
     allowed_resources?: string[];
     default_aud?: string[];
+    allowed_aaguids?: string[];
     scim?: ScimClientRequestResponse;
 }
 

--- a/frontend/src/i18n/admin/de.ts
+++ b/frontend/src/i18n/admin/de.ts
@@ -40,6 +40,8 @@ export let I18nAdminDe: I18nAdmin = {
         size: 'Größe',
     },
     clients: {
+        allowedAaguids: 'Erlaubte AAGUIDs',
+        descAllowedAaguids: `Optionale Positivliste von Authenticator-AAGUIDs (kanonische UUID-Form), die für hardwareattestierte Sitzungen mit diesem Client akzeptiert werden. Eine leere Liste wendet keine AAGUID-Einschränkung an.`,
         allowedResources: 'Erlaubte Ressourcen',
         defaultAud: 'Standard-Audiences',
         descAllowedResources: `Optionale RFC 8707 Resource Indicators, die dieser Client anfordern darf. Eine leere Liste lehnt jeden 'resource'-Parameter mit 'invalid_target' ab.`,
@@ -557,6 +559,7 @@ export let I18nAdminDe: I18nAdmin = {
         sendResetEmail: 'Reset E-Mail Senden',
     },
     validation: {
+        aaguid: 'Ungültige AAGUID',
         css: 'Ungültiger CSS Wert',
         origin: 'Ungültige Origin',
         uri: 'Ungültige URI',

--- a/frontend/src/i18n/admin/en.ts
+++ b/frontend/src/i18n/admin/en.ts
@@ -37,6 +37,8 @@ export let I18nAdminEn: I18nAdmin = {
         size: 'Size',
     },
     clients: {
+        allowedAaguids: 'Allowed AAGUIDs',
+        descAllowedAaguids: `Optional allow-list of authenticator AAGUIDs (canonical UUID form) accepted for hardware-attested sessions with this client. An empty list applies no AAGUID restriction.`,
         allowedResources: 'Allowed Resources',
         defaultAud: 'Default Audiences',
         descAllowedResources: `Optional RFC 8707 resource indicators this client may request. An empty list rejects any 'resource' request parameter with 'invalid_target'.`,
@@ -529,6 +531,7 @@ export let I18nAdminEn: I18nAdmin = {
         sendResetEmail: 'Send Reset E-Mail',
     },
     validation: {
+        aaguid: 'Invalid AAGUID',
         css: 'Invalid CSS Value',
         origin: 'Invalid Origin',
         uri: 'Invalid URI',

--- a/frontend/src/i18n/admin/fr.ts
+++ b/frontend/src/i18n/admin/fr.ts
@@ -41,6 +41,8 @@ export let I18nAdminFr: I18nAdmin = {
         size: 'Taille',
     },
     clients: {
+        allowedAaguids: 'AAGUID autorisés',
+        descAllowedAaguids: `Liste d'autorisation facultative des AAGUID d'authentificateurs (forme UUID canonique) acceptés pour les sessions attestées par le matériel avec ce client. Une liste vide n'applique aucune restriction d'AAGUID.`,
         allowedResources: 'Ressources autorisées',
         defaultAud: 'Audiences par défaut',
         descAllowedResources: `Indicateurs de ressources RFC 8707 optionnels que ce client peut demander. Une liste vide rejette tout paramètre 'resource' avec 'invalid_target'.`,
@@ -562,6 +564,7 @@ export let I18nAdminFr: I18nAdmin = {
         sendResetEmail: 'Envoyer un e-mail de réinitialisation',
     },
     validation: {
+        aaguid: 'AAGUID invalide',
         css: 'Valeur CSS invalide',
         origin: 'Origine invalide',
         uri: 'URI invalide',

--- a/frontend/src/i18n/admin/interface.ts
+++ b/frontend/src/i18n/admin/interface.ts
@@ -60,6 +60,8 @@ export interface I18nAdmin {
         defaultAud: string;
         descAllowedResources: string;
         descDefaultAud: string;
+        allowedAaguids: string;
+        descAllowedAaguids: string;
         descGroupPrefix: string;
         descName: string;
         descOrigin: string;
@@ -455,6 +457,7 @@ export interface I18nAdmin {
         sendResetEmail: string;
     };
     validation: {
+        aaguid: string;
         css: string;
         origin: string;
         uri: string;

--- a/frontend/src/i18n/admin/ko.ts
+++ b/frontend/src/i18n/admin/ko.ts
@@ -36,6 +36,8 @@ export let I18nAdminKo: I18nAdmin = {
         size: 'Size',
     },
     clients: {
+        allowedAaguids: '허용된 AAGUID',
+        descAllowedAaguids: `이 클라이언트와의 하드웨어 증명 세션에 허용되는 인증자 AAGUID(표준 UUID 형식)의 선택적 허용 목록입니다. 목록이 비어 있으면 AAGUID 제한이 적용되지 않습니다.`,
         allowedResources: '허용된 리소스',
         defaultAud: '기본 대상(Audience)',
         descAllowedResources: `이 클라이언트가 요청할 수 있는 선택적 RFC 8707 리소스 인디케이터입니다. 목록이 비어 있으면 모든 'resource' 요청 파라미터를 'invalid_target'으로 거부합니다.`,
@@ -517,6 +519,7 @@ export let I18nAdminKo: I18nAdmin = {
         sendResetEmail: '재설정 이메일 보내기',
     },
     validation: {
+        aaguid: '잘못된 AAGUID',
         css: '비정상적인 CSS',
         origin: '비정상적인 오리진',
         uri: '비정상적인 URI',

--- a/frontend/src/i18n/admin/nb.ts
+++ b/frontend/src/i18n/admin/nb.ts
@@ -39,6 +39,8 @@ export let I18nAdminNb: I18nAdmin = {
         size: 'Størrelse',
     },
     clients: {
+        allowedAaguids: 'Tillatte AAGUID-er',
+        descAllowedAaguids: `Valgfri tillatelsesliste over autentiserings-AAGUID-er (kanonisk UUID-form) som godtas for maskinvareattesterte økter med denne klienten. En tom liste gir ingen AAGUID-begrensning.`,
         allowedResources: 'Tillatte ressurser',
         defaultAud: 'Standard-mottakere (aud)',
         descAllowedResources: `Valgfrie RFC 8707 ressursindikatorer denne klienten kan be om. En tom liste avviser enhver 'resource'-parameter med 'invalid_target'.`,
@@ -501,6 +503,7 @@ export let I18nAdminNb: I18nAdmin = {
         sendResetEmail: 'Send e-post for tilbakestilling',
     },
     validation: {
+        aaguid: 'Ugyldig AAGUID',
         css: 'Gyldig CSS-verdi',
         origin: 'Gyldig origin',
         uri: 'Gyldig URI',

--- a/frontend/src/i18n/admin/nl.ts
+++ b/frontend/src/i18n/admin/nl.ts
@@ -40,6 +40,8 @@ export let I18nAdminNl: I18nAdmin = {
         size: 'Grootte',
     },
     clients: {
+        allowedAaguids: 'Toegestane AAGUIDs',
+        descAllowedAaguids: `Optionele acceptatielijst van authenticator-AAGUIDs (canonieke UUID-vorm) die worden geaccepteerd voor hardware-geattesteerde sessies met deze client. Een lege lijst past geen AAGUID-beperking toe.`,
         allowedResources: 'Toegestane resources',
         defaultAud: 'Standaard audiences',
         descAllowedResources: `Optionele RFC 8707 resource-indicatoren die deze client mag opvragen. Een lege lijst weigert elke 'resource'-parameter met 'invalid_target'.`,
@@ -548,6 +550,7 @@ export let I18nAdminNl: I18nAdmin = {
         sendResetEmail: 'Reset e-mail versturen',
     },
     validation: {
+        aaguid: 'Ongeldige AAGUID',
         css: 'Ongeldige CSS-waarde',
         origin: 'Ongeldige origin',
         uri: 'Ongeldige URI',

--- a/frontend/src/i18n/admin/ru.ts
+++ b/frontend/src/i18n/admin/ru.ts
@@ -40,6 +40,8 @@ export let I18nAdminRu: I18nAdmin = {
         size: 'Размер',
     },
     clients: {
+        allowedAaguids: 'Разрешённые AAGUID',
+        descAllowedAaguids: `Необязательный список разрешённых AAGUID аутентификаторов (в канонической форме UUID), принимаемых для сеансов с аппаратной аттестацией для этого клиента. Пустой список не применяет ограничения по AAGUID.`,
         allowedResources: 'Разрешённые ресурсы',
         defaultAud: 'Аудитории по умолчанию',
         descAllowedResources: `Необязательные индикаторы ресурсов RFC 8707, которые может запрашивать этот клиент. Пустой список отклоняет любой параметр 'resource' с ошибкой 'invalid_target'.`,
@@ -539,6 +541,7 @@ export let I18nAdminRu: I18nAdmin = {
         sendResetEmail: 'Отправить письмо для сброса',
     },
     validation: {
+        aaguid: 'Недопустимый AAGUID',
         css: 'Недопустимое CSS-значение',
         origin: 'Недопустимый источник',
         uri: 'Недопустимый URI',

--- a/frontend/src/i18n/admin/uk.ts
+++ b/frontend/src/i18n/admin/uk.ts
@@ -39,6 +39,8 @@ export let I18nAdminUk: I18nAdmin = {
         size: 'Розмір',
     },
     clients: {
+        allowedAaguids: 'Дозволені AAGUID',
+        descAllowedAaguids: `Необов'язковий список дозволених AAGUID автентифікаторів (у канонічній формі UUID), які приймаються для сеансів з апаратною атестацією для цього клієнта. Порожній список не застосовує обмеження за AAGUID.`,
         allowedResources: 'Дозволені ресурси',
         defaultAud: 'Аудиторії за замовчуванням',
         descAllowedResources: `Необов'язкові індикатори ресурсів RFC 8707, які може запитувати цей клієнт. Порожній список відхиляє будь-який параметр 'resource' з помилкою 'invalid_target'.`,
@@ -541,6 +543,7 @@ export let I18nAdminUk: I18nAdmin = {
         sendResetEmail: 'Надіслати лист для відновлення',
     },
     validation: {
+        aaguid: 'Недійсний AAGUID',
         css: 'Некоректне значення CSS',
         origin: 'Некоректний Origin',
         uri: 'Некоректний URI',

--- a/frontend/src/i18n/admin/zh.ts
+++ b/frontend/src/i18n/admin/zh.ts
@@ -37,6 +37,8 @@ export let I18nAdminZh: I18nAdmin = {
         size: '大小',
     },
     clients: {
+        allowedAaguids: '允许的 AAGUID',
+        descAllowedAaguids: `此客户端进行硬件证明会话时接受的验证器 AAGUID（规范 UUID 形式）的可选允许列表。空列表则不应用任何 AAGUID 限制。`,
         allowedResources: '允许的资源',
         defaultAud: '默认受众 (aud)',
         descAllowedResources: `此客户端可以请求的可选 RFC 8707 资源指示符。空列表将以 'invalid_target' 拒绝任何 'resource' 请求参数。`,
@@ -508,6 +510,7 @@ export let I18nAdminZh: I18nAdmin = {
         sendResetEmail: '发送重置邮件',
     },
     validation: {
+        aaguid: '无效的 AAGUID',
         css: '无效的CSS值',
         origin: '无效的来源',
         uri: '无效的URI',

--- a/frontend/src/lib/admin/clients/ClientConfig.svelte
+++ b/frontend/src/lib/admin/clients/ClientConfig.svelte
@@ -8,6 +8,7 @@
     import Form from '$lib5/form/Form.svelte';
     import LabeledValue from '$lib5/LabeledValue.svelte';
     import {
+        PATTERN_AAGUID,
         PATTERN_CLIENT_NAME,
         PATTERN_CONTACT,
         PATTERN_GROUP,
@@ -69,6 +70,9 @@
         client.allowed_resources ? Array.from(client.allowed_resources) : [],
     );
     let defaultAud: string[] = $state(client.default_aud ? Array.from(client.default_aud) : []);
+    let allowedAaguids: string[] = $state(
+        client.allowed_aaguids ? Array.from(client.allowed_aaguids) : [],
+    );
 
     let scimEnabled = $state(client.scim !== undefined);
     let scim: ScimClientRequestResponse = $state({
@@ -137,6 +141,7 @@
             origins = client.allowed_origins ? Array.from(client.allowed_origins) : [];
             allowedResources = client.allowed_resources ? Array.from(client.allowed_resources) : [];
             defaultAud = client.default_aud ? Array.from(client.default_aud) : [];
+            allowedAaguids = client.allowed_aaguids ? Array.from(client.allowed_aaguids) : [];
             redirectURIs = Array.from(client.redirect_uris);
             postLogoutRedirectURIs = client.post_logout_redirect_uris
                 ? Array.from(client.post_logout_redirect_uris)
@@ -235,6 +240,7 @@
             claims_at_root: claimsAtRoot,
             allowed_resources: allowedResources.length > 0 ? allowedResources : undefined,
             default_aud: defaultAud.length > 0 ? defaultAud : undefined,
+            allowed_aaguids: allowedAaguids.length > 0 ? allowedAaguids : undefined,
         };
 
         if (flows.authorizationCode) {
@@ -413,6 +419,16 @@
             label={ta.clients.defaultAud}
             errMsg={ta.validation.uri}
             pattern={PATTERN_URI}
+        />
+
+        <div style:height=".5rem"></div>
+        <p class="mb-0"><b>Hardware Attestation</b></p>
+        <p class="desc">{ta.clients.descAllowedAaguids}</p>
+        <InputTags
+            bind:values={allowedAaguids}
+            label={ta.clients.allowedAaguids}
+            errMsg={ta.validation.aaguid}
+            pattern={PATTERN_AAGUID}
         />
 
         <div style:height=".5rem"></div>

--- a/frontend/src/utils/patterns.ts
+++ b/frontend/src/utils/patterns.ts
@@ -1,3 +1,5 @@
+export const PATTERN_AAGUID =
+    '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$';
 export const PATTERN_ALNUM = '^[a-zA-Z0-9]*$';
 // export const PATTERN_ALNUM_64 = '^[a-zA-Z0-9]{64}$';
 export const PATTERN_ATPROTO_ID =

--- a/migrations/hiqlite/32_client_allowed_aaguids.sql
+++ b/migrations/hiqlite/32_client_allowed_aaguids.sql
@@ -1,0 +1,2 @@
+ALTER TABLE clients
+    ADD allowed_aaguids TEXT;

--- a/migrations/postgres/V27__client_allowed_aaguids.sql
+++ b/migrations/postgres/V27__client_allowed_aaguids.sql
@@ -1,0 +1,2 @@
+ALTER TABLE clients
+    ADD allowed_aaguids VARCHAR;

--- a/src/api_types/src/clients.rs
+++ b/src/api_types/src/clients.rs
@@ -216,6 +216,13 @@ pub struct UpdateClientRequest {
     /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%@]+$>`
     #[validate(custom(function = "validate_vec_uri"))]
     pub default_aud: Option<Vec<String>>,
+    /// Allow-list of authenticator AAGUIDs (canonical dashed UUID form) accepted for
+    /// hardware-attested sessions with this client. An empty / missing list means no
+    /// AAGUID restriction.
+    ///
+    /// Validation: `Vec<^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$>`
+    #[validate(custom(function = "validate_vec_aaguid"))]
+    pub allowed_aaguids: Option<Vec<String>>,
     #[validate(nested)]
     pub scim: Option<ScimClientRequestResponse>,
 }
@@ -280,6 +287,8 @@ pub struct ClientResponse {
     pub allowed_resources: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_aud: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_aaguids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scim: Option<ScimClientRequestResponse>,
 }

--- a/src/api_types/src/cust_validation.rs
+++ b/src/api_types/src/cust_validation.rs
@@ -1,10 +1,32 @@
 use rauthy_common::constants::CLIENT_CLAIMS_MAX_LEN;
 use rauthy_common::regex::{
-    RE_ATTR, RE_CODE_CHALLENGE_METHOD, RE_CONTACT, RE_GRANT_TYPES, RE_GROUPS, RE_LINUX_HOSTNAME,
-    RE_ORIGIN, RE_ROLES_SCOPES, RE_URI,
+    RE_AAGUID, RE_ATTR, RE_CODE_CHALLENGE_METHOD, RE_CONTACT, RE_GRANT_TYPES, RE_GROUPS,
+    RE_LINUX_HOSTNAME, RE_ORIGIN, RE_ROLES_SCOPES, RE_URI,
 };
 use std::borrow::Cow;
 use validator::ValidationError;
+
+#[inline]
+pub fn validate_vec_aaguid(value: &[String]) -> Result<(), ValidationError> {
+    let mut err = None;
+
+    if value.is_empty() {
+        err = Some("'allowed_aaguids' cannot be empty when provided");
+    } else {
+        value.iter().for_each(|v| {
+            if !RE_AAGUID.is_match(v) {
+                err = Some(
+                    "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                );
+            }
+        });
+    }
+
+    if let Some(e) = err {
+        return Err(ValidationError::new(e));
+    }
+    Ok(())
+}
 
 #[inline]
 pub fn validate_vec_attr(value: &[String]) -> Result<(), ValidationError> {

--- a/src/bin/tests/handler_auth.rs
+++ b/src/bin/tests/handler_auth.rs
@@ -302,6 +302,7 @@ async fn test_authorization_code_flow() -> Result<(), Box<dyn Error>> {
         claims_at_root: false,
         allowed_resources: None,
         default_aud: None,
+        allowed_aaguids: None,
         scim: None,
     };
     let url_client = format!("{}/clients/{}", backend_url, CLIENT_ID);

--- a/src/bin/tests/handler_scopes.rs
+++ b/src/bin/tests/handler_scopes.rs
@@ -82,6 +82,7 @@ async fn test_scopes() -> Result<(), Box<dyn Error>> {
         claims_at_root: false,
         allowed_resources: None,
         default_aud: None,
+        allowed_aaguids: None,
         scim: None,
     };
     let res = client

--- a/src/bin/tests/zza_handler_cust_attrs.rs
+++ b/src/bin/tests/zza_handler_cust_attrs.rs
@@ -135,6 +135,7 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         claims_at_root: false,
         allowed_resources: None,
         default_aud: None,
+        allowed_aaguids: None,
         scim: None,
     };
     let res = client

--- a/src/bin/tests/zzd_handler_clients.rs
+++ b/src/bin/tests/zzd_handler_clients.rs
@@ -68,6 +68,7 @@ async fn put_client_claims(
         claims_at_root,
         allowed_resources: None,
         default_aud: None,
+        allowed_aaguids: None,
         scim: None,
     };
 
@@ -211,6 +212,7 @@ async fn test_clients() -> Result<(), Box<dyn Error>> {
         claims_at_root: false,
         allowed_resources: None,
         default_aud: None,
+        allowed_aaguids: None,
         scim: None,
     };
 

--- a/src/bin/tests/zzf_handler_resource_indicators.rs
+++ b/src/bin/tests/zzf_handler_resource_indicators.rs
@@ -52,6 +52,7 @@ fn base_update() -> UpdateClientRequest {
         claims_at_root: false,
         allowed_resources: None,
         default_aud: None,
+        allowed_aaguids: None,
         scim: None,
     }
 }

--- a/src/bin/tests/zzg_handler_allowed_aaguids.rs
+++ b/src/bin/tests/zzg_handler_allowed_aaguids.rs
@@ -1,0 +1,125 @@
+use crate::common::{get_auth_headers, get_backend_url};
+use pretty_assertions::assert_eq;
+use rauthy_api_types::clients::{ClientResponse, NewClientRequest, UpdateClientRequest};
+use rauthy_api_types::oidc::JwkKeyPairAlg;
+use std::error::Error;
+
+mod common;
+
+const ID: &str = "aaguid_test";
+// Two well-formed canonical (dashed) AAGUIDs. Any valid UUID round-trips here: this slice
+// only stores and surfaces the allow-list, enforcement at the WebAuthn ceremony is a
+// planned follow-up, so the values need not map to a real authenticator.
+const AAGUID_A: &str = "ee882879-721c-4913-9775-3dfcce97072a";
+const AAGUID_B: &str = "d8522d9f-575b-4866-88a9-ba99fa02f35b";
+
+fn base_update() -> UpdateClientRequest {
+    UpdateClientRequest {
+        name: Some("AAGUID Test".to_string()),
+        confidential: true,
+        redirect_uris: vec!["http://localhost/callback".to_string()],
+        post_logout_redirect_uris: None,
+        allowed_origins: None,
+        enabled: true,
+        flows_enabled: vec!["authorization_code".to_string()],
+        access_token_alg: JwkKeyPairAlg::EdDSA,
+        id_token_alg: JwkKeyPairAlg::EdDSA,
+        auth_code_lifetime: 60,
+        access_token_lifetime: 300,
+        scopes: vec!["openid".to_string()],
+        default_scopes: vec!["openid".to_string()],
+        challenges: Some(vec!["S256".to_string()]),
+        force_mfa: false,
+        client_uri: None,
+        contacts: None,
+        backchannel_logout_uri: None,
+        restrict_group_prefix: None,
+        claims: None,
+        claims_at_root: false,
+        allowed_resources: None,
+        default_aud: None,
+        allowed_aaguids: None,
+        scim: None,
+    }
+}
+
+/// End-to-end coverage for the per-client `allowed_aaguids` allow-list: the CSV round-trip
+/// through create -> update -> read (both the `PUT` response and a fresh `GET`), that
+/// clearing the list persists as absent, and that a malformed AAGUID is rejected with 400
+/// by `validate_vec_aaguid`.
+#[tokio::test]
+async fn test_allowed_aaguids() -> Result<(), Box<dyn Error>> {
+    let auth_headers = get_auth_headers().await?;
+    let backend_url = get_backend_url();
+    let http = reqwest::Client::new();
+
+    // create a confidential client
+    let new_client = NewClientRequest {
+        id: ID.to_string(),
+        secret: None,
+        name: Some("AAGUID Test".to_string()),
+        confidential: true,
+        redirect_uris: vec!["http://localhost/callback".to_string()],
+        post_logout_redirect_uris: None,
+    };
+    let res = http
+        .post(format!("{backend_url}/clients"))
+        .headers(auth_headers.clone())
+        .json(&new_client)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+
+    // (1) set a two-entry allow-list; the PUT response echoes it back in order
+    let mut upd = base_update();
+    upd.allowed_aaguids = Some(vec![AAGUID_A.to_string(), AAGUID_B.to_string()]);
+    let res = http
+        .put(format!("{backend_url}/clients/{ID}"))
+        .headers(auth_headers.clone())
+        .json(&upd)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let resp = res.json::<ClientResponse>().await?;
+    assert_eq!(
+        resp.allowed_aaguids,
+        Some(vec![AAGUID_A.to_string(), AAGUID_B.to_string()])
+    );
+
+    // (2) a fresh GET returns the same persisted allow-list (proves it survived storage)
+    let res = http
+        .get(format!("{backend_url}/clients/{ID}"))
+        .headers(auth_headers.clone())
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let resp = res.json::<ClientResponse>().await?;
+    assert_eq!(
+        resp.allowed_aaguids,
+        Some(vec![AAGUID_A.to_string(), AAGUID_B.to_string()])
+    );
+
+    // (3) clearing the list round-trips as absent
+    let res = http
+        .put(format!("{backend_url}/clients/{ID}"))
+        .headers(auth_headers.clone())
+        .json(&base_update())
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let resp = res.json::<ClientResponse>().await?;
+    assert_eq!(resp.allowed_aaguids, None);
+
+    // (4) a malformed AAGUID is rejected with 400 by `validate_vec_aaguid`
+    let mut upd = base_update();
+    upd.allowed_aaguids = Some(vec!["not-a-uuid".to_string()]);
+    let res = http
+        .put(format!("{backend_url}/clients/{ID}"))
+        .headers(auth_headers.clone())
+        .json(&upd)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 400);
+
+    Ok(())
+}

--- a/src/common/src/regex.rs
+++ b/src/common/src/regex.rs
@@ -1,6 +1,10 @@
 use regex::Regex;
 use std::sync::{LazyLock, OnceLock};
 
+pub static RE_AAGUID: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+        .unwrap()
+});
 pub static RE_ALNUM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9]+$").unwrap());
 pub static RE_ALNUM_48: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9]{48}$").unwrap());

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -43,8 +43,8 @@ SET name = $1, enabled = $2, confidential = $3, secret = $4, secret_kid = $5, re
     id_token_alg = $11, auth_code_lifetime = $12, access_token_lifetime = $13, scopes = $14,
     default_scopes = $15, challenge = $16, force_mfa= $17, client_uri = $18, contacts = $19,
     backchannel_logout_uri = $20, restrict_group_prefix = $21, claims = $22,
-    claims_at_root = $23, allowed_resources = $24, default_aud = $25
-WHERE id = $26"#;
+    claims_at_root = $23, allowed_resources = $24, default_aud = $25, allowed_aaguids = $26
+WHERE id = $27"#;
 
 /**
 # OIDC Client
@@ -94,6 +94,9 @@ pub struct Client {
     pub allowed_resources: Option<String>,
     /// Audiences always added to this client's tokens, independent of any request (CSV).
     pub default_aud: Option<String>,
+    /// Allow-list of authenticator AAGUIDs (CSV) accepted for hardware-attested
+    /// sessions with this client. Empty / `None` means no AAGUID restriction.
+    pub allowed_aaguids: Option<String>,
 }
 
 impl Debug for Client {
@@ -105,7 +108,8 @@ impl Debug for Client {
         flows_enabled: {}, access_token_alg: {}, id_token_alg: {}, auth_code_lifetime: {}, \
         access_token_lifetime: {}, scopes: {}, default_scopes: {}, challenge: {:?}, force_mfa: {}, \
         client_uri: {:?}, contacts: {:?}, backchannel_logout_uri: {:?}, restrict_group_prefix: {:?}, \
-        claims: {:?}, claims_at_root: {}, allowed_resources: {:?}, default_aud: {:?} \
+        claims: {:?}, claims_at_root: {}, allowed_resources: {:?}, default_aud: {:?}, \
+        allowed_aaguids: {:?} \
         }}",
             self.id,
             self.name,
@@ -131,6 +135,7 @@ impl Debug for Client {
             self.claims_at_root,
             self.allowed_resources,
             self.default_aud,
+            self.allowed_aaguids,
         )
     }
 }
@@ -159,9 +164,9 @@ INSERT INTO clients (id, name, enabled, confidential, secret, secret_kid, redire
 post_logout_redirect_uris, allowed_origins, flows_enabled, access_token_alg, id_token_alg,
 auth_code_lifetime, access_token_lifetime, scopes, default_scopes, challenge, force_mfa,
 client_uri, contacts, backchannel_logout_uri, restrict_group_prefix, allowed_resources,
-default_aud)
+default_aud, allowed_aaguids)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17,
-$18, $19, $20, $21, $22, $23, $24)"#;
+$18, $19, $20, $21, $22, $23, $24, $25)"#;
 
         if is_hiqlite() {
             DB::hql()
@@ -191,7 +196,8 @@ $18, $19, $20, $21, $22, $23, $24)"#;
                         &client.backchannel_logout_uri,
                         &client.restrict_group_prefix,
                         &client.allowed_resources,
-                        &client.default_aud
+                        &client.default_aud,
+                        &client.allowed_aaguids
                     ),
                 )
                 .await?;
@@ -223,6 +229,7 @@ $18, $19, $20, $21, $22, $23, $24)"#;
                     &client.restrict_group_prefix,
                     &client.allowed_resources,
                     &client.default_aud,
+                    &client.allowed_aaguids,
                 ],
             )
             .await?;
@@ -519,6 +526,7 @@ VALUES ($1, $2, $3, $4)"#;
             .filter(|uri| !uri.is_empty());
         let allowed_resources = self.allowed_resources.clone().filter(|r| !r.is_empty());
         let default_aud = self.default_aud.clone().filter(|a| !a.is_empty());
+        let allowed_aaguids = self.allowed_aaguids.clone().filter(|a| !a.is_empty());
 
         txn.push((
             SQL_SAVE,
@@ -548,6 +556,7 @@ VALUES ($1, $2, $3, $4)"#;
                 self.claims_at_root,
                 allowed_resources,
                 default_aud,
+                allowed_aaguids,
                 &self.id
             ),
         ));
@@ -569,6 +578,7 @@ VALUES ($1, $2, $3, $4)"#;
             .filter(|uri| !uri.is_empty());
         let allowed_resources = self.allowed_resources.clone().filter(|r| !r.is_empty());
         let default_aud = self.default_aud.clone().filter(|a| !a.is_empty());
+        let allowed_aaguids = self.allowed_aaguids.clone().filter(|a| !a.is_empty());
 
         DB::pg_txn_append(
             txn,
@@ -599,6 +609,7 @@ VALUES ($1, $2, $3, $4)"#;
                 &self.claims_at_root,
                 &allowed_resources,
                 &default_aud,
+                &allowed_aaguids,
                 &self.id,
             ],
         )
@@ -627,6 +638,7 @@ VALUES ($1, $2, $3, $4)"#;
             .filter(|uri| !uri.is_empty());
         let allowed_resources = self.allowed_resources.clone().filter(|r| !r.is_empty());
         let default_aud = self.default_aud.clone().filter(|a| !a.is_empty());
+        let allowed_aaguids = self.allowed_aaguids.clone().filter(|a| !a.is_empty());
 
         if is_hiqlite() {
             DB::hql()
@@ -658,6 +670,7 @@ VALUES ($1, $2, $3, $4)"#;
                         self.claims_at_root,
                         allowed_resources,
                         default_aud,
+                        allowed_aaguids,
                         self.id.clone()
                     ),
                 )
@@ -691,6 +704,7 @@ VALUES ($1, $2, $3, $4)"#;
                     &self.claims_at_root,
                     &allowed_resources,
                     &default_aud,
+                    &allowed_aaguids,
                     &self.id,
                 ],
             )
@@ -955,6 +969,22 @@ impl Client {
     pub fn get_default_aud(&self) -> Option<Vec<String>> {
         self.default_aud.as_ref()?;
         Some(self.default_aud_iter().map(String::from).collect())
+    }
+
+    /// Borrowed, allocation-free view of the `allowed_aaguids` CSV (empties skipped).
+    #[inline]
+    pub fn allowed_aaguids_iter(&self) -> impl Iterator<Item = &str> {
+        self.allowed_aaguids
+            .as_deref()
+            .unwrap_or_default()
+            .split(',')
+            .filter(|s| !s.is_empty())
+    }
+
+    #[inline]
+    pub fn get_allowed_aaguids(&self) -> Option<Vec<String>> {
+        self.allowed_aaguids.as_ref()?;
+        Some(self.allowed_aaguids_iter().map(String::from).collect())
     }
 
     /// Validates an RFC 8707 `resource` request value against this client's policy: it
@@ -1549,6 +1579,7 @@ impl Client {
             .and_then(|bytes| serde_json::from_slice(bytes).ok());
         let allowed_resources = self.get_allowed_resources();
         let default_aud = self.get_default_aud();
+        let allowed_aaguids = self.get_allowed_aaguids();
 
         let access_token_alg = JwkKeyPairAlg::from_str(&self.access_token_alg)
             .expect("internal JwkKeyPairAlg conversion to always succeed")
@@ -1582,6 +1613,7 @@ impl Client {
             claims_at_root: self.claims_at_root,
             allowed_resources,
             default_aud,
+            allowed_aaguids,
             scim: scim.map(|scim| ScimClientRequestResponse {
                 bearer_token: scim.bearer_token,
                 base_uri: scim.base_uri,
@@ -1637,6 +1669,7 @@ impl From<EphemeralClientRequest> for Client {
             claims_at_root: false,
             allowed_resources: value.allowed_resources.map(|r| r.join(",")),
             default_aud: None,
+            allowed_aaguids: None,
         }
     }
 }
@@ -1680,6 +1713,7 @@ impl Default for Client {
             claims_at_root: false,
             allowed_resources: None,
             default_aud: None,
+            allowed_aaguids: None,
         }
     }
 }
@@ -1929,6 +1963,7 @@ mod tests {
             claims_at_root: false,
             allowed_resources: None,
             default_aud: None,
+            allowed_aaguids: None,
         };
 
         assert_eq!(client.get_access_token_alg().unwrap(), JwkKeyPairAlg::EdDSA);
@@ -2018,6 +2053,29 @@ mod tests {
                 "batman@localhost.de".to_string(),
                 "@alfred:matrix.org".to_string(),
             ]
+        );
+
+        // allowed_aaguids: none by default, then a CSV round-trips through the iter + getter,
+        // with empty entries skipped (mirrors the `default_aud` / `allowed_resources` behavior)
+        assert!(client.get_allowed_aaguids().is_none());
+        assert_eq!(client.allowed_aaguids_iter().count(), 0);
+        client.allowed_aaguids = Some(
+            "01020304-0506-0708-0a0b-0c0d0e0f1011,,fa2b99dc-9e39-4257-8f92-a9930c7635ee"
+                .to_string(),
+        );
+        assert_eq!(
+            client.allowed_aaguids_iter().collect::<Vec<_>>(),
+            vec![
+                "01020304-0506-0708-0a0b-0c0d0e0f1011",
+                "fa2b99dc-9e39-4257-8f92-a9930c7635ee",
+            ]
+        );
+        assert_eq!(
+            client.get_allowed_aaguids(),
+            Some(vec![
+                "01020304-0506-0708-0a0b-0c0d0e0f1011".to_string(),
+                "fa2b99dc-9e39-4257-8f92-a9930c7635ee".to_string(),
+            ])
         );
 
         // validate origin

--- a/src/data/src/migration/anti_lockout.rs
+++ b/src/data/src/migration/anti_lockout.rs
@@ -64,6 +64,7 @@ pub async fn anti_lockout() -> Result<(), ErrorResponse> {
         claims_at_root: false,
         allowed_resources: None,
         default_aud: None,
+        allowed_aaguids: None,
     };
     debug!(client = ?rauthy, "Rauthy client anti-lockout");
 

--- a/src/data/src/migration/inserts.rs
+++ b/src/data/src/migration/inserts.rs
@@ -235,10 +235,10 @@ INSERT INTO clients
 allowed_origins, flows_enabled, access_token_alg, id_token_alg, auth_code_lifetime,
 access_token_lifetime, scopes, default_scopes, challenge, force_mfa, client_uri, contacts,
 backchannel_logout_uri, restrict_group_prefix, claims, claims_at_root, allowed_resources,
-default_aud)
+default_aud, allowed_aaguids)
 VALUES
 ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,
-$22, $23, $24, $25, $26)"#;
+$22, $23, $24, $25, $26, $27)"#;
 
     if is_hiqlite() {
         DB::hql().execute(sql_1, params!()).await?;
@@ -273,7 +273,8 @@ $22, $23, $24, $25, $26)"#;
                         b.claims,
                         b.claims_at_root,
                         b.allowed_resources,
-                        b.default_aud
+                        b.default_aud,
+                        b.allowed_aaguids
                     ),
                 )
                 .await?;
@@ -310,6 +311,7 @@ $22, $23, $24, $25, $26)"#;
                     &b.claims_at_root,
                     &b.allowed_resources,
                     &b.default_aud,
+                    &b.allowed_aaguids,
                 ],
             )
             .await?;

--- a/src/service/src/client.rs
+++ b/src/service/src/client.rs
@@ -65,6 +65,10 @@ pub async fn update_client(
         .default_aud
         .map(|a| a.join(","))
         .filter(|a| !a.is_empty());
+    client.allowed_aaguids = client_req
+        .allowed_aaguids
+        .map(|a| a.join(","))
+        .filter(|a| !a.is_empty());
 
     client.save().await?;
 


### PR DESCRIPTION
## What

Adds an optional per-client allow-list of authenticator AAGUIDs
(`Client.allowed_aaguids`, stored as a CSV of canonical dashed UUIDs), surfaced through
the client API and the Admin UI. An empty or missing list applies no restriction, so
existing clients are unaffected.

This is the storage and management layer only. It mirrors, field for field, the
per-client CSV pattern introduced in #1608 (`allowed_resources` / `default_aud`): one
nullable column, an api_types field on the request and response, a service-layer
`Vec<String>` to CSV mapping, paired hiqlite + postgres migrations, and an Admin UI list
editor with i18n.

## Why

Operators who run their own attestation policy want to say "this client only accepts
specific authenticator models." This PR lands the generic, self-contained piece of that:
a place to store and manage the allow-list per client. It is useful on its own (it is the
data model an operator configures), and it is the first of the three separable pieces in
the attestation design proposed in #1618. It intentionally carries no WebAuthn-ceremony
behavior yet: capturing an AAGUID at registration and enforcing this list at attestation
time are the planned follow-ups (P2/P3 in #1618), so nothing here changes token issuance
or the login flow.

## Changes

Backend:
- `Client.allowed_aaguids: Option<String>` (CSV) with `allowed_aaguids_iter()` /
  `get_allowed_aaguids()` helpers, wired through every SQL site (save/create/update),
  the `Debug` impl, `Default`, the DB-to-DB migration insert, the anti-lockout literal,
  and the `ClientResponse` mapping.
- `service/client.rs`: request `Vec<String>` to CSV mapping (same shape as
  `allowed_resources`).
- api_types: `allowed_aaguids` on `UpdateClientRequest` (validated) and `ClientResponse`.
- Validation: `validate_vec_aaguid` + `RE_AAGUID` (canonical dashed UUID), so a malformed
  value is rejected with 400 at the API boundary.
- Migrations: `hiqlite/32_client_allowed_aaguids.sql`,
  `postgres/V27__client_allowed_aaguids.sql` (each `ADD COLUMN allowed_aaguids`, nullable).

Frontend:
- `ClientConfig.svelte`: a "Hardware Attestation" AAGUID list editor
  (state init, `$effect` reset, submit payload), plus `PATTERN_AAGUID`.
- api types + i18n strings (`allowedAaguids`, `descAllowedAaguids`, `validation.aaguid`)
  across all admin locales.

Tests:
- `src/bin/tests/zzg_handler_allowed_aaguids.rs`: create a client, set a two-entry
  allow-list, assert it round-trips on the PUT response and a fresh GET, assert clearing
  it persists as absent, and assert a malformed AAGUID is rejected with 400. Runs on both
  hiqlite and postgres.
- Updated the existing client-request test fixtures for the new field.

Docs: `CHANGELOG.md` entry.

## Notes

- Opt-in and backward compatible: the new column is nullable; existing rows read as
  `NULL` (no restriction), so behavior is unchanged after upgrade.
- No new dependencies.
