### PR TITLE
Fix: forward RFC 8707 `resource` on the session-refresh login (SPA, follow-up to #1657)

### DIFF
--- a/frontend/src/api/types/authorize.ts
+++ b/frontend/src/api/types/authorize.ts
@@ -40,6 +40,9 @@ export interface LoginRefreshRequest {
     /// Validation: PATTERN_CODE_CHALLENGE
     code_challenge?: string;
     code_challenge_method?: CodeChallengeMethod;
+    /// RFC 8707 resource indicator forwarded from the authorization request.
+    /// Validation: PATTERN_URI
+    resource?: string;
 }
 
 export interface RequestResetRequest {

--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -228,6 +228,9 @@
             payload.code_challenge = challenge;
             payload.code_challenge_method = challengeMethod;
         }
+        if (resource) {
+            payload.resource = resource;
+        }
 
         let res = await fetchPost<undefined | WebauthnLoginResponse>(
             '/auth/v1/oidc/authorize/refresh',

--- a/src/api_types/src/oidc.rs
+++ b/src/api_types/src/oidc.rs
@@ -5,7 +5,7 @@ use actix_web::HttpRequest;
 use actix_web::http::header;
 use rauthy_common::regex::{
     RE_ALNUM, RE_BASE64, RE_CLIENT_ID, RE_CODE_CHALLENGE_METHOD, RE_CODE_VERIFIER, RE_GRANT_TYPES,
-    RE_LOWERCASE, RE_SCOPE_SPACE, RE_URI,
+    RE_LOWERCASE, RE_SCOPE_SPACE, RE_URI, RE_URI_RESOURCE,
 };
 use rauthy_common::utils::base64_decode;
 use rauthy_error::{ErrorResponse, ErrorResponseType};
@@ -66,8 +66,8 @@ pub struct AuthRequest {
     /// requested resource is validated against the client's `allowed_resources` and,
     /// on success, added to the issued access token's `aud`.
     ///
-    /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$`
-    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$"))]
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_URI_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
     pub resource: Option<String>,
 }
 
@@ -138,8 +138,8 @@ pub struct LoginRequest {
     /// RFC 8707 resource indicator forwarded from the authorization request, carried
     /// into the auth code so the issued access token can be audience-restricted.
     ///
-    /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$`
-    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$"))]
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_URI_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
     pub resource: Option<String>,
 }
 
@@ -169,6 +169,12 @@ pub struct LoginRefreshRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
     pub code_challenge_method: Option<String>,
+    /// RFC 8707 resource indicator forwarded from the authorization request, carried
+    /// into the auth code so the issued access token can be audience-restricted.
+    ///
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_URI_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
+    pub resource: Option<String>,
 }
 
 #[derive(Default, Deserialize, Validate, ToSchema, IntoParams)]
@@ -269,8 +275,8 @@ pub struct TokenRequest {
     /// `refresh_token` grant it may only narrow (be a subset of) the resources granted
     /// to the original token, never widen them.
     ///
-    /// Validation: `[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$`
-    #[validate(regex(path = "*RE_URI", code = "[a-zA-Z0-9,.:/_-&?=~#!$'()*+%@]+$"))]
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_URI_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
     pub resource: Option<String>,
 }
 
@@ -518,4 +524,64 @@ pub struct TokenInfo<'a> {
     pub exp: Option<i64>,
     #[serde(borrow, skip_serializing_if = "Option::is_none")]
     pub cnf: Option<JktClaim<'a>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use validator::Validate;
+
+    // Regression test for RFC 8707 `resource` being dropped on the silent re-auth path.
+    // The refresh authorize request must deserialize and validate a `resource` just like
+    // the full-login `LoginRequest` does, so audience-bound tokens survive later logins.
+    #[test]
+    fn login_refresh_request_carries_valid_resource() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "https://mcp.example.com/mcp"
+        }"#;
+
+        let req: LoginRefreshRequest =
+            serde_json::from_str(json).expect("must deserialize the resource field");
+        assert_eq!(req.resource.as_deref(), Some("https://mcp.example.com/mcp"));
+        assert!(
+            req.validate().is_ok(),
+            "a valid absolute-URI resource must pass validation"
+        );
+    }
+
+    #[test]
+    fn login_refresh_request_rejects_invalid_resource() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "not a valid uri"
+        }"#;
+
+        let req: LoginRefreshRequest =
+            serde_json::from_str(json).expect("must deserialize even an invalid resource");
+        assert!(
+            req.validate().is_err(),
+            "a resource with disallowed characters must fail validation"
+        );
+    }
+
+    // RFC 8707 §2: the `resource` MUST be an absolute URI without a fragment. The
+    // fragment-excluding `RE_URI_RESOURCE` validator must reject a `#` fragment.
+    #[test]
+    fn login_refresh_request_rejects_resource_with_fragment() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "https://mcp.example.com/mcp#frag"
+        }"#;
+
+        let req: LoginRefreshRequest =
+            serde_json::from_str(json).expect("must deserialize even a fragmented resource");
+        assert!(
+            req.validate().is_err(),
+            "a resource containing a URI fragment must fail validation"
+        );
+    }
 }

