### PR TITLE
feat(oidc): RFC 9068 `at+jwt` typ header on access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Breaking
+
+#### RFC 9068 `at+jwt` Token Type
+
+Access Tokens are issued with a JWT header `typ` of `at+jwt` now, as specified in
+[RFC 9068](https://www.rfc-editor.org/rfc/rfc9068.html). Rauthy's Access Tokens have been
+RFC 9068-shaped for a long time already, but the header still used the generic `JWT`, which made it
+impossible for a resource server to tell an Access Token apart from an ID Token by the header alone.
+ID, Refresh and Logout Tokens are unchanged and keep using `JWT`.
+
+This is only breaking for downstream resource servers that check the header `typ` for exactly `JWT`.
+Rauthy itself accepts both values, so Access Tokens issued before an update stay valid until they
+expire. `rauthy-client` accepts `at+jwt` starting with `v0.14.3`; update the client before updating
+Rauthy to avoid an interruption in service.
+
+[#1651](https://github.com/sebadob/rauthy/pull/1651)
+
 ### Changes
 
 #### Session MFA Upgrade after Passkey Registration

--- a/src/bin/tests/handler_auth.rs
+++ b/src/bin/tests/handler_auth.rs
@@ -189,6 +189,20 @@ async fn test_authorization_code_flow() -> Result<(), Box<dyn Error>> {
         .map(|v| v.to_string().replace('\"', ""))
         .unwrap();
 
+    // an ID token uses the generic `JWT`, while an access token must use `at+jwt` (RFC 9068)
+    let typ = header
+        .claim("typ")
+        .map(|v| v.to_string().replace('\"', ""))
+        .expect("'typ' is not set in id token header");
+    assert_eq!(typ, "JWT");
+
+    let access_header = josekit::jwt::decode_header(ts.access_token.clone())?;
+    let access_typ = access_header
+        .claim("typ")
+        .map(|v| v.to_string().replace('\"', ""))
+        .expect("'typ' is not set in access token header");
+    assert_eq!(access_typ, "at+jwt");
+
     // retrieve jwk for kid
     let kid_url = format!("{}/oidc/certs/{}", backend_url, kid);
     let res = reqwest::get(&kid_url).await?;

--- a/src/jwt/src/token.rs
+++ b/src/jwt/src/token.rs
@@ -12,8 +12,27 @@ use tracing::warn;
 pub struct JwtHeader<'a> {
     pub alg: JwkKeyPairAlg,
     pub kid: &'a str,
-    // should always be JWT -> DPoP tokens have their own validation
+    // either `JWT` or `at+jwt` -> DPoP tokens have their own validation
     pub typ: &'a str,
+}
+
+/// The JWT header `typ`. Not to be confused with the `typ` claim inside the payload, which is
+/// Rauthy's own token type and has different values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JwtHeaderTyp {
+    /// The generic `JWT` for ID, Refresh and Logout Tokens.
+    Jwt,
+    /// `at+jwt` for Access Tokens as specified in RFC 9068.
+    AtJwt,
+}
+
+impl JwtHeaderTyp {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Jwt => "JWT",
+            Self::AtJwt => "at+jwt",
+        }
+    }
 }
 
 pub struct JwtToken;
