### PR TITLE
Fix: carry RFC 8707 `resource` through the session-refresh authorize path

### DIFF
--- a/frontend/src/api/types/authorize.ts
+++ b/frontend/src/api/types/authorize.ts
@@ -40,6 +40,9 @@ export interface LoginRefreshRequest {
     /// Validation: PATTERN_CODE_CHALLENGE
     code_challenge?: string;
     code_challenge_method?: CodeChallengeMethod;
+    /// RFC 8707 resource indicator forwarded from the authorization request.
+    /// Validation: PATTERN_RESOURCE
+    resource?: string;
 }
 
 export interface RequestResetRequest {

--- a/frontend/src/lib/admin/clients/ClientConfig.svelte
+++ b/frontend/src/lib/admin/clients/ClientConfig.svelte
@@ -12,6 +12,7 @@
         PATTERN_CONTACT,
         PATTERN_GROUP,
         PATTERN_ORIGIN,
+        PATTERN_RESOURCE,
         PATTERN_URI,
     } from '$utils/patterns';
     import {
@@ -405,14 +406,14 @@
             bind:values={allowedResources}
             label={ta.clients.allowedResources}
             errMsg={ta.validation.uri}
-            pattern={PATTERN_URI}
+            pattern={PATTERN_RESOURCE}
         />
         <p class="desc">{ta.clients.descDefaultAud}</p>
         <InputTags
             bind:values={defaultAud}
             label={ta.clients.defaultAud}
             errMsg={ta.validation.uri}
-            pattern={PATTERN_URI}
+            pattern={PATTERN_RESOURCE}
         />
 
         <div style:height=".5rem"></div>

--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -228,6 +228,9 @@
             payload.code_challenge = challenge;
             payload.code_challenge_method = challengeMethod;
         }
+        if (resource) {
+            payload.resource = resource;
+        }
 
         let res = await fetchPost<undefined | WebauthnLoginResponse>(
             '/auth/v1/oidc/authorize/refresh',

--- a/frontend/src/utils/patterns.ts
+++ b/frontend/src/utils/patterns.ts
@@ -31,5 +31,8 @@ export const PATTERN_PHONE = '^\\+[0-9]{0,32}$';
 export const PATTERN_SCOPE_SPACE = '^[a-zA-Z0-9\\-_\\/:\\s*]{0,512}$';
 export const PATTERN_STREET = '^[a-zA-Z0-9À-ÿ\\-.\\s]{0,48}$';
 export const PATTERN_URI = "^[a-zA-Z0-9,.:\\/_\\-&?=~#!$'\\(\\)*+%@]*$";
+// Like PATTERN_URI but without `#`: an RFC 8707 resource indicator must be an absolute URI
+// without a fragment (RFC 8707 §2). Matches the backend `RE_RESOURCE`.
+export const PATTERN_RESOURCE = "^[a-zA-Z0-9,.:\\/_\\-&?=~!$'\\(\\)*+%@]*$";
 export const PATTERN_USER_NAME =
     "^[a-zA-Z0-9À-ɏ\\-'\\s\\u3041-\\u3096\\u30A0-\\u30FF\\u3400-\\u4DB5\\u4E00-\\u9FCB\\uF900-\\uFA6A\\u2E80-\\u2FD5\\uFF66-\\uFF9F\\uFFA1-\\uFFDC\\u31F0-\\u31FF]{1,32}$";

--- a/src/api_types/src/clients.rs
+++ b/src/api_types/src/clients.rs
@@ -117,8 +117,8 @@ pub struct EphemeralClientRequest {
     /// requested `resource` is validated against this list; when absent, `resource` is
     /// only honored if `ephemeral_clients.danger_allow_unvalidated_resource` is enabled.
     ///
-    /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%@]+$>`
-    #[validate(custom(function = "validate_vec_uri"))]
+    /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~!$'()*+%@]+$>`
+    #[validate(custom(function = "validate_vec_resource"))]
     pub allowed_resources: Option<Vec<String>>,
 }
 
@@ -207,14 +207,14 @@ pub struct UpdateClientRequest {
     /// RFC 8707 allow-list of resource indicators this client may request. An empty /
     /// missing list rejects any `resource` request parameter with `invalid_target`.
     ///
-    /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%@]+$>`
-    #[validate(custom(function = "validate_vec_uri"))]
+    /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~!$'()*+%@]+$>`
+    #[validate(custom(function = "validate_vec_resource"))]
     pub allowed_resources: Option<Vec<String>>,
     /// Audiences that are always added to this client's tokens, independent of any
     /// `resource` request parameter. Useful for clients that cannot send a `resource`.
     ///