--- a/src/bin/tests/handler_1645_resource_refresh.rs
+++ b/src/bin/tests/handler_1645_resource_refresh.rs
@@ -1,0 +1,225 @@
+use crate::common::{
+    PASSWORD, USERNAME, code_state_from_headers, cookie_csrf_headers_from_res_direct,
+    get_auth_headers, get_backend_url, get_solved_pow,
+};
+use pretty_assertions::assert_eq;
+use rauthy_api_types::clients::{ClientResponse, NewClientRequest, UpdateClientRequest};
+use rauthy_api_types::oidc::{JwkKeyPairAlg, LoginRequest, TokenRequest};
+use rauthy_common::sha256;
+use rauthy_common::utils::{base64_url_encode, base64_url_no_pad_decode};
+use rauthy_service::token_set::TokenSet;
+use std::error::Error;
+
+mod common;
+
+const RID: &str = "res_refresh_test";
+const RESOURCE: &str = "https://rs.example.com/mcp";
+
+fn decode_payload(token: &str) -> serde_json::Value {
+    let payload_b64 = token.split('.').nth(1).expect("a JWT payload segment");
+    let bytes = base64_url_no_pad_decode(payload_b64).expect("valid base64url payload");
+    serde_json::from_slice(&bytes).expect("valid JSON claims")
+}
+
+fn aud_contains(token: &str, expected: &str) -> bool {
+    let claims = decode_payload(token);
+    match claims.get("aud") {
+        Some(serde_json::Value::String(s)) => s == expected,
+        Some(serde_json::Value::Array(arr)) => arr.iter().any(|v| v.as_str() == Some(expected)),
+        _ => false,
+    }
+}
+
+// -----------------------------------------------------------------------------------------
+// #1645 - the RFC 8707 `resource` indicator must survive the silent re-auth path
+// (`POST /oidc/authorize/refresh`).
+//
+// When a still-valid session re-issues a code via the silent re-auth endpoint, the
+// authorization request still carries the `resource`. Before the fix, `post_authorize_refresh`
+// dropped it, so the re-issued auth code (and thus the exchanged access token) lost the
+// audience restriction and its `aud` no longer contained the resource.
+//
+// This test drives the full flow end-to-end:
+//   (a) create a client with `allowed_resources` = [RESOURCE]
+//   (b) full authorization_code login WITH `resource`, exchange -> assert `aud` contains RESOURCE
+//   (c) hit `POST /oidc/authorize/refresh` on the SAME authenticated session WITH the same
+//       `resource`, exchange the new code -> assert `aud` STILL contains RESOURCE
+//
+// Without the fix, step (c)'s token drops the resource and the final `aud` assertion fails.
+// -----------------------------------------------------------------------------------------
+#[tokio::test]
+async fn test_1645_resource_survives_authorize_refresh() -> Result<(), Box<dyn Error>> {
+    let backend_url = get_backend_url();
+    let auth_headers = get_auth_headers().await?;
+    let http = reqwest::Client::new();
+
+    let redirect_uri = "http://localhost:3000/oidc/callback".to_string();
+    let challenge_plain = "oDXug9zfYqfz8ejcqMpALRPXfW8QhbKV2AVuScAt8xrLKDAmaRYQ4yRi2uqcH9ys";
+    let challenge_s256 = base64_url_encode(sha256!(challenge_plain.as_bytes()));
+
+    // (a) create a public client (PKCE, no secret) and configure `allowed_resources`
+    let new_client = NewClientRequest {
+        id: RID.to_string(),
+        secret: None,
+        name: Some("Resource Refresh Test".to_string()),
+        confidential: false,
+        redirect_uris: vec![redirect_uri.clone()],
+        post_logout_redirect_uris: None,
+    };
+    let res = http
+        .post(format!("{backend_url}/clients"))
+        .headers(auth_headers.clone())
+        .json(&new_client)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+
+    let upd = UpdateClientRequest {
+        name: Some("Resource Refresh Test".to_string()),
+        confidential: false,
+        redirect_uris: vec![redirect_uri.clone()],
+        post_logout_redirect_uris: None,
+        allowed_origins: None,
+        enabled: true,
+        flows_enabled: vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ],
+        access_token_alg: JwkKeyPairAlg::EdDSA,
+        id_token_alg: JwkKeyPairAlg::EdDSA,
+        auth_code_lifetime: 60,
+        access_token_lifetime: 300,
+        scopes: vec!["openid".to_string()],
+        default_scopes: vec!["openid".to_string()],
+        challenges: Some(vec!["S256".to_string()]),
+        force_mfa: false,
+        client_uri: None,
+        contacts: None,
+        backchannel_logout_uri: None,
+        restrict_group_prefix: None,
+        claims: None,
+        claims_at_root: false,
+        allowed_resources: Some(vec![RESOURCE.to_string()]),
+        default_aud: None,
+        scim: None,
+    };
+    let res = http
+        .put(format!("{backend_url}/clients/{RID}"))
+        .headers(auth_headers.clone())
+        .json(&upd)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let resp = res.json::<ClientResponse>().await?;
+    assert_eq!(resp.allowed_resources, Some(vec![RESOURCE.to_string()]));
+
+    // Init session (cookie + CSRF) we authenticate then reuse for the silent re-auth call.
+    let res = http
+        .post(format!("{backend_url}/oidc/session"))
+        .send()
+        .await?;
+    assert!(res.status().is_success());
+    let session_headers = cookie_csrf_headers_from_res_direct(res).await?;
+
+    // (b) full authorization_code login WITH the RFC 8707 `resource`
+    let query_pkce = format!(
+        "client_id={RID}&redirect_uri={redirect_uri}&response_type=code\
+        &code_challenge={challenge_s256}&code_challenge_method=S256"
+    );
+    let url_auth = format!("{backend_url}/oidc/authorize?{query_pkce}");
+
+    let req_login = LoginRequest {
+        email: USERNAME.to_string(),
+        password: Some(PASSWORD.to_string()),
+        pow: get_solved_pow().await,
+        client_id: RID.to_string(),
+        redirect_uri: redirect_uri.clone(),
+        scopes: None,
+        state: None,
+        nonce: Some("MySuperNonce".to_string()),
+        code_challenge: Some(challenge_s256.clone()),
+        code_challenge_method: Some("S256".to_string()),
+        resource: Some(RESOURCE.to_string()),
+    };
+    let res = http
+        .post(&url_auth)
+        .headers(session_headers.clone())
+        .json(&req_login)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 202);
+    let (code, _state) = code_state_from_headers(res)?;
+
+    let token_req = TokenRequest {
+        grant_type: "authorization_code".to_string(),
+        code: Some(code),
+        redirect_uri: Some(redirect_uri.clone()),
+        client_id: Some(RID.to_string()),
+        client_secret: None,
+        code_verifier: Some(challenge_plain.to_string()),
+        device_code: None,
+        username: None,
+        password: None,
+        refresh_token: None,
+        resource: Some(RESOURCE.to_string()),
+    };
+    let res = http
+        .post(format!("{backend_url}/oidc/token"))
+        .form(&token_req)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let ts = res.json::<TokenSet>().await?;
+    assert!(
+        aud_contains(&ts.access_token, RESOURCE),
+        "initial access token `aud` must contain the requested resource"
+    );
+
+    // (c) silent re-auth via `POST /oidc/authorize/refresh` on the SAME authenticated session,
+    // carrying the same `resource`. This is the path that dropped the resource before the fix.
+    // `LoginRefreshRequest` is deserialize-only (no `Serialize`), so build the body as raw JSON.
+    let req_refresh = serde_json::json!({
+        "client_id": RID,
+        "redirect_uri": redirect_uri,
+        "nonce": "MySuperNonce",
+        "code_challenge": challenge_s256,
+        "code_challenge_method": "S256",
+        "resource": RESOURCE,
+    });
+    let res = http
+        .post(format!("{backend_url}/oidc/authorize/refresh"))
+        .headers(session_headers.clone())
+        .json(&req_refresh)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 202);
+    let (code_refresh, _state) = code_state_from_headers(res)?;
+
+    let token_req = TokenRequest {
+        grant_type: "authorization_code".to_string(),
+        code: Some(code_refresh),
+        redirect_uri: Some(redirect_uri.clone()),
+        client_id: Some(RID.to_string()),
+        client_secret: None,
+        code_verifier: Some(challenge_plain.to_string()),
+        device_code: None,
+        username: None,
+        password: None,
+        refresh_token: None,
+        resource: Some(RESOURCE.to_string()),
+    };
+    let res = http
+        .post(format!("{backend_url}/oidc/token"))
+        .form(&token_req)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let ts_refresh = res.json::<TokenSet>().await?;
+    // the crux of #1645: the re-issued token must STILL be audience-bound to the resource
+    assert!(
+        aud_contains(&ts_refresh.access_token, RESOURCE),
+        "access token from /authorize/refresh must still contain the resource in `aud`"
+    );
+
+    Ok(())
+}

