### PR TITLE
Fix: serve RFC 8414 metadata at the path-insertion URL for the `/auth/v1` issuer

### DIFF
--- a/src/api/src/oidc.rs
+++ b/src/api/src/oidc.rs
@@ -1268,3 +1268,29 @@ pub async fn get_well_known() -> Result<HttpResponse, ErrorResponse> {
 pub async fn get_well_known_oauth() -> Result<HttpResponse, ErrorResponse> {
     well_known_response().await
 }
+
+// RFC 8414 §3.1 path-insertion alias for the AS-metadata document. Because
+// rauthy's issuer carries a path component (`https://<host>/auth/v1/`), an
+// RFC-compliant client forms the metadata URL by INSERTING
+// `/.well-known/oauth-authorization-server` between host and issuer path, i.e.
+// `https://<host>/.well-known/oauth-authorization-server/auth/v1`. claude.ai
+// probes exactly this path-insertion form; without it the request falls through
+// to the SPA catch-all (301 -> HTML), so the client never reads
+// `client_id_metadata_document_supported` and falls back to Dynamic Client
+// Registration. The `/auth/v1` segment is rauthy's fixed API mount prefix (see
+// the hardcoded issuer in `rauthy_config.rs`), so the route can be a constant.
+// Body is identical to `get_well_known_oauth`. See issue #1643.
+//
+// Both the trailing-slash and no-slash forms are served: the issuer path is
+// `/auth/v1/` (with a trailing slash), so a strict client may preserve it, while
+// claude.ai probes the no-slash form. rauthy runs no `NormalizePath` middleware,
+// so each exact path needs its own route.
+#[get("/.well-known/oauth-authorization-server/auth/v1")]
+pub async fn get_well_known_oauth_rfc8414() -> Result<HttpResponse, ErrorResponse> {
+    well_known_response().await
+}
+
+#[get("/.well-known/oauth-authorization-server/auth/v1/")]
+pub async fn get_well_known_oauth_rfc8414_trailing() -> Result<HttpResponse, ErrorResponse> {
+    well_known_response().await
+}

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -253,6 +253,8 @@ async fn server_with_metrics() -> std::io::Result<()> {
             .wrap(metrics_collector.clone())
             .service(oidc::get_well_known)
             .service(oidc::get_well_known_oauth)
+            .service(oidc::get_well_known_oauth_rfc8414)
+            .service(oidc::get_well_known_oauth_rfc8414_trailing)
             .service(fed_cm::get_fed_cm_well_known)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first
@@ -338,6 +340,8 @@ async fn server_without_metrics() -> std::io::Result<()> {
             .wrap(default_headers())
             .service(oidc::get_well_known)
             .service(oidc::get_well_known_oauth)
+            .service(oidc::get_well_known_oauth_rfc8414)
+            .service(oidc::get_well_known_oauth_rfc8414_trailing)
             .service(fed_cm::get_fed_cm_well_known)
             // Important: Do not move this middleware do need the least amount of computing
             // for blacklisted IPs -> middlewares are executed in reverse order -> this one first

--- a/src/bin/tests/handler_generic.rs
+++ b/src/bin/tests/handler_generic.rs
@@ -59,3 +59,38 @@ async fn test_get_well_known() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+// Regression for issue #1643: because the issuer carries a path
+// (`.../auth/v1/`), RFC 8414 §3.1 mandates the AS-metadata URL be formed by
+// INSERTING `/.well-known/oauth-authorization-server` between host and path.
+// claude.ai probes exactly this path-insertion form; it must return the same
+// JSON well-known document (not the SPA fallback) so the client can read
+// `client_id_metadata_document_supported`.
+#[tokio::test]
+async fn test_get_well_known_oauth_rfc8414() -> Result<(), Box<dyn Error>> {
+    let backend = get_backend_url();
+    let root = backend.strip_suffix("/auth/v1").unwrap_or(&backend);
+
+    // Both the no-slash form (probed by claude.ai) and the trailing-slash form
+    // (issuer path is `/auth/v1/`) must return the well-known document, not the SPA.
+    for url in [
+        format!("{root}/.well-known/oauth-authorization-server/auth/v1"),
+        format!("{root}/.well-known/oauth-authorization-server/auth/v1/"),
+    ] {
+        let res = reqwest::get(&url).await?;
+
+        assert_eq!(res.status(), 200, "unexpected status for {url}");
+        assert_eq!(
+            res.headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json"),
+            "unexpected content-type for {url}",
+        );
+        let content = res.json::<WellKnown>().await?;
+        // strip trailing /
+        assert_eq!(content.issuer[..content.issuer.len() - 1], get_issuer());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Rauthy's issuer carries a path (`https://<host>/auth/v1/`). Per RFC 8414 §3.1 the metadata URL for a path-ful issuer inserts the well-known segment between host and path: `/.well-known/oauth-authorization-server/auth/v1`. Rauthy only exposed the root alias `/.well-known/oauth-authorization-server` (added for ChatGPT, which probes the root form), so the path-insertion URL fell through to the SPA catch-all and 301'd to HTML. A client that follows RFC 8414 to the letter (claude.ai does) can't discover `client_id_metadata_document_supported` and falls back to Dynamic Client Registration.

This serves the same metadata body at the path-insertion URL, in both the no-slash and trailing-slash forms (the issuer path ends in `/`, and there's no `NormalizePath` middleware). It's registered at the two app-root builder sites, not the `/auth/v1`-scoped one, where it would resolve to a nonsensical `/auth/v1/.well-known/oauth-authorization-server/auth/v1`. `/auth/v1` is a constant base path, so the routes are fixed.

You mentioned in the issue that there's already a root-level mechanism for this. If you'd rather I reuse that than add the two explicit handlers, point me at it and I'll switch.

Regression test hits both slash forms and asserts 200, `application/json`, and a matching issuer. Full suite green.

Closes #1643.