-    /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%@]+$>`
-    #[validate(custom(function = "validate_vec_uri"))]
+    /// Validation: `Vec<^[a-zA-Z0-9,.:/_\\-&?=~!$'()*+%@]+$>`
+    #[validate(custom(function = "validate_vec_resource"))]
     pub default_aud: Option<Vec<String>>,
     #[validate(nested)]
     pub scim: Option<ScimClientRequestResponse>,

--- a/src/api_types/src/cust_validation.rs
+++ b/src/api_types/src/cust_validation.rs
@@ -1,7 +1,7 @@
 use rauthy_common::constants::CLIENT_CLAIMS_MAX_LEN;
 use rauthy_common::regex::{
     RE_ATTR, RE_CODE_CHALLENGE_METHOD, RE_CONTACT, RE_GRANT_TYPES, RE_GROUPS, RE_LINUX_HOSTNAME,
-    RE_ORIGIN, RE_ROLES_SCOPES, RE_URI,
+    RE_ORIGIN, RE_RESOURCE, RE_ROLES_SCOPES, RE_URI,
 };
 use std::borrow::Cow;
 use validator::ValidationError;
@@ -144,6 +144,19 @@ pub fn validate_vec_uri(value: &[String]) -> Result<(), ValidationError> {
     });
     if let Some(e) = err {
         return Err(ValidationError::new(e));
+    }
+    Ok(())
+}
+
+/// RFC 8707 resource indicators (client `allowed_resources` / `default_aud`). Same as a URI
+/// but a fragment (`#`) is not allowed, since a resource indicator MUST be an absolute URI
+/// without a fragment (RFC 8707 §2). Matches the request-side `resource` validation.
+#[inline]
+pub fn validate_vec_resource(value: &[String]) -> Result<(), ValidationError> {
+    for v in value {
+        if !RE_RESOURCE.is_match(v) {
+            return Err(ValidationError::new("^[a-zA-Z0-9,.:/_\\-&?=~!$'()*+%@]+$"));
+        }
     }
     Ok(())
 }

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -5,7 +5,7 @@ use actix_web::HttpRequest;
 use actix_web::http::header;
 use rauthy_common::regex::{
     RE_ALNUM, RE_BASE64, RE_CLIENT_ID, RE_CODE_CHALLENGE_METHOD, RE_CODE_VERIFIER, RE_GRANT_TYPES,
-    RE_LOWERCASE, RE_SCOPE_SPACE, RE_URI,
+    RE_LOWERCASE, RE_RESOURCE, RE_SCOPE_SPACE, RE_URI,
 };
 use rauthy_common::utils::base64_decode;
 use rauthy_error::{ErrorResponse, ErrorResponseType};
@@ -66,8 +66,8 @@ pub struct AuthRequest {
     /// requested resource is validated against the client's `allowed_resources` and,
     /// on success, added to the issued access token's `aud`.
     ///
-    /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$`
-    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$"))]
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
     pub resource: Option<String>,
 }
 
@@ -138,8 +138,8 @@ pub struct LoginRequest {
     /// RFC 8707 resource indicator forwarded from the authorization request, carried
     /// into the auth code so the issued access token can be audience-restricted.
     ///
-    /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$`
-    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$"))]
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
     pub resource: Option<String>,
 }
 
@@ -169,6 +169,12 @@ pub struct LoginRefreshRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
     pub code_challenge_method: Option<String>,
+    /// RFC 8707 resource indicator forwarded from the authorization request, carried
+    /// into the auth code so the issued access token can be audience-restricted.
+    ///
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
+    pub resource: Option<String>,
 }
 
 #[derive(Default, Deserialize, Validate, ToSchema, IntoParams)]