@@ -22,13 +41,15 @@ impl JwtToken {
     pub fn build<C: Debug + Serialize>(
         jwk: &JwkKeyPair,
         claims: &C,
+        typ: JwtHeaderTyp,
     ) -> Result<String, ErrorResponse> {
         let mut token = String::with_capacity(1024);
 
         let header = format!(
-            "{{\"alg\":\"{}\",\"kid\":\"{}\",\"typ\":\"JWT\"}}",
+            "{{\"alg\":\"{}\",\"kid\":\"{}\",\"typ\":\"{}\"}}",
             jwk.typ.as_str(),
-            jwk.kid
+            jwk.kid,
+            typ.as_str()
         );
         base64_url_no_pad_encode_buf(header.as_bytes(), &mut token);
         token.push('.');
@@ -94,7 +115,10 @@ impl JwtToken {
 
         base64_url_no_pad_decode_buf(header, buf)?;
         let header = serde_json::from_slice::<JwtHeader>(buf)?;
-        if header.typ != "JWT" {
+        // Access Tokens use `at+jwt` (RFC 9068), everything else `JWT`. Both must be accepted
+        // independently of the token type, because Access Tokens issued before that change are
+        // still valid until they expire.
+        if header.typ != JwtHeaderTyp::Jwt.as_str() && header.typ != JwtHeaderTyp::AtJwt.as_str() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
                 "Invalid JWT Header `typ`",
@@ -185,9 +209,16 @@ impl ValidationClaims<'_> {
 #[cfg(test)]
 mod tests {
     use crate::claims::JwtTokenType;
-    use crate::token::ValidationClaims;
+    use crate::token::{JwtHeaderTyp, ValidationClaims};
     use chrono::Utc;
     use rauthy_error::{ErrorResponse, ErrorResponseType};
+
+    #[test]
+    fn test_jwt_header_typ() {
+        // RFC 9068 specifies exactly this value for Access Tokens
+        assert_eq!(JwtHeaderTyp::AtJwt.as_str(), "at+jwt");
+        assert_eq!(JwtHeaderTyp::Jwt.as_str(), "JWT");
+    }
 
     #[test]
     fn test_validation_claims() -> Result<(), ErrorResponse> {

--- a/src/jwt/src/token.rs
+++ b/src/jwt/src/token.rs
@@ -19,14 +19,14 @@ pub struct JwtHeader<'a> {
 /// The JWT header `typ`. Not to be confused with the `typ` claim inside the payload, which is
 /// Rauthy's own token type and has different values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum JwtHeaderTyp {
+pub enum JwtHeaderType {
     /// The generic `JWT` for ID, Refresh and Logout Tokens.
     Jwt,
     /// `at+jwt` for Access Tokens as specified in RFC 9068.
     AtJwt,
 }
 
-impl JwtHeaderTyp {
+impl JwtHeaderType {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Jwt => "JWT",
@@ -41,7 +41,7 @@ impl JwtToken {
     pub fn build<C: Debug + Serialize>(
         jwk: &JwkKeyPair,
         claims: &C,
-        typ: JwtHeaderTyp,
+        typ: JwtHeaderType,
     ) -> Result<String, ErrorResponse> {
         let mut token = String::with_capacity(1024);
 
@@ -118,7 +118,8 @@ impl JwtToken {
         // Access Tokens use `at+jwt` (RFC 9068), everything else `JWT`. Both must be accepted
         // independently of the token type, because Access Tokens issued before that change are
         // still valid until they expire.
-        if header.typ != JwtHeaderTyp::Jwt.as_str() && header.typ != JwtHeaderTyp::AtJwt.as_str() {
+        if header.typ != JwtHeaderType::Jwt.as_str() && header.typ != JwtHeaderType::AtJwt.as_str()
+        {
             return Err(ErrorResponse::new(
                 ErrorResponseType::BadRequest,
                 "Invalid JWT Header `typ`",
@@ -209,15 +210,15 @@ impl ValidationClaims<'_> {
 #[cfg(test)]
 mod tests {
     use crate::claims::JwtTokenType;
-    use crate::token::{JwtHeaderTyp, ValidationClaims};
+    use crate::token::{JwtHeaderType, ValidationClaims};
     use chrono::Utc;
     use rauthy_error::{ErrorResponse, ErrorResponseType};
 
     #[test]
     fn test_jwt_header_typ() {
         // RFC 9068 specifies exactly this value for Access Tokens
-        assert_eq!(JwtHeaderTyp::AtJwt.as_str(), "at+jwt");
-        assert_eq!(JwtHeaderTyp::Jwt.as_str(), "JWT");
+        assert_eq!(JwtHeaderType::AtJwt.as_str(), "at+jwt");
+        assert_eq!(JwtHeaderType::Jwt.as_str(), "JWT");
     }
 
     #[test]

--- a/src/service/src/oidc/bcl_logout_token.rs
+++ b/src/service/src/oidc/bcl_logout_token.rs
@@ -98,7 +98,7 @@ impl LogoutToken<'_> {
             sid: self.sid,
             nonce: None,
         };
-        rauthy_jwt::token::JwtToken::build(kp, &claims)
+        rauthy_jwt::token::JwtToken::build(kp, &claims, rauthy_jwt::token::JwtHeaderTyp::Jwt)
     }
 
     /// Parse and validate the token as specified in

--- a/src/service/src/oidc/bcl_logout_token.rs
+++ b/src/service/src/oidc/bcl_logout_token.rs
@@ -8,6 +8,7 @@ use rauthy_data::rauthy_config::RauthyConfig;
 use rauthy_error::ErrorResponse;
 use rauthy_error::ErrorResponseType;
 use rauthy_jwt::claims::{JwtCommonClaims, JwtLogoutClaims, JwtTokenType};
+use rauthy_jwt::token::{JwtHeaderType, JwtToken};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::str::FromStr;
@@ -98,7 +99,7 @@ impl LogoutToken<'_> {
             sid: self.sid,
             nonce: None,
         };
-        rauthy_jwt::token::JwtToken::build(kp, &claims, rauthy_jwt::token::JwtHeaderTyp::Jwt)
+        JwtToken::build(kp, &claims, JwtHeaderType::Jwt)
     }
 
     /// Parse and validate the token as specified in

--- a/src/service/src/token_set.rs
+++ b/src/service/src/token_set.rs
@@ -18,7 +18,7 @@ use rauthy_jwt::claims::{
     JwtAccessClaims, JwtAmrValue, JwtCommonClaims, JwtIdClaims, JwtTokenType,
     validate_no_reserved_collision,
 };
-use rauthy_jwt::token::JwtToken;
+use rauthy_jwt::token::{JwtHeaderTyp, JwtToken};
 use ring::digest;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -280,7 +280,7 @@ impl TokenSet {
 
         let key_pair_alg = JwkKeyPairAlg::from_str(&client.access_token_alg)?;
         let kp = JwkKeyPair::find_latest(key_pair_alg).await?;
-        let token = JwtToken::build(&kp, &claims_new_impl)?;
+        let token = JwtToken::build(&kp, &claims_new_impl, JwtHeaderTyp::AtJwt)?;
 
         Ok((AccessTokenJti(issued_token.jti), token))
     }
@@ -445,7 +445,7 @@ impl TokenSet {
 
         let key_pair_alg = JwkKeyPairAlg::from_str(&client.id_token_alg)?;
         let kp = JwkKeyPair::find_latest(key_pair_alg).await?;
-        JwtToken::build(&kp, &claims)
+        JwtToken::build(&kp, &claims, JwtHeaderTyp::Jwt)
     }
 
     /// Builds the refresh token for a user after all validation has been successful
@@ -512,7 +512,7 @@ impl TokenSet {
             };
 
             let kp = JwkKeyPair::find_latest(JwkKeyPairAlg::default()).await?;
-            JwtToken::build(&kp, &claims)?
+            JwtToken::build(&kp, &claims, JwtHeaderTyp::Jwt)?
         };
 
         // only save the last 50 characters for validation

--- a/src/service/src/token_set.rs
+++ b/src/service/src/token_set.rs
@@ -18,7 +18,7 @@ use rauthy_jwt::claims::{
     JwtAccessClaims, JwtAmrValue, JwtCommonClaims, JwtIdClaims, JwtTokenType,
     validate_no_reserved_collision,
 };
-use rauthy_jwt::token::{JwtHeaderTyp, JwtToken};
+use rauthy_jwt::token::{JwtHeaderType, JwtToken};
 use ring::digest;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -280,7 +280,7 @@ impl TokenSet {
 
         let key_pair_alg = JwkKeyPairAlg::from_str(&client.access_token_alg)?;
         let kp = JwkKeyPair::find_latest(key_pair_alg).await?;
-        let token = JwtToken::build(&kp, &claims_new_impl, JwtHeaderTyp::AtJwt)?;
+        let token = JwtToken::build(&kp, &claims_new_impl, JwtHeaderType::AtJwt)?;
 
         Ok((AccessTokenJti(issued_token.jti), token))
     }
@@ -445,7 +445,7 @@ impl TokenSet {
 
         let key_pair_alg = JwkKeyPairAlg::from_str(&client.id_token_alg)?;
         let kp = JwkKeyPair::find_latest(key_pair_alg).await?;
-        JwtToken::build(&kp, &claims, JwtHeaderTyp::Jwt)
+        JwtToken::build(&kp, &claims, JwtHeaderType::Jwt)
     }
 
     /// Builds the refresh token for a user after all validation has been successful
@@ -512,7 +512,7 @@ impl TokenSet {
             };
 
             let kp = JwkKeyPair::find_latest(JwkKeyPairAlg::default()).await?;
-            JwtToken::build(&kp, &claims, JwtHeaderTyp::Jwt)?
+            JwtToken::build(&kp, &claims, JwtHeaderType::Jwt)?
         };
 
         // only save the last 50 characters for validation


### PR DESCRIPTION
Closes #1641.

Rauthy's access tokens are already RFC 9068-shaped, but the JWT header `typ` was hardcoded to the
generic `JWT` for every token, so a resource server could not tell an access token from an ID token
by the header alone. Access tokens use `at+jwt` now; ID, refresh and logout tokens keep `JWT`.

As agreed, this is unconditional, with no config flag.

**Merge gating:** this is the breaking half, so per your note it wants a minor rather than a patch,
and ideally lands after `rauthy-client v0.14.3` (#1650) is released.

**Backwards compatibility:** validation accepts both `JWT` and `at+jwt` regardless of token type, so
access tokens issued before an update stay valid until they expire. The check is deliberately not
tightened to require `at+jwt` when `expected_type == Bearer`, since that would reject still-valid
pre-update tokens.

**Downstream:** only breaking for a resource server that checks the header `typ` for exactly `JWT`.
`rauthy-client` accepts `at+jwt` from `v0.14.3` (#1650), so releasing that first avoids any
interruption in service.

**One design note:** the header `typ` is modelled as a small `JwtHeaderTyp` enum rather than a bare
string parameter. `JwtToken::build` is generic over the claims type and cannot infer the token kind,
so the value has to be passed at all 4 call sites; an enum makes it impossible to typo, and keeps it
clearly apart from the `typ` *claim* in the payload, which is Rauthy's own token type with different
values (`Bearer` / `Id` / `Refresh` / ...) and is untouched here. Happy to switch it to a plain
`&'static str` if you prefer less surface.

### Verification

- `cargo check --workspace`, `clippy`, `fmt --check` clean.
- `just test-hiqlite` full suite green with `at+jwt` live, so introspection, userinfo, revocation
  and refresh all still validate.
- `test_authorization_code_flow` extended to assert the headers positively: access token `at+jwt`,
  ID token `JWT`. Header construction had no test coverage before.