--- a/src/common/src/regex.rs
+++ b/src/common/src/regex.rs
@@ -71,6 +71,10 @@ pub static RE_STREET: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9À-ÿ-.\s]{0,48}$").unwrap());
 pub static RE_URI: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%@]+$").unwrap());
+// Like `RE_URI` but WITHOUT `#`, so a value cannot contain a fragment. Used for RFC 8707
+// `resource` indicators, which MUST be an absolute URI without a fragment (RFC 8707 §2).
+pub static RE_URI_RESOURCE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9,.:/_\-&?=~!$'()*+%@]+$").unwrap());
 pub static RE_USER_NAME: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[a-zA-Z0-9À-ɏ-'\s\x{3041}-\x{3096}\x{30A0}-\x{30FF}\x{3400}-\x{4DB5}\x{4E00}-\x{9FCB}\x{F900}-\x{FA6A}\x{2E80}-\x{2FD5}\x{FF66}-\x{FF9F}\x{FFA1}-\x{FFDC}\x{31F0}-\x{31FF}]{1,32}$").unwrap()
 });

--- a/src/service/src/oidc/authorize.rs
+++ b/src/service/src/oidc/authorize.rs
@@ -184,8 +184,9 @@ pub async fn post_authorize_refresh(
             nonce: req_data.nonce,
             code_challenge: req_data.code_challenge,
             code_challenge_method: req_data.code_challenge_method,
-            // a session refresh has no new authorization request to carry a `resource`
-            resource: None,
+            // the silent re-auth authorize request still carries the RFC 8707 `resource`,
+            // thread it through so audience-bound tokens survive subsequent logins
+            resource: req_data.resource,
             header_origin,
             require_webauthn,
         },