@@ -269,8 +275,8 @@ pub struct TokenRequest {
     /// `refresh_token` grant it may only narrow (be a subset of) the resources granted
     /// to the original token, never widen them.
     ///
-    /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$`
-    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$"))]
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
     pub resource: Option<String>,
 }
 
@@ -518,4 +524,64 @@ pub struct TokenInfo<'a> {
     pub exp: Option<i64>,
     #[serde(borrow, skip_serializing_if = "Option::is_none")]
     pub cnf: Option<JktClaim<'a>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use validator::Validate;
+
+    // Regression test for RFC 8707 `resource` being dropped on the silent re-auth path.
+    // The refresh authorize request must deserialize and validate a `resource` just like
+    // the full-login `LoginRequest` does, so audience-bound tokens survive later logins.
+    #[test]
+    fn login_refresh_request_carries_valid_resource() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "https://mcp.example.com/mcp"
+        }"#;
+
+        let req: LoginRefreshRequest =
+            serde_json::from_str(json).expect("must deserialize the resource field");
+        assert_eq!(req.resource.as_deref(), Some("https://mcp.example.com/mcp"));
+        assert!(
+            req.validate().is_ok(),
+            "a valid absolute-URI resource must pass validation"
+        );
+    }
+
+    #[test]
+    fn login_refresh_request_rejects_invalid_resource() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "not a valid uri"
+        }"#;
+
+        let req: LoginRefreshRequest =
+            serde_json::from_str(json).expect("must deserialize even an invalid resource");
+        assert!(
+            req.validate().is_err(),
+            "a resource with disallowed characters must fail validation"
+        );
+    }
+
+    // RFC 8707 §2: the `resource` MUST be an absolute URI without a fragment. The
+    // fragment-excluding `RE_RESOURCE` validator must reject a `#` fragment.
+    #[test]
+    fn login_refresh_request_rejects_resource_with_fragment() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "https://mcp.example.com/mcp#frag"
+        }"#;
+
+        let req: LoginRefreshRequest =
+            serde_json::from_str(json).expect("must deserialize even a fragmented resource");
+        assert!(
+            req.validate().is_err(),
+            "a resource containing a URI fragment must fail validation"
+        );
+    }
 }

--- a/src/bin/tests/zzf_handler_resource_indicators.rs
+++ b/src/bin/tests/zzf_handler_resource_indicators.rs
@@ -1,10 +1,14 @@
-use crate::common::{get_auth_headers, get_backend_url};
+use crate::common::{
+    PASSWORD, USERNAME, code_state_from_headers, cookie_csrf_headers_from_res_direct,
+    get_auth_headers, get_backend_url, get_solved_pow,
+};
 use pretty_assertions::assert_eq;
 use rauthy_api_types::clients::{
     ClientResponse, ClientSecretResponse, NewClientRequest, UpdateClientRequest,
 };
-use rauthy_api_types::oidc::{JwkKeyPairAlg, TokenRequest};
-use rauthy_common::utils::base64_url_no_pad_decode;
+use rauthy_api_types::oidc::{JwkKeyPairAlg, LoginRequest, TokenRequest};
+use rauthy_common::sha256;
+use rauthy_common::utils::{base64_url_encode, base64_url_no_pad_decode};
 use rauthy_service::token_set::TokenSet;
 use std::error::Error;
 
@@ -14,6 +18,18 @@ const ID: &str = "res_test";
 const RES_A: &str = "https://rs-a.example.com/api";
 const RES_B: &str = "https://rs-b.example.com/api";
 const DEFAULT_AUD: &str = "https://always.example.com/";
+
+const ID_REFRESH: &str = "res_refresh_test";
+const RES_REFRESH: &str = "https://rs.example.com/mcp";
+
+/// Returns whether the token's `aud` (string or string[]) contains `expected`.
+fn aud_contains(access_token: &str, expected: &str) -> bool {
+    match decode_aud(access_token) {
+        serde_json::Value::String(s) => s == expected,
+        serde_json::Value::Array(arr) => arr.iter().any(|v| v.as_str() == Some(expected)),
+        _ => false,
+    }
+}
 
 /// Decodes the (unverified) JWT payload and returns the `aud` claim as raw JSON, so a
 /// test can distinguish a single-string `aud` from a `string[]` `aud`.
