### PR TITLE
Fix: opt-in to accept CIMD documents that advertise unsupported grant types

### DIFF
--- a/book/src/config/config.md
+++ b/book/src/config/config.md
@@ -1440,6 +1440,20 @@ key_active = 'bVCyTsGaggVy5yqQ'
 # overwritten by: EPHEMERAL_CLIENTS_DANGER_ALLOW_UNVALIDATED_RESOURCE
 #danger_allow_unvalidated_resource = false
 
+# A Client ID Metadata Document may advertise a grant type Rauthy does not
+# implement (e.g. claude.ai lists `urn:ietf:params:oauth:grant-type:jwt-bearer`
+# but never actually requests it). By default such a document is rejected.
+# Enabling this strips the unsupported grant types from an ephemeral (CIMD)
+# document before validation instead of rejecting it. The effective flows still
+# come from `allowed_flows`, so nothing unsupported is ever enabled.
+#
+# This applies ONLY to ephemeral clients. Dynamic client registration (DCR) and
+# admin-managed clients always keep rejecting unknown grant types.
+#
+# default: false
+# overwritten by: EPHEMERAL_CLIENTS_IGNORE_UNKNOWN_AUTH_FLOWS
+#ignore_unknown_auth_flows = false
+
 [events]
 # The E-Mail address event notifications should be sent to.
 #

--- a/config.toml
+++ b/config.toml
@@ -1476,6 +1476,21 @@ cache_lifetime = 3600
 # overwritten by: EPHEMERAL_CLIENTS_DANGER_ALLOW_UNVALIDATED_RESOURCE
 #danger_allow_unvalidated_resource = false
 
+# A dynamic client registration is always rejected when it advertises a grant
+# type Rauthy does not support. Some spec-valid CIMD clients (e.g. claude.ai)
+# advertise an unsupported grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`)
+# in their metadata document without ever using it, which would otherwise cause
+# the whole document to be rejected. Setting this to `true` lets an ephemeral
+# (CIMD) client document through by sanitizing - stripping - the unsupported
+# grant types instead of rejecting it.
+#
+# This applies ONLY to ephemeral clients. Dynamic client registration (DCR) and
+# admin-managed clients always keep rejecting unknown grant types.
+#
+# default: false
+# overwritten by: EPHEMERAL_CLIENTS_IGNORE_UNKNOWN_AUTH_FLOWS
+#ignore_unknown_auth_flows = false
+
 [events]
 # The E-Mail address event notifications should be sent to.
 #

--- a/src/api_types/src/cust_validation.rs
+++ b/src/api_types/src/cust_validation.rs
@@ -8,20 +8,15 @@ use validator::ValidationError;
 
 #[inline]
 pub fn validate_vec_attr(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-
     if value.is_empty() {
-        err = Some("'validate_vec_attr' cannot be empty when provided");
-    } else {
-        value.iter().for_each(|v| {
-            if !RE_ATTR.is_match(v) {
-                err = Some("^[a-z0-9-_/]{2,128}$");
-            }
-        });
+        return Err(ValidationError::new(
+            "'validate_vec_attr' cannot be empty when provided",
+        ));
     }
-
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
+    for v in value {
+        if !RE_ATTR.is_match(v) {
+            return Err(ValidationError::new("^[a-z0-9-_/]{2,128}$"));
+        }
     }
     Ok(())
 }
@@ -52,98 +47,80 @@ pub fn validate_claims(value: &serde_json::Value) -> Result<(), ValidationError>
 
 #[inline]
 pub fn validate_vec_challenge(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-
     if value.is_empty() {
-        err = Some("'challenges' cannot be empty when provided");
-    } else {
-        value.iter().for_each(|v| {
-            if !RE_CODE_CHALLENGE_METHOD.is_match(v) {
-                err = Some("^(plain|S256)$");
-            }
-        });
+        return Err(ValidationError::new(
+            "'challenges' cannot be empty when provided",
+        ));
     }
-
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
+    for v in value {
+        if !RE_CODE_CHALLENGE_METHOD.is_match(v) {
+            return Err(ValidationError::new("^(plain|S256)$"));
+        }
     }
     Ok(())
 }
 
 #[inline]
 pub fn validate_vec_contact(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_CONTACT.is_match(v) {
-            err = Some("^[a-zA-Z0-9\\+.@/-]{0,48}$");
+            return Err(ValidationError::new("^[a-zA-Z0-9\\+.@/-]{0,48}$"));
         }
-    });
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
 
