### PR TITLE
fix: avoid persistent cache state with PostgreSQL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -675,7 +675,8 @@ log_sync = "interval_200"
 # In-memory only significantly increases the throughput though, so it
 # depends on your needs, what you should prefer.
 #
-# default: true
+# default: true for Hiqlite. PostgreSQL mode always forces this to false so
+# the cache cannot outlive the PostgreSQL database it is derived from.
 # overwritten by: HQL_CACHE_STORAGE_DISK
 cache_storage_disk = true
 

--- a/src/data/src/database.rs
+++ b/src/data/src/database.rs
@@ -66,16 +66,16 @@ pub struct DB;
 
 impl DB {
     /// Builds the NodeConfig and starts the Hiqlite node
-    pub async fn init(config: hiqlite::NodeConfig) -> Result<(), ErrorResponse> {
+    pub async fn init(mut config: hiqlite::NodeConfig) -> Result<(), ErrorResponse> {
         if HIQLITE_CLIENT.get().is_some() {
             panic!("DB::init() must only be called once at startup");
         }
 
-        // Note: At the time of writing, I have not included the option to not start the DB
-        // layer when the feature is enabled, as this would mean many adoptions and additional
-        // checks in the Hiqlite code.
-        // This means, even if Postgres is configured, this will still create and start the Hiqlite
-        // DB, but it simply won't do anything else than heartbeats between the nodes.
+        // PostgreSQL is the source of truth in this mode. Keep the Hiqlite cache available for
+        // request-level caching and coordination, but do not persist its WAL or snapshots: a
+        // persistent cache can outlive a PostgreSQL cluster rollover and return objects which no
+        // longer exist in the active database.
+        configure_cache_storage(&mut config, is_postgres());
         let client = hiqlite::start_node_with_cache::<Cache>(config).await?;
 
         if is_postgres() {
@@ -298,6 +298,36 @@ impl DB {
         DbVersion::upsert(db_version).await?;
 
         Ok(())
+    }
+}
+
+fn configure_cache_storage(config: &mut hiqlite::NodeConfig, postgres: bool) {
+    if postgres {
+        config.cache_storage_disk = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::configure_cache_storage;
+
+    #[test]
+    fn postgres_cache_is_not_persisted() {
+        let mut config = hiqlite::NodeConfig::default();
+        assert!(config.cache_storage_disk);
+
+        configure_cache_storage(&mut config, true);
+
+        assert!(!config.cache_storage_disk);
+    }
+
+    #[test]
+    fn hiqlite_cache_storage_setting_is_unchanged() {
+        let mut config = hiqlite::NodeConfig::default();
+
+        configure_cache_storage(&mut config, false);
+
+        assert!(config.cache_storage_disk);
     }
 }
 


### PR DESCRIPTION
## What changed

When PostgreSQL is selected as Rauthy's durable database, force Hiqlite cache storage to memory-only. Hiqlite remains available for request caching and coordination, but its cache WAL and snapshots are no longer persisted.

## Why

PostgreSQL is the source of truth in this mode. A persistent Hiqlite cache can survive a PostgreSQL cluster rollover and return objects that no longer exist in the active database. During recovery, that can expose stale users, providers, or other cached objects.

Native Hiqlite mode keeps its existing cache-storage setting.

## Scope

This intentionally does not remove the Hiqlite runtime cache/control plane. PostgreSQL-only without Hiqlite startup is a larger architectural change and should be handled as a separate follow-up.

## Validation

- `cargo fmt --all -- --check` passed.
- Added unit tests for PostgreSQL forcing cache persistence off and native Hiqlite preserving the configured setting.
- `git diff --check` passed.
- `cargo test -p rauthy-data database::tests` was attempted in the Nix development shell but the clean checkout could not compile because generated `templates/html/*` artifacts are absent.
- `just build-ui` was attempted after `npm ci`, but the checkout also lacks generated WASM modules and the available Nix Rust sysroot does not include `wasm32-unknown-unknown`; no generated files were fabricated.
