### PR TITLE
UI: keep the password reset / new account form inside short landscape viewports

### DIFF
--- a/frontend/src/lib/PasswordPolicy.svelte
+++ b/frontend/src/lib/PasswordPolicy.svelte
@@ -170,6 +170,11 @@
     ul {
         margin-left: 1rem;
         list-style: none;
+        /* Two columns when the host page is wide enough (halves the block's
+           height on short landscape viewports), single column otherwise. */
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+        column-gap: 1rem;
     }
 
     li {

--- a/frontend/src/routes/users/{id}/reset/reset/+page.svelte
+++ b/frontend/src/routes/users/{id}/reset/reset/+page.svelte
@@ -372,6 +372,17 @@
         overflow-y: auto;
     }
 
+    /* Keep the whole form (incl. the Save button) inside short landscape
+       viewports (e.g. iPad landscape ~700px, where the on-screen keyboard
+       shrinks only the visual viewport and hides anything below it). */
+    .container h1 {
+        margin: 0.5rem 0;
+    }
+
+    .container p {
+        margin: 0.25rem 0;
+    }
+
     .err {
         margin-top: 0.5rem;
         max-width: 20rem;
@@ -388,7 +399,7 @@
     }
 
     .generate {
-        margin-bottom: 0.66rem;
+        margin-bottom: 0.25rem;
     }
 
     .policy {
@@ -397,7 +408,7 @@
     }
 
     .typeChoice {
-        margin-bottom: 1rem;
+        margin-bottom: 0.5rem;
         display: flex;
         gap: 0.5rem;
     }


### PR DESCRIPTION
Fixes #1660.

## Problem

On tablets in landscape (layout height ~620–730 px once browser chrome is
subtracted) the expanded password form on
`/auth/v1/users/{id}/reset/{code}` is taller (691 px, EN) than the page's height
budget. The document itself never scrolls (`body`/`Main`/`ContentCenter` are pinned to
`100dvh`) and the `.container` clamp leaves ~31 px of inner scroll, so the Save button
sits ~3 px from the viewport's bottom edge. On iOS the on-screen keyboard shrinks only
the visual viewport — not `dvh` — so the keyboard covers Save with no scroll path left.
Real-world effect: a new user on an iPad in landscape cannot save their initial
password (rotating to portrait is the workaround). Full analysis and measurements in
#1660.

## Change (CSS-only, two files)

- `frontend/src/lib/PasswordPolicy.svelte` — policy `ul` becomes a responsive grid:
  `repeat(auto-fit, minmax(14rem, 1fr))`. Two columns on wide pages; narrow hosts
  (account page) stay single-column and visually unchanged.
- `frontend/src/routes/users/{id}/reset/reset/+page.svelte` — tighter vertical rhythm
  scoped to this page: `h1` 1rem→0.5rem, `p` 0.5rem→0.25rem, `.typeChoice`
  1rem→0.5rem, `.generate` 0.66rem→0.25rem. The existing `max-height` clamp stays as
  the fallback for even shorter viewports.

## Measured effect

Form height 691 → **581 px** (EN); minimum viewport height with Save fully visible and
zero scrolling: **~731 → ~621 px**. Checked over a 20-viewport matrix (Galaxy S8+,
iPhone SE/15 Pro/15 Pro Max, Pixel 7, iPad mini/Air/Pro 12.9 — portrait and landscape —
plus chrome-reduced and keyboard-strip heights), asserting per viewport: Save reachable
(directly or via the container's scroll), no top clipping, no horizontal overflow, no
overlap between the absolute theme/language widgets and the form. No regressions;
the tablet-landscape band that produced the field report now fits without scrolling.
Happy to also contribute the matrix script if you want it in the repo.

## Notes

- `prettier --check` passes on both files; `svelte-check` reports only the two
  pre-existing `src/wasm/*` module errors (generated artifacts not present in a fresh
  clone without the Rust toolchain).
- Narrow phone portrait (375×667) still uses the scroll path (form is 725 px there);
  a full no-scroll fit would need content changes (e.g. collapsible policy list) —
  left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkiUm4ngAaGoUwuV5n3mVU