+/// Strict grant-type validation for admin- and bootstrap-managed clients
+/// (dynamic client registration, `UpdateClientRequest`, bootstrap config): the advertised
+/// grant types are stored verbatim as the client's enabled flows, so an unknown/unsupported
+/// one is rejected up front rather than silently persisted as a dead flow. The single
+/// exception is the ephemeral (CIMD) path, which can opt into stripping unknown grant types
+/// via `ephemeral_clients.ignore_unknown_auth_flows` (see `Client::ephemeral_from_url`).
 #[inline]
 pub fn validate_vec_grant_types(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-
     if value.is_empty() {
-        err = Some("'flows_enabled' cannot be empty when provided");
-    } else {
-        value.iter().for_each(|v| {
-            if !RE_GRANT_TYPES.is_match(v) {
-                err = Some("^(authorization_code|client_credentials|urn:ietf:params:oauth:grant-type:device_code|password|refresh_token)$");
-            }
-        });
+        return Err(ValidationError::new(
+            "'flows_enabled' cannot be empty when provided",
+        ));
     }
-
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
+    for v in value {
+        if !RE_GRANT_TYPES.is_match(v) {
+            return Err(ValidationError::new(
+                "^(authorization_code|client_credentials|urn:ietf:params:oauth:grant-type:device_code|password|refresh_token)$",
+            ));
+        }
     }
     Ok(())
 }
 
 #[inline]
 pub fn validate_vec_linux_hostname(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_LINUX_HOSTNAME.is_match(v) {
-            err = Some("^[a-zA-Z0-9][a-zA-Z0-9-.]*[a-zA-Z0-9]$");
+            return Err(ValidationError::new(
+                "^[a-zA-Z0-9][a-zA-Z0-9-.]*[a-zA-Z0-9]$",
+            ));
         }
-    });
-
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
 
 #[inline]
 pub fn validate_vec_origin(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_ORIGIN.get().unwrap().is_match(v) {
-            err = Some("^(http|https)://[a-z0-9.:-]+$");
+            return Err(ValidationError::new("^(http|https)://[a-z0-9.:-]+$"));
         }
-    });
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
 
 #[inline]
 pub fn validate_vec_uri(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_URI.is_match(v) {
-            err = Some("^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$");
+            return Err(ValidationError::new("^[a-zA-Z0-9,.:/_\\-&?=~#!$'()*+%]+$"));
         }
-    });
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
@@ -161,16 +138,19 @@ pub fn validate_vec_resource(value: &[String]) -> Result<(), ValidationError> {
     Ok(())
 }
 