@@ -168,6 +184,184 @@ async fn test_resource_indicators() -> Result<(), Box<dyn Error>> {
     token_req.resource = Some(RES_A.to_string());
     let res = http.post(&url_token).form(&token_req).send().await?;
     assert_eq!(res.status(), 400);
+
+    Ok(())
+}
+
+// #1657 (issue #1645): the RFC 8707 `resource` indicator must survive the silent re-auth
+// path (`POST /oidc/authorize/refresh`). When a still-valid session re-issues a code via
+// that endpoint, the request still carries the `resource`; before the fix
+// `post_authorize_refresh` hard-coded `resource: None`, so the re-issued code (and its
+// exchanged token) silently lost the audience restriction on every login after the first.
+#[tokio::test]
+async fn test_resource_survives_authorize_refresh() -> Result<(), Box<dyn Error>> {
+    let backend_url = get_backend_url();
+    let auth_headers = get_auth_headers().await?;
+    let http = reqwest::Client::new();
+
+    let redirect_uri = "http://localhost:3000/oidc/callback".to_string();
+    let challenge_plain = "oDXug9zfYqfz8ejcqMpALRPXfW8QhbKV2AVuScAt8xrLKDAmaRYQ4yRi2uqcH9ys";
+    let challenge_s256 = base64_url_encode(sha256!(challenge_plain.as_bytes()));
+
+    // public PKCE client with `allowed_resources` = [RES_REFRESH]
+    let new_client = NewClientRequest {
+        id: ID_REFRESH.to_string(),
+        secret: None,
+        name: Some("Resource Refresh Test".to_string()),
+        confidential: false,
+        redirect_uris: vec![redirect_uri.clone()],
+        post_logout_redirect_uris: None,
+    };
+    let res = http
+        .post(format!("{backend_url}/clients"))
+        .headers(auth_headers.clone())
+        .json(&new_client)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+
+    let upd = UpdateClientRequest {
+        name: Some("Resource Refresh Test".to_string()),
+        confidential: false,
+        redirect_uris: vec![redirect_uri.clone()],
+        post_logout_redirect_uris: None,
+        allowed_origins: None,
+        enabled: true,
+        flows_enabled: vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ],
+        access_token_alg: JwkKeyPairAlg::EdDSA,
+        id_token_alg: JwkKeyPairAlg::EdDSA,
+        auth_code_lifetime: 60,
+        access_token_lifetime: 300,
+        scopes: vec!["openid".to_string()],
+        default_scopes: vec!["openid".to_string()],
+        challenges: Some(vec!["S256".to_string()]),
+        force_mfa: false,
+        client_uri: None,
+        contacts: None,
+        backchannel_logout_uri: None,
+        restrict_group_prefix: None,
+        claims: None,
+        claims_at_root: false,
+        allowed_resources: Some(vec![RES_REFRESH.to_string()]),
+        default_aud: None,
+        scim: None,
+    };
+    let res = http
+        .put(format!("{backend_url}/clients/{ID_REFRESH}"))
+        .headers(auth_headers.clone())
+        .json(&upd)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+
+    // authenticated session we reuse for the silent re-auth call
+    let res = http
+        .post(format!("{backend_url}/oidc/session"))
+        .send()
+        .await?;
+    assert!(res.status().is_success());
+    let session_headers = cookie_csrf_headers_from_res_direct(res).await?;
+
+    // full authorization_code login WITH the RFC 8707 `resource`
+    let query_pkce = format!(
+        "client_id={ID_REFRESH}&redirect_uri={redirect_uri}&response_type=code\
+        &code_challenge={challenge_s256}&code_challenge_method=S256"
+    );
+    let url_auth = format!("{backend_url}/oidc/authorize?{query_pkce}");
+    let req_login = LoginRequest {
+        email: USERNAME.to_string(),
+        password: Some(PASSWORD.to_string()),
+        pow: get_solved_pow().await,
+        client_id: ID_REFRESH.to_string(),
+        redirect_uri: redirect_uri.clone(),
+        scopes: None,
+        state: None,
+        nonce: Some("MySuperNonce".to_string()),
+        code_challenge: Some(challenge_s256.clone()),
+        code_challenge_method: Some("S256".to_string()),
+        resource: Some(RES_REFRESH.to_string()),
+    };
+    let res = http
+        .post(&url_auth)
+        .headers(session_headers.clone())
+        .json(&req_login)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 202);
+    let (code, _state) = code_state_from_headers(res)?;
+
+    let token_req = TokenRequest {
+        grant_type: "authorization_code".to_string(),
+        code: Some(code),
+        redirect_uri: Some(redirect_uri.clone()),
+        client_id: Some(ID_REFRESH.to_string()),
+        client_secret: None,
+        code_verifier: Some(challenge_plain.to_string()),
+        device_code: None,
+        username: None,
+        password: None,
+        refresh_token: None,
+        resource: Some(RES_REFRESH.to_string()),
+    };
+    let res = http
+        .post(format!("{backend_url}/oidc/token"))
+        .form(&token_req)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let ts = res.json::<TokenSet>().await?;
+    assert!(
+        aud_contains(&ts.access_token, RES_REFRESH),
+        "initial access token `aud` must contain the requested resource"
+    );
+
+    // silent re-auth via `POST /oidc/authorize/refresh` on the SAME session, same `resource`.
+    // `LoginRefreshRequest` is deserialize-only (no `Serialize`), so build the body as raw JSON.
+    let req_refresh = serde_json::json!({
+        "client_id": ID_REFRESH,
+        "redirect_uri": redirect_uri,
+        "nonce": "MySuperNonce",
+        "code_challenge": challenge_s256,
+        "code_challenge_method": "S256",
+        "resource": RES_REFRESH,
+    });
+    let res = http
+        .post(format!("{backend_url}/oidc/authorize/refresh"))
+        .headers(session_headers.clone())
+        .json(&req_refresh)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 202);
+    let (code_refresh, _state) = code_state_from_headers(res)?;
+
+    let token_req = TokenRequest {
+        grant_type: "authorization_code".to_string(),
+        code: Some(code_refresh),
+        redirect_uri: Some(redirect_uri.clone()),
+        client_id: Some(ID_REFRESH.to_string()),
+        client_secret: None,
+        code_verifier: Some(challenge_plain.to_string()),
+        device_code: None,
+        username: None,
+        password: None,
+        refresh_token: None,
+        resource: Some(RES_REFRESH.to_string()),
+    };
+    let res = http
+        .post(format!("{backend_url}/oidc/token"))
+        .form(&token_req)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let ts_refresh = res.json::<TokenSet>().await?;
+    // the crux of #1645: the re-issued token must STILL be audience-bound to the resource
+    assert!(
+        aud_contains(&ts_refresh.access_token, RES_REFRESH),
+        "access token from /authorize/refresh must still contain the resource in `aud`"
+    );
 
     Ok(())
 }

