### PR TITLE
Feat: RFC 8252 + relaxed client name regex

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -77,6 +77,25 @@ userinfo_strict = true
 # overwritten by: DANGER_DISABLE_INTROSPECT_AUTH
 danger_disable_introspect_auth = false
 
+# If set to `true`, loopback redirect URIs (to `localhost`, `127.0.0.1`
+# or `[::1]`) will match on any port, as required by RFC 8252 section 7.3
+# for native / CLI apps that bind an ephemeral loopback port at runtime.
+# Both the port-less form and an explicit `*` wildcard are accepted for
+# `localhost` when this is enabled.
+#
+# This only applies to dynamic and ephemeral clients. Static clients
+# always require an exact match or an explicit `*` wildcard, even with
+# this option set, because an admin has full control over their config.
+#
+# Only enable this if you need it, e.g. an MCP client whose loopback
+# redirect port is not known in advance and cannot be pre-registered.
+# It is `false` by default to keep redirect matching as strict as
+# possible out of the box.
+#
+# default: false
+# overwritten by: RFC_8252_ENABLE
+rfc_8252_enable = false
+
 # By default, `refresh_token`s will have an `nbf` claim, making them
 # valid at `access_token_lifetime - 60 seconds`. Any usage before
 # this time will result in invalidation of not only the token itself,

--- a/src/common/src/regex.rs
+++ b/src/common/src/regex.rs
@@ -27,7 +27,7 @@ pub static RE_CLIENT_ID: LazyLock<Regex> =
 pub static RE_CLIENT_ID_STRICT: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._\-]{2,256}$").unwrap());
 pub static RE_CLIENT_NAME: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[a-zA-Z0-9À-ɏ-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{2,128}$").unwrap()
+    Regex::new(r"^[a-zA-Z0-9À-ɏ()-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{2,128}$").unwrap()
 });
 pub static RE_CODE_CHALLENGE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9-._~]{43,128}$").unwrap());

--- a/src/common/src/regex.rs
+++ b/src/common/src/regex.rs
@@ -27,7 +27,7 @@ pub static RE_CLIENT_ID: LazyLock<Regex> =
 pub static RE_CLIENT_ID_STRICT: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._\-]{2,256}$").unwrap());
 pub static RE_CLIENT_NAME: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[a-zA-Z0-9À-ɏ()-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{2,128}$").unwrap()
+    Regex::new(r"^[a-zA-Z0-9À-ɏ()\-\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{2,128}$").unwrap()
 });
 pub static RE_CODE_CHALLENGE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9-._~]{43,128}$").unwrap());
@@ -82,3 +82,19 @@ pub static RE_TOKEN_ENDPOINT_AUTH_METHOD: LazyLock<Regex> =
 pub static RE_ATPROTO_HANDLE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]|([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)$").unwrap()
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_re_client_name() {
+        // the regex is built lazily, so it is only ever compiled on first use --
+        // this forces it and would catch a character class that does not parse
+        assert!(RE_CLIENT_NAME.is_match("Claude Code (nks)"));
+        assert!(RE_CLIENT_NAME.is_match("My Client"));
+        assert!(RE_CLIENT_NAME.is_match("client-name"));
+        assert!(RE_CLIENT_NAME.is_match("クライアント"));
+        assert!(!RE_CLIENT_NAME.is_match("<script>"));
+    }
+}

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -1290,9 +1290,14 @@ impl Client {
 
     #[inline]
     pub fn validate_redirect_uri(&self, redirect_uri: &str) -> Result<(), ErrorResponse> {
+        // RFC 8252 loopback any-port matching — opt-in via access.rfc_8252_enable,
+        // and only for dynamic and ephemeral clients (never static ones).
+        let loopback = RauthyConfig::get().vars.access.rfc_8252_enable
+            && (self.is_dynamic() || self.is_ephemeral());
         let has_any = self.get_redirect_uris().iter().any(|uri| {
             (uri.ends_with('*') && redirect_uri.starts_with(uri.split_once('*').unwrap().0))
                 || uri.as_str().eq(redirect_uri)
+                || (loopback && loopback_redirect_match(uri, redirect_uri))
         });
 
         if has_any {
@@ -1484,6 +1489,30 @@ impl Client {
         } else {
             Ok(())
         }
+    }
+}
+
+/// RFC 8252 section 7.3: for a loopback redirect URI, the authorization
+/// server MUST allow any port chosen by the client at request time. Native
+/// apps (and CLI OAuth clients) bind an ephemeral loopback port, so a
+/// registered `http://127.0.0.1/cb` must match a requested
+/// `http://127.0.0.1:52345/cb`. Everything except the port must be equal,
+/// and both sides must be loopback hosts. Gated behind access.rfc_8252_enable
+/// and applied to dynamic and ephemeral clients only (see `validate_redirect_uri`).
+fn loopback_redirect_match(registered: &str, requested: &str) -> bool {
+    fn parts(u: &str) -> Option<(String, String, String)> {
+        let url = Url::parse(u).ok()?;
+        let host = url.host_str()?.to_string();
+        Some((url.scheme().to_string(), host, url.path().to_string()))
+    }
+    fn is_loopback(host: &str) -> bool {
+        host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1"
+    }
+    match (parts(registered), parts(requested)) {
+        (Some((rs, rh, rp)), Some((qs, qh, qp))) => {
+            is_loopback(&rh) && is_loopback(&qh) && rs == qs && rh == qh && rp == qp
+        }
+        _ => false,
     }
 }
 

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -302,6 +302,7 @@ impl Default for Vars {
             access: VarsAccess {
                 userinfo_strict: true,
                 danger_disable_introspect_auth: false,
+                rfc_8252_enable: false,
                 disable_refresh_token_nbf: false,
                 sec_header_block: true,
                 session_validate_ip: true,
@@ -1234,6 +1235,9 @@ impl Vars {
             "DANGER_DISABLE_INTROSPECT_AUTH",
         ) {
             self.access.danger_disable_introspect_auth = v;
+        }
+        if let Some(v) = t_bool(&mut table, "access", "rfc_8252_enable", "RFC_8252_ENABLE") {
+            self.access.rfc_8252_enable = v;
         }
         if let Some(v) = t_bool(
             &mut table,
@@ -3638,6 +3642,7 @@ pub struct VarsDev {
 pub struct VarsAccess {
     pub userinfo_strict: bool,
     pub danger_disable_introspect_auth: bool,
+    pub rfc_8252_enable: bool,
     pub disable_refresh_token_nbf: bool,
     pub sec_header_block: bool,
     pub session_validate_ip: bool,

--- a/src/service/src/oidc/token_info.rs
+++ b/src/service/src/oidc/token_info.rs
@@ -60,8 +60,22 @@ pub async fn get_token_info(
     })?;
 
     buf.clear();
-    let client = check_client_auth(req, client_id, &mut buf).await?;
-    let cors_header = client.get_validated_origin_header(req)?;
+    let cors_header = if RauthyConfig::get()
+        .vars
+        .access
+        .danger_disable_introspect_auth
+    {
+        // With introspection authz disabled, don't look up the token's
+        // client at all. check_client_auth resolves the token's `azp` via
+        // find_enabled_client first and only checks the flag afterwards, so
+        // an ephemeral client (never persisted) makes it 401 before the flag
+        // applies. Skipping the lookup lets a resource server introspect
+        // tokens of any client. No client means no client-scoped CORS header.
+        None
+    } else {
+        let client = check_client_auth(req, client_id, &mut buf).await?;
+        client.get_validated_origin_header(req)?
+    };
 
     Ok((info, cors_header))
 }


### PR DESCRIPTION
Four independent bugs that break standard OAuth login for MCP clients (Claude Code, opencode) when Rauthy runs on postgres. Ran into them wiring Rauthy up as the auth server for an MCP resource server; all reproduce on current main.

- client name regex rejects `()`, so a client named `Claude Code (nks)` 400s on registration
- loopback `redirect_uri` is not port-agnostic (RFC 8252 §7.3) — a registered `http://127.0.0.1/cb` never matches the requested `http://127.0.0.1:PORT/cb`, so CLI clients 400 with "Invalid redirect uri"
- `ClientDyn::update_used` binds one param to a two-param UPDATE, so the dynamic-client auth_code token exchange always 500s on postgres (hiqlite is fine)
- `danger_disable_introspect_auth` is checked after `find_enabled_client(azp)`, so introspecting a token issued to an ephemeral client 401s even with the flag on

One commit each. Happy to split into separate PRs if you prefer.