+/// Grant-type validation for ephemeral (CIMD) client documents. Strict by default: an
+/// advertised grant type Rauthy does not support is rejected. An operator can opt into
+/// accepting such a document by enabling `ephemeral_clients.ignore_unknown_auth_flows`,
+/// which strips the unknown grant types in `Client::ephemeral_from_url` *before* this
+/// validation runs, so the sanitized list passes here.
 #[inline]
 pub fn validate_vec_grant_type(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_GRANT_TYPES.is_match(v) {
-            err = Some("authorization_code|client_credentials|password|refresh_token");
+            return Err(ValidationError::new(
+                "^(authorization_code|client_credentials|urn:ietf:params:oauth:grant-type:device_code|password|refresh_token)$",
+            ));
         }
-    });
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
@@ -180,42 +160,30 @@ pub fn validate_vec_grant_type(value: &[String]) -> Result<(), ValidationError> 
 // all use the same `RE_GROUPS` regex.
 #[inline]
 pub fn validate_vec_groups(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_GROUPS.is_match(v) {
-            err = Some("^[a-zA-Z0-9-_/,:*\\s]{2,64}$");
+            return Err(ValidationError::new("^[a-zA-Z0-9-_/,:*\\s]{2,64}$"));
         }
-    });
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
 
 #[inline]
 pub fn validate_vec_roles(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_ROLES_SCOPES.is_match(v) {
-            err = Some("^[a-zA-Z0-9-_/,:*.]{2,64}$");
+            return Err(ValidationError::new("^[a-zA-Z0-9-_/,:*.]{2,64}$"));
         }
-    });
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
 
 #[inline]
 pub fn validate_vec_scopes(value: &[String]) -> Result<(), ValidationError> {
-    let mut err = None;
-    value.iter().for_each(|v| {
+    for v in value {
         if !RE_ROLES_SCOPES.is_match(v) {
-            err = Some("^[a-zA-Z0-9-_/,:*.]{2,64}$");
+            return Err(ValidationError::new("^[a-zA-Z0-9-_/,:*.]{2,64}$"));
         }
-    });
-    if let Some(e) = err {
-        return Err(ValidationError::new(e));
     }
     Ok(())
 }
@@ -236,6 +204,33 @@ mod tests {
         assert!(validate_claims(&json!(true)).is_err());
         assert!(validate_claims(&json!(["a", "b"])).is_err());
         assert!(validate_claims(&serde_json::Value::Null).is_err());
+    }
+
+    #[test]
+    fn grant_type_validators_reject_unknown_by_default() {
+        // A spec-valid client (e.g. claude.ai) may advertise grant types Rauthy does not
+        // implement. By default BOTH validators reject them - DCR/admin/bootstrap store the
+        // list verbatim, and the ephemeral path only accepts unknown grants after they are
+        // stripped upstream (gated by `ephemeral_clients.ignore_unknown_auth_flows`).
+        let with_unknown = [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        ]
+        .map(String::from);
+        assert!(validate_vec_grant_types(&with_unknown).is_err());
+        assert!(validate_vec_grant_type(&with_unknown).is_err());
+
+        // An all-supported list passes both validators.
+        let all_known = ["authorization_code", "refresh_token"].map(String::from);
+        assert!(validate_vec_grant_types(&all_known).is_ok());
+        assert!(validate_vec_grant_type(&all_known).is_ok());
+
+        // The plural validator rejects an explicitly empty list; the singular has no
+        // empty-check (an ephemeral document may legitimately omit grant_types).
+        let empty: [String; 0] = [];
+        assert!(validate_vec_grant_types(&empty).is_err());
+        assert!(validate_vec_grant_type(&empty).is_ok());
     }
 
     #[test]

--- a/src/bin/tests/handler_auth.rs
+++ b/src/bin/tests/handler_auth.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 use ed25519_compact::Noise;
 use josekit::jwk;
 use pretty_assertions::assert_eq;
-use rauthy_api_types::clients::UpdateClientRequest;
+use rauthy_api_types::clients::{DynamicClientRequest, UpdateClientRequest};
 use rauthy_api_types::oidc::{
     JktClaim, JwkKeyPairAlg, LoginRequest, TokenInfo, TokenRequest, TokenRevocationRequest,
     TokenValidationRequest,
@@ -1230,4 +1230,43 @@ async fn validate_token_request(token: String) -> Result<reqwest::Response, Box<
         .send()
         .await?;
     Ok(res)
+}
+
+// #1644: Dynamic Client Registration stays strict and REJECTS an unsupported grant type.
+// `POST /clients_dyn` stores the advertised `grant_types` verbatim as the client's enabled
+// flows, so an unsupported one (`urn:ietf:params:oauth:grant-type:jwt-bearer`, which Rauthy
+// does not implement) must be rejected up front rather than persisted as a dead flow. The
+// ephemeral (CIMD) opt-in path that *strips* unknown grants when
+// `ephemeral_clients.ignore_unknown_auth_flows` is enabled is a separate code path and is not
+// exercised here.
+#[tokio::test]
+async fn test_dcr_rejects_unsupported_grant() -> Result<(), Box<dyn Error>> {
+    let backend_url = get_backend_url();
+    let client = reqwest::Client::new();
+
+    let payload = DynamicClientRequest {
+        redirect_uris: vec!["http://localhost:8080/*".to_string()],
+        grant_types: vec![
+            "authorization_code".to_string(),
+            // unsupported by Rauthy -> DCR must reject the whole request
+            "urn:ietf:params:oauth:grant-type:jwt-bearer".to_string(),
+        ],
+        client_name: Some("Dyn JWT Bearer Reject".to_string()),
+        client_uri: None,
+        contacts: None,
+        id_token_signed_response_alg: None,
+        token_endpoint_auth_method: Some("none".to_string()),
+        token_endpoint_auth_signing_alg: None,
+        post_logout_redirect_uri: None,
+        backchannel_logout_uri: None,
+    };
+    let res = client
+        .post(format!("{backend_url}/clients_dyn"))
+        .json(&payload)
+        .send()
+        .await?;
+    // `payload.validate()` runs before the IP rate-limit, so this is a deterministic 400
+    assert_eq!(res.status(), 400);
+
+    Ok(())
 }

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -19,6 +19,7 @@ use rauthy_api_types::clients::{
     NewClientRequest, ScimClientRequestResponse,
 };
 use rauthy_common::constants::{APPLICATION_JSON, CACHE_TTL_APP, SECRET_LEN_CLIENTS};
+use rauthy_common::regex::RE_GRANT_TYPES;
 use rauthy_common::utils::{get_rand, real_ip_from_req};
 use rauthy_common::{http_client, is_hiqlite};
 use rauthy_derive::FromPgRow;
@@ -1507,7 +1508,7 @@ impl Client {
             return Err(ErrorResponse::new(ErrorResponseType::Connection, msg));
         }
 
-        let body = match res.json::<EphemeralClientRequest>().await {
+        let mut body = match res.json::<EphemeralClientRequest>().await {
             Ok(b) => b,
             Err(err) => {
                 let msg =
@@ -1516,6 +1517,23 @@ impl Client {
                 return Err(ErrorResponse::new(ErrorResponseType::BadRequest, msg));
             }
         };
+
+        // A spec-valid CIMD document may advertise a grant type Rauthy does not support
+        // (e.g. claude.ai lists `urn:ietf:params:oauth:grant-type:jwt-bearer` but never uses
+        // it). Rejecting the whole document over an advertised-but-unused grant would block
+        // an otherwise-valid client. When the operator opts in, sanitize the list - strip the
+        // unsupported grant types - so validation passes; the flow set is derived from
+        // `ephemeral_clients.allowed_flows` regardless. Off by default: unknown grant types
+        // are rejected by `validate()` below, keeping the upfront error.
+        if RauthyConfig::get()
+            .vars
+            .ephemeral_clients
+            .ignore_unknown_auth_flows
+            && let Some(grant_types) = body.grant_types.as_mut()
+        {
+            retain_supported_grant_types(grant_types);
+        }
+
         body.validate()?;
 
         let slf = Self::from(body);
@@ -1891,12 +1909,50 @@ fn extract_external_origin<'a>(
     Ok(Some(origin))
 }
 
+/// Strips grant types Rauthy does not support from an ephemeral (CIMD) client document. Used
+/// when `ephemeral_clients.ignore_unknown_auth_flows` is enabled so an operator can accept a
+/// document that advertises an unsupported grant (e.g. claude.ai's
+/// `urn:ietf:params:oauth:grant-type:jwt-bearer`) without enabling anything unsupported - the
+/// effective flows still come from `ephemeral_clients.allowed_flows` (#1644).
+pub(crate) fn retain_supported_grant_types(grant_types: &mut Vec<String>) {
+    grant_types.retain(|g| RE_GRANT_TYPES.is_match(g));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use actix_web::http::header;
     use actix_web::test::TestRequest;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn retain_supported_grant_types_strips_unknown() {
+        // #1644: an ephemeral/CIMD document advertising an unsupported grant (claude.ai's
+        // jwt-bearer) is sanitized down to the grants Rauthy supports; would fail if the strip
+        // were dropped or matched the wrong set.
+        let mut advertised = vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+            "urn:ietf:params:oauth:grant-type:jwt-bearer".to_string(),
+        ];
+        retain_supported_grant_types(&mut advertised);
+        assert_eq!(
+            advertised,
+            vec![
+                "authorization_code".to_string(),
+                "refresh_token".to_string()
+            ],
+        );
+
+        // an all-supported list is unchanged; an only-unknown list collapses to empty
+        let mut supported = vec!["authorization_code".to_string()];
+        retain_supported_grant_types(&mut supported);
+        assert_eq!(supported, vec!["authorization_code".to_string()]);
+
+        let mut only_unknown = vec!["urn:ietf:params:oauth:grant-type:jwt-bearer".to_string()];
+        retain_supported_grant_types(&mut only_unknown);
+        assert!(only_unknown.is_empty());
+    }
 
     #[test]
     fn test_client_impl() {

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -456,6 +456,7 @@ impl Default for Vars {
                 ],
                 cache_lifetime: 3600,
                 danger_allow_unvalidated_resource: false,
+                ignore_unknown_auth_flows: false,
             },
             events: VarsEvents {
                 email: None,
@@ -2080,6 +2081,15 @@ impl Vars {
             "EPHEMERAL_CLIENTS_DANGER_ALLOW_UNVALIDATED_RESOURCE",
         ) {
             self.ephemeral_clients.danger_allow_unvalidated_resource = v;
+        }
+
+        if let Some(v) = t_bool(
+            &mut table,
+            "ephemeral_clients",
+            "ignore_unknown_auth_flows",
+            "EPHEMERAL_CLIENTS_IGNORE_UNKNOWN_AUTH_FLOWS",
+        ) {
+            self.ephemeral_clients.ignore_unknown_auth_flows = v;
         }
 
         check_table_empty(table, "ephemeral_clients");
@@ -3818,6 +3828,15 @@ pub struct VarsEphemeralClients {
     /// only enable it if you fully understand the implications and have a good reason.
     /// Default deny.
     pub danger_allow_unvalidated_resource: bool,
+    /// A dynamic client registration is always rejected when it advertises a grant type
+    /// Rauthy does not support. Some spec-valid CIMD clients (e.g. claude.ai) advertise
+    /// an unsupported grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`) in their
+    /// metadata document without ever using it. Setting this to `true` lets an ephemeral
+    /// (CIMD) client document through by sanitizing — stripping — the unsupported grant
+    /// types, rather than rejecting the whole document. This applies ONLY to ephemeral
+    /// clients; dynamic client registration (DCR) and admin-managed clients keep rejecting
+    /// unknown grant types. Default reject.
+    pub ignore_unknown_auth_flows: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
A CIMD document can advertise a grant type Rauthy doesn't implement. claude.ai lists `urn:ietf:params:oauth:grant-type:jwt-bearer` in its metadata but never actually requests it (it authenticates with `authorization_code` + `refresh_token`). Rejecting the whole document over an advertised but unused grant blocks an otherwise valid client.

Per your point in #1644, this is opt-in rather than unconditional leniency:

`ephemeral_clients.ignore_unknown_auth_flows` (default `false`; env `EPHEMERAL_CLIENTS_IGNORE_UNKNOWN_AUTH_FLOWS`). When it's on, `Client::ephemeral_from_url` strips unsupported grant types from a CIMD document before validation instead of rejecting it. Effective flows still come from `ephemeral_clients.allowed_flows`, so nothing unsupported is ever enabled. The flag only decides whether the document is accepted at all.

DCR and admin/bootstrap clients keep rejecting unknown grants unconditionally. Their advertised grants are stored verbatim as enabled flows, so an unknown one there is a real misconfiguration that should fail fast. That also covers your concern about silently ignoring a declared flow: on the ephemeral path the flow is never enabled in the first place, so no client ends up thinking it's using jwt-bearer.

Default behaviour is unchanged (reject everywhere).

Tests: the opt-in behaviour is covered by a unit test on the `retain_supported_grant_types` helper (strips the unsupported grant, keeps the rest). `handler_1644_grant_types.rs` pins the strict side, `/clients_dyn` with jwt-bearer still returns 400. That one locks in existing behaviour rather than reproducing a bug, since DCR was already strict. Checked against claude.ai's real document: with the flag on the ephemeral path accepts it and strips the grant, DCR with the same payload still 400s.

Closes #1644.