--- a/src/common/src/regex.rs
+++ b/src/common/src/regex.rs
@@ -71,6 +71,10 @@ pub static RE_STREET: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9À-ÿ-.\s]{0,48}$").unwrap());
 pub static RE_URI: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%@]+$").unwrap());
+// Like `RE_URI` but WITHOUT `#`, so a value cannot contain a fragment. Used for RFC 8707
+// `resource` indicators, which MUST be an absolute URI without a fragment (RFC 8707 §2).
+pub static RE_RESOURCE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~!$'()*+%@]+$").unwrap());
 pub static RE_USER_NAME: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[a-zA-Z0-9À-ɏ-'\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{1,32}$").unwrap()
 });

--- a/src/service/src/oidc/authorize.rs
+++ b/src/service/src/oidc/authorize.rs
@@ -184,8 +184,9 @@ pub async fn post_authorize_refresh(
             nonce: req_data.nonce,
             code_challenge: req_data.code_challenge,
             code_challenge_method: req_data.code_challenge_method,
-            // a session refresh has no new authorization request to carry a `resource`
-            resource: None,
+            // the silent re-auth authorize request still carries the RFC 8707 `resource`,
+            // thread it through so audience-bound tokens survive subsequent logins
+            resource: req_data.resource,
             header_origin,
             require_webauthn,
         },


### PR DESCRIPTION
`resource` is accepted on `/oidc/authorize` but dropped on `/oidc/authorize/refresh`: `LoginRefreshRequest` has no `resource` field and `post_authorize_refresh` hard-codes `resource: None`, so it never reaches the new auth code. Audience binding works on a user's first login and silently breaks on every later one once a session exists (the `/token` call then fails with "the requested resource was not granted at the authorization request").

The fix adds the field and threads it through the same `AuthorizeData` -> `finish_authorize` path the full-login flow already uses, so it's validated the same way via `client.validate_resource_request`. The `refresh_token` grant is untouched.

It also tightens the `resource` validators to reject a `#` fragment. RFC 8707 §2 wants an absolute URI without one, the shared `RE_URI` allowed it, and the field docs already said "without a fragment". I flagged this in the issue thread.

One caveat: the UI still needs to forward `resource` on the `/authorize/refresh` POST for the full end-to-end path. The backend now accepts and carries it.

Regression test in `handler_1645_resource_refresh.rs`: log in with a `resource` and check `aud`, then do a silent re-auth via `/authorize/refresh` with the same `resource` and check the re-issued token still has it in `aud`. The last assertion fails without the fix. Validator unit tests cover a valid resource, a malformed one, and one with a fragment.

Closes #1645. (#1654 is the same authorize/refresh path for `auth_time`, handled separately in #1659.)