### PR TITLE
feat(users): accept preferred_username on user creation

### DIFF
--- a/src/api_types/src/users.rs
+++ b/src/api_types/src/users.rs
@@ -57,6 +57,9 @@ pub struct NewUserRequest {
     /// Validation: `email`
     #[validate(email)]
     pub email: String,
+    /// Validation: `[user_values.preferred_username] -> regex_rust`
+    #[validate(regex(path = "RE_PREFERRED_USERNAME"))]
+    pub preferred_username: Option<String>,
     /// Validation: `[a-zA-Z0-9À-ÿ-'\\s]{1,32}`
     #[validate(regex(path = "*RE_USER_NAME", code = "[a-zA-Z0-9À-ɏ-'\\s]{1,32}"))]
     pub family_name: Option<String>,

--- a/src/bin/tests/handler_group_admin.rs
+++ b/src/bin/tests/handler_group_admin.rs
@@ -43,6 +43,7 @@ async fn create_user(
         given_name: Some("Test".to_string()),
         family_name: Some("User".to_string()),
         email: email.to_string(),
+        preferred_username: None,
         language: Language::En,
         roles,
         groups: Some(groups),

--- a/src/bin/tests/handler_users.rs
+++ b/src/bin/tests/handler_users.rs
@@ -35,6 +35,7 @@ async fn test_users() -> Result<(), Box<dyn Error>> {
         given_name: Some("Alfred".to_string()),
         family_name: Some("Batman".to_string()),
         email: "alfred@batcave.io".to_string(),
+        preferred_username: Some("alfredo".to_string()),
         language: Language::En,
         roles: vec![
             "admin".to_string(),
@@ -93,6 +94,11 @@ async fn test_users() -> Result<(), Box<dyn Error>> {
     assert_eq!(res.status(), 200);
     let user_by_id = res.json::<UserResponse>().await?;
     assert_eq!(user_by_id.email, "alfred@batcave.io");
+    // the preferred_username given at creation must round-trip onto the created user
+    assert_eq!(
+        user_by_id.user_values.preferred_username.as_deref(),
+        Some("alfredo")
+    );
 
     // get the new user by email
     let url_email = format!("{}/users/email/{}", get_backend_url(), alfred.email);

--- a/src/bin/tests/zzb_handler_password_policy.rs
+++ b/src/bin/tests/zzb_handler_password_policy.rs
@@ -84,6 +84,7 @@ async fn test_password_policy() -> Result<(), Box<dyn Error>> {
         given_name: Some("IT Test".to_string()),
         family_name: Some("Testy".to_string()),
         email: "alfred@batcave.io".to_string(),
+        preferred_username: None,
         language: Language::En,
         roles: vec!["user".to_string()],
         groups: None,

--- a/src/data/src/entity/users.rs
+++ b/src/data/src/entity/users.rs
@@ -46,6 +46,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::max;
 use std::default::Default;
 use std::fmt::{Debug, Formatter};
+use std::mem;
 use std::ops::Add;
 use time::OffsetDateTime;
 use tracing::{debug, error, trace};
@@ -225,15 +226,16 @@ impl User {
         Self::insert(new_user).await
     }
 
-    pub async fn create_from_new(new_user_req: NewUserRequest) -> Result<User, ErrorResponse> {
+    pub async fn create_from_new(mut new_user_req: NewUserRequest) -> Result<User, ErrorResponse> {
         // pre-uniqueness check for better UX and error handling; the DB unique index on
         // `users_values.preferred_username` is the authoritative guard (see UserValues::insert).
         if let Some(preferred_username) = &new_user_req.preferred_username {
             UserValues::validate_preferred_username_free(preferred_username.clone()).await?;
         }
 
-        let tz = new_user_req.tz.clone();
-        let preferred_username = new_user_req.preferred_username.clone();
+        // neither value is read by `from_new_user_req()`, so both can be moved out directly
+        let tz = mem::take(&mut new_user_req.tz);
+        let preferred_username = mem::take(&mut new_user_req.preferred_username);
         let new_user = User::from_new_user_req(new_user_req).await?;
         let user = User::create(new_user, None, tz.as_deref()).await?;
 

--- a/src/data/src/entity/users.rs
+++ b/src/data/src/entity/users.rs
@@ -226,23 +226,31 @@ impl User {
     }
 
     pub async fn create_from_new(new_user_req: NewUserRequest) -> Result<User, ErrorResponse> {
+        // pre-uniqueness check for better UX and error handling; the DB unique index on
+        // `users_values.preferred_username` is the authoritative guard (see UserValues::insert).
+        if let Some(preferred_username) = &new_user_req.preferred_username {
+            UserValues::validate_preferred_username_free(preferred_username.clone()).await?;
+        }
+
         let tz = new_user_req.tz.clone();
+        let preferred_username = new_user_req.preferred_username.clone();
         let new_user = User::from_new_user_req(new_user_req).await?;
         let user = User::create(new_user, None, tz.as_deref()).await?;
 
-        if tz.is_some() && tz.as_deref() != Some("UTC") && tz.as_deref() != Some("Etc/UTC") {
+        // UTC is the implicit default and is not persisted into the user values.
+        let store_tz = if tz.as_deref() != Some("UTC") && tz.as_deref() != Some("Etc/UTC") {
+            tz
+        } else {
+            None
+        };
+        if store_tz.is_some() || preferred_username.is_some() {
             UserValues::insert(
                 user.id.clone(),
                 UserValuesRequest {
-                    birthdate: None,
-                    phone: None,
-                    street: None,
-                    zip: None,
-                    city: None,
-                    country: None,
-                    tz,
+                    tz: store_tz,
+                    ..Default::default()
                 },
-                None,
+                preferred_username,
             )
             .await?;
         }


### PR DESCRIPTION
### What

`POST /users` (`NewUserRequest`) did not accept `preferred_username`, so operators could only set it with a second request after creation (as raised in #1615). This adds it to the creation payload.

### Changes

- `NewUserRequest` gains an optional `preferred_username`, validated with `RE_PREFERRED_USERNAME`, the same rule the self-registration request (`NewUserRegistrationRequest`) already uses.
- `User::create_from_new` persists it through `UserValues`, mirroring `create_from_reg`: a `validate_preferred_username_free` pre-check for a clean early error, with the existing `users_values.preferred_username` unique index as the authoritative guard. The tz-only persistence branch is generalized so a `preferred_username` (or a non-UTC tz) triggers the `UserValues` insert; UTC stays unpersisted as before.
- The update path is unchanged.

### Notes

`post_users` returns `user.into_response(None)`, so the create response body does not echo `user_values`; the value is persisted and visible on the subsequent `GET /users/{id}`, which the extended `test_users` integration test asserts.

### Tests

`cargo check --workspace --tests`, `fmt`, and `clippy` clean on the changed crates. `test_users` now creates a user with `preferred_username` and asserts it round-trips on read.

Closes #1615
