### PR TITLE
Remove `user_id` from ToS await resp

### DIFF
--- a/frontend/src/api/types/tos.ts
+++ b/frontend/src/api/types/tos.ts
@@ -20,7 +20,6 @@ export interface ToSResponse {
 
 export interface ToSAwaitLoginResponse {
     tos_await_code: string;
-    user_id: string;
     force_accept?: boolean;
 }
 

--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -99,7 +99,6 @@
 
     let email = $state(useParam('login_hint').get() || '');
     let password = $state('');
-    let userId = $state('');
     let showPasswordInput = $derived(
         needsPassword && existingMfaUser !== email && !showReset && !isAtproto,
     );
@@ -340,7 +339,6 @@
         } else if (res.status === 206) {
             // login successful, but the user needs to accept updated ToS
             let body = res.body as ToSAwaitLoginResponse;
-            userId = body.user_id;
             tosAcceptCode = body.tos_await_code;
             await fetchTos();
         } else if (res.status === 400) {
@@ -448,7 +446,6 @@
 
     async function onToSCancel() {
         password = '';
-        userId = '';
         tosAcceptCode = '';
         tos = undefined;
         isLoading = false;

--- a/frontend/src/routes/providers/callback/+page.svelte
+++ b/frontend/src/routes/providers/callback/+page.svelte
@@ -20,7 +20,6 @@
     let clientMfaForce = $state(false);
     let error = $state('');
 
-    let userId: undefined | string = $state();
     let mfaPurpose: undefined | MfaPurpose = $state();
 
     let tos: undefined | ToSLatestResponse = $state();
@@ -83,8 +82,7 @@
             // -> all good, but needs additional passkey validation
             error = '';
             let body = res.body;
-            if (body && 'user_id' in body && 'code' in body) {
-                userId = body.user_id as string;
+            if (body && 'code' in body) {
                 mfaPurpose = { Login: body.code as string };
             } else {
                 console.error('did not receive a proper WebauthnLoginResponse after HTTP200');
@@ -98,7 +96,6 @@
         } else if (res.status === 206) {
             // login successful, but the user needs to accept updated ToS
             let body = res.body as ToSAwaitLoginResponse;
-            userId = body.user_id;
             tosAcceptCode = body.tos_await_code;
             tosForceAccept = body.force_accept || false;
             await fetchTos();
@@ -161,7 +158,7 @@
 </svelte:head>
 
 <ContentCenter>
-    {#if mfaPurpose && userId}
+    {#if mfaPurpose}
         <WebauthnRequest
             purpose={mfaPurpose}
             onSuccess={onWebauthnSuccess}

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -161,7 +161,6 @@ pub async fn map_auth_step(
 
             Ok(builder.json(&ToSAwaitLoginResponse {
                 tos_await_code: res.code,
-                user_id: Some(res.user_id),
                 force_accept: (new_user_created == NewFederatedUserCreated::Yes).then_some(true),
             }))
         }

--- a/src/api_types/src/tos.rs
+++ b/src/api_types/src/tos.rs
@@ -31,7 +31,6 @@ pub struct ToSResponse {
 #[derive(Serialize, ToSchema)]
 pub struct ToSAwaitLoginResponse {
     pub tos_await_code: String,
-    pub user_id: Option<String>,
     pub force_accept: Option<bool>,
 }
 

--- a/src/data/src/entity/webauthn.rs
+++ b/src/data/src/entity/webauthn.rs
@@ -613,7 +613,6 @@ impl WebauthnAdditionalData {
                 let mut resp = HttpResponseBuilder::new(StatusCode::from_u16(206).unwrap()).json(
                     &ToSAwaitLoginResponse {
                         tos_await_code: tos_req.await_code,
-                        user_id: None,
                         force_accept: None,
                     },
                 );


### PR DESCRIPTION
We don't need the `user_id` during `TosAwait` anymore. This keeps it completely private.