### PR DESCRIPTION
Follow-up to #1657 (issue #1645), covering the frontend half.

#1657 made the backend accept and carry `resource` on `POST /oidc/authorize/refresh`, but the login SPA only forwards `resource` on the full-login request, not on the silent re-auth. So once a session exists, a returning user's authorize goes through `/authorize/refresh` without the resource, the re-issued auth code has no resource, and the token exchange then fails with "the requested `resource` was not granted at the authorization request" (or, if the client does not re-request it, the token silently loses its audience binding).

The full-login path already does this a few lines below; this just adds the same conditional to the refresh payload:

```js
if (resource) {
    payload.resource = resource;
}
```

plus the `resource` field on the `LoginRefreshRequest` type, matching `LoginRequest`.

Reproduced against a real client (claude.ai as an MCP OAuth client with an RFC 8707 resource): first login worked, every returning-session login lost the `…/mcp` audience and the resource server rejected the token. Logging out (forcing the full-login path) confirmed the difference, and this change makes the refresh path behave the same.

Stacked on #1657, so until that merges the diff here also shows its commit; I will rebase once it lands. No backend change. The backend contract is already covered by the integration test on that branch (`handler_1645_resource_refresh.rs`, which posts `resource` to `/authorize/refresh` and asserts the exchanged token keeps it in `aud`); rauthy has no SPA test harness for the login page, so the frontend side is verified by the live reproduction above.