### PR TITLE
Client: accept `at+jwt` JWT header typ

### DIFF
--- a/rauthy-client/CHANGELOG.md
+++ b/rauthy-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.14.3
+
+The JWT header `typ` validation accepts `at+jwt` in addition to `JWT` now. RFC 9068 specifies
+`at+jwt` as the header `typ` for OAuth 2.0 access tokens, and a future Rauthy version will emit it.
+Updating the client beforehand makes that switch possible without an interruption in service.
+
 ## v0.14.2
 
 This release only exists to (hopefully) resolve docs.rs builds.

--- a/rauthy-client/Cargo.toml
+++ b/rauthy-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rauthy-client"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]
 license = "Apache-2.0"

--- a/rauthy-client/examples/actix-web/Cargo.lock
+++ b/rauthy-client/examples/actix-web/Cargo.lock
@@ -1750,7 +1750,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rauthy-client"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "actix-web",
  "base64",

--- a/rauthy-client/examples/axum/Cargo.lock
+++ b/rauthy-client/examples/axum/Cargo.lock
@@ -1492,7 +1492,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rauthy-client"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "axum",
  "axum-extra",

--- a/rauthy-client/examples/generic/Cargo.lock
+++ b/rauthy-client/examples/generic/Cargo.lock
@@ -1771,7 +1771,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rauthy-client"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "base64",
  "bincode",

--- a/rauthy-client/src/tokens/token.rs
+++ b/rauthy-client/src/tokens/token.rs
@@ -53,7 +53,9 @@ impl JwtToken {
 
         base64_url_no_pad_decode_buf(header, buf)?;
         let header = serde_json::from_slice::<JwtHeader>(buf)?;
-        if header.typ != "JWT" {
+        // RFC 9068 specifies `at+jwt` for access tokens. Accept both, because tokens issued
+        // before that change, as well as ID tokens, use `JWT`.
+        if header.typ != "JWT" && header.typ != "at+jwt" {
             return Err(RauthyError::InvalidJwt("Invalid JWT Header `typ`"));
         }
         let jwk = JwkPublicKey::get_for_token(token).await?;


### PR DESCRIPTION
Refs #1641. Prep for the server-side change; safe to merge and release on its own.

RFC 9068 specifies `at+jwt` as the JWT header `typ` for OAuth 2.0 access tokens. The client's
validation only accepts `JWT` today, so it would reject Rauthy's access tokens the moment Rauthy
emits the RFC-compliant value. Accepting both here first is what makes that switch possible without
an interruption in service, as you described in #1641.

- `JwtToken::validate_claims_into` accepts `JWT` and `at+jwt`.
- Version bumped to `v0.14.3` + CHANGELOG entry, example `Cargo.lock`s refreshed.

Nothing else changes: tokens issued before the switch, and ID tokens, keep using `JWT`.

The server-side counterpart is #1651, which is breaking and can wait for a minor. Releasing this
client version first is what avoids any interruption in service.
