### PR TITLE
fix(users): upgrade session to MFA after passkey registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+#### Session MFA Upgrade after Passkey Registration
+
+Registering a Passkey from the Account dashboard upgrades the current session to MFA now. Before,
+`is_mfa` stayed `false` until the next login, which meant a fresh admin account that just enrolled
+its first Passkey was still rejected by `admin_force_mfa` and had to log out and back in. The
+Account dashboard also updates the MFA indicator directly after registering or deleting a Passkey
+instead of only after a manual page reload.
+
+[#1649](https://github.com/sebadob/rauthy/pull/1649)
+
 ## v0.36.0
 
 ### Breaking

--- a/frontend/src/lib/account/AccMFA.svelte
+++ b/frontend/src/lib/account/AccMFA.svelte
@@ -22,7 +22,7 @@
     import Form from '$lib/form/Form.svelte';
     import IconArrowPathSquare from '$icons/IconArrowPathSquare.svelte';
 
-    let { user }: { user: UserResponse } = $props();
+    let { user = $bindable() }: { user: UserResponse } = $props();
 
     const isSupported = 'credentials' in navigator;
 
@@ -104,6 +104,15 @@
         }
     }
 
+    // `webauthn_user_id` is set by the backend with the very first passkey, and reset with the
+    // last deletion. Refetch so the MFA indicator updates without a manual page reload.
+    async function fetchUser() {
+        let res = await fetchGet<UserResponse>(`/auth/v1/users/${user.id}`);
+        if (res.body) {
+            user = res.body;
+        }
+    }
+
     async function handleRegister() {
         resetMsgErr();
 
@@ -138,6 +147,7 @@
             showRegInput = false;
             passkeyName = '';
             await fetchPasskeys();
+            await fetchUser();
         }
     }
 
@@ -153,6 +163,7 @@
         let res = await fetchDelete(`/auth/v1/users/${user.id}/webauthn/delete/${name}`, payload);
         if (res.status === 200) {
             await fetchPasskeys();
+            await fetchUser();
         } else {
             msg = res.error?.message || 'Error';
         }

--- a/frontend/src/lib/account/AccMain.svelte
+++ b/frontend/src/lib/account/AccMain.svelte
@@ -189,7 +189,7 @@
                 {:else if selected === t.common.password}
                     <AccPassword {user} {authProvider} viewModePhone />
                 {:else if selected === t.account.navMfa}
-                    <AccMFA {user} />
+                    <AccMFA bind:user />
                 {:else if selected === 'WebID'}
                     {#if webIdData}
                         <AccWebId bind:webIdData />
@@ -228,7 +228,7 @@
                     {:else if selected === t.common.password}
                         <AccPassword {user} {authProvider} />
                     {:else if selected === t.account.navMfa}
-                        <AccMFA {user} />
+                        <AccMFA bind:user />
                     {:else if selected === 'WebID'}
                         {#if webIdData}
                             <AccWebId bind:webIdData />

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -1707,6 +1707,16 @@ pub async fn post_webauthn_reg_finish(
         principal.is_user(&id)?;
 
         webauthn::reg_finish(id, payload).await?;
+
+        // The registration ceremony is a fresh proof of possession for this very session, and
+        // starting it already required an `MfaModToken`. Upgrade the session in place so the user
+        // does not need a logout / login round-trip to satisfy `admin_force_mfa`.
+        let session = principal.get_session()?;
+        if !session.is_mfa {
+            let mut session = session.clone();
+            session.set_mfa(true).await?;
+        }
+
         Ok(HttpResponse::Created().finish())
     }
 }

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -1715,10 +1715,9 @@ pub async fn post_webauthn_reg_finish(
         // The session lookup is deliberately graceful: the passkey has already been persisted at
         // this point, so a flow that gets here without a session (during an initial account setup,
         // for instance) must never have its successful registration turned into an error.
-        if let Some(session) = &principal.session
+        if let Some(mut session) = principal.into_inner().session
             && !session.is_mfa
         {
-            let mut session = session.clone();
             session.set_mfa(true).await?;
         }
 

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -1711,8 +1711,13 @@ pub async fn post_webauthn_reg_finish(
         // The registration ceremony is a fresh proof of possession for this very session, and
         // starting it already required an `MfaModToken`. Upgrade the session in place so the user
         // does not need a logout / login round-trip to satisfy `admin_force_mfa`.
-        let session = principal.get_session()?;
-        if !session.is_mfa {
+        //
+        // The session lookup is deliberately graceful: the passkey has already been persisted at
+        // this point, so a flow that gets here without a session (during an initial account setup,
+        // for instance) must never have its successful registration turned into an error.
+        if let Some(session) = &principal.session
+            && !session.is_mfa
+        {
             let mut session = session.clone();
             session.set_mfa(true).await?;
         }


### PR DESCRIPTION
Resolves #1636.

Registering a Passkey from the Account dashboard did not touch the current session, so `is_mfa`
stayed `false` until the next login. A fresh admin account that just enrolled its first Passkey was
therefore still rejected by `admin_force_mfa`, with a message that reads like something went wrong,
and had to log out and back in.

As discussed, the session is now upgraded in place on a successful `reg_finish`.

### Backend

`post_webauthn_reg_finish` checks `is_mfa` on the principal's session after a successful
`webauthn::reg_finish` and upgrades it via the existing `Session::set_mfa`, the same primitive the
login paths already use. It only writes when the session is not already MFA, to avoid a pointless DB
write plus cache put on every additional Passkey.

Two guards fall out of the existing structure rather than being added:

- the `magic_link_id` branch returns before this code, so the reset / new-account flow is untouched
  (it has no session anyway);
- `principal.is_user(&id)?` already runs above, so an admin registering a credential for someone
  else can never upgrade their own session.

The registration start already requires an `MfaModToken`, so the user has proven recent credentials
inside a short window, and the ceremony itself is a fresh proof of possession for this very session.

### Frontend

The companion nit from the issue is fixed too: the Account dashboard showed *MFA activated ✗* until
a manual reload. The indicator reads `user.webauthn_user_id`, but `AccMFA` received `user` as a
read-only prop and only refreshed its own `passkeys` array. `user` is `$bindable()` now and is
refetched after registering or deleting a Passkey, so the indicator flips immediately.

Deleting the last Passkey had the mirror bug (indicator stuck on the check mark) and is fixed by the
same change. As a side effect, the re-auth modal no longer offers password re-auth off a stale
`user` right after the first Passkey was registered.

### Verification

- `cargo check` / `cargo clippy` / `cargo fmt --check` clean.
- `just test-hiqlite` full suite green.
- `npm run check` (svelte-check) reports no new problems, `prettier --check` clean.
