### PR TITLE
Fix: client azp refresh check

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1284,11 +1284,11 @@ connect_retries = 3
 #
 # default: not set
 # overwritten by: SMTP_ROOT_CA
-root_ca = """
------BEGIN CERTIFICATE-----
-...
------END CERTIFICATE-----
-"""
+#root_ca = """
+#-----BEGIN CERTIFICATE-----
+#...
+#-----END CERTIFICATE-----
+#"""
 
 # Can be set to `true` to skip trying a real TLS connection
 # via SMTP and use STARTTLS directly.

--- a/justfile
+++ b/justfile
@@ -513,6 +513,7 @@ pre-pr-checks: build-ui fmt is-clean test-hiqlite test-postgres
 # does a `cargo update` + `npm update` for the UI
 update:
     #!/usr/bin/env bash
+    set -euxo pipefail
 
     # We need at least nightly-2026-06-21 for the min release age feature
     # from .cargo/config.toml

--- a/src/data/src/email/email_change_info.rs
+++ b/src/data/src/email/email_change_info.rs
@@ -48,7 +48,7 @@ pub async fn send_email_change_info_new(
         "{}users/{}/email_confirm/{}",
         RauthyConfig::get().issuer,
         magic_link.user_id,
-        &magic_link.id,
+        magic_link.id,
     );
     let exp = email_ts_prettify(magic_link.exp, &user.language, user_tz);
     let theme_vars = ThemeCssFull::find_theme_variables_email()

--- a/src/data/src/email/password_reset.rs
+++ b/src/data/src/email/password_reset.rs
@@ -51,7 +51,7 @@ pub async fn send_pwd_reset(magic_link: &MagicLink, user: &User, user_tz: Option
         "{}users/{}/reset/{}?type={}",
         RauthyConfig::get().issuer,
         magic_link.user_id,
-        &magic_link.id,
+        magic_link.id,
         magic_link.usage,
     );
     let exp = email_ts_prettify(magic_link.exp, &user.language, user_tz);

--- a/src/data/src/entity/atproto.rs
+++ b/src/data/src/entity/atproto.rs
@@ -93,7 +93,7 @@ impl Client {
         } else {
             format!(
                 "{}/auth/v1/atproto/client_metadata",
-                &config.pub_url_with_scheme
+                config.pub_url_with_scheme
             )
         };
 

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -1474,7 +1474,7 @@ impl Client {
         let secret_enc = self.secret.as_ref().ok_or_else(|| {
             ErrorResponse::new(
                 ErrorResponseType::Internal,
-                format!("'{}' has no secret while being confidential", &self.id),
+                format!("'{}' has no secret while being confidential", self.id),
             )
         })?;
         let cleartext = EncValue::try_from(secret_enc.clone())?.decrypt()?;

--- a/src/data/src/entity/sessions.rs
+++ b/src/data/src/entity/sessions.rs
@@ -714,7 +714,7 @@ impl Session {
         if self.roles.is_none() {
             return Err(ErrorResponse::new(
                 ErrorResponseType::NotFound,
-                format!("User '{}' is not assigned to any roles", &self.id),
+                format!("User '{}' is not assigned to any roles", self.id),
             ));
         }
         Ok(self

--- a/src/data/src/entity/webids.rs
+++ b/src/data/src/entity/webids.rs
@@ -229,7 +229,7 @@ impl WebId {
                 t_user,
                 "http://xmlns.com/foaf/0.1/mbox",
                 NamedNode {
-                    iri: &format!("mailto:{}", &resp.email),
+                    iri: &format!("mailto:{}", resp.email),
                 },
             ))?;
         }

--- a/src/data/src/vault_config.rs
+++ b/src/data/src/vault_config.rs
@@ -190,7 +190,7 @@ impl KvVersion {
 impl VaultSource {
     fn build_kv_read_url(&self, path: &str) -> Result<String, Box<dyn std::error::Error>> {
         let api_path = self.kv_version.get_api_path(&self.mount, path);
-        let url = format!("{}{}", &self.addr, api_path);
+        let url = format!("{}{}", self.addr, api_path);
         Ok(url)
     }
 }

--- a/src/service/src/client.rs
+++ b/src/service/src/client.rs
@@ -133,7 +133,7 @@ pub async fn get_client_secret(id: String) -> Result<ClientSecretResponse, Error
     if !client.confidential {
         return Err(ErrorResponse::new(
             ErrorResponseType::NotFound,
-            format!("'{}' is a public client", &client.id),
+            format!("'{}' is a public client", client.id),
         ));
     }
     let secret = client.get_secret_cleartext()?;

--- a/src/service/src/oidc/grant_types/refresh_token.rs
+++ b/src/service/src/oidc/grant_types/refresh_token.rs
@@ -40,7 +40,7 @@ pub async fn grant_type_refresh(
 
     // validate common refresh token claims first and get the payload
     let (ts, dpop_none) =
-        validation::validate_and_refresh_token(Some(client), &refresh_token, &req).await?;
+        validation::validate_and_refresh_token(client, &refresh_token, &req).await?;
 
     let mut headers = Vec::new();
     if let Some(h) = header_origin {

--- a/src/service/src/oidc/validation.rs
+++ b/src/service/src/oidc/validation.rs
@@ -60,21 +60,33 @@ pub async fn validate_auth_req_param(
 }
 
 pub async fn validate_and_refresh_token(
-    // when this is some, it will be checked against the 'azp' claim, otherwise skipped and a client
-    // will be fetched inside this function
-    client_opt: Option<Client>,
+    client: Client,
     refresh_token: &str,
     req: &HttpRequest,
 ) -> Result<(TokenSet, Option<String>), ErrorResponse> {
+    let (_, validation_str) = refresh_token.split_at(refresh_token.len() - 49);
+
     let mut buf = Vec::with_capacity(256);
     JwtToken::validate_claims_into(refresh_token, Some(JwtTokenType::Refresh), 0, &mut buf).await?;
     let claims: JwtRefreshClaims = serde_json::from_slice(&buf)?;
 
-    let client = if let Some(c) = client_opt {
-        c
-    } else {
-        Client::find(claims.common.azp.to_string()).await?
-    };
+    if client.id != claims.common.azp {
+        // If this is a non-matching client.id, this is most probably a malicious request.
+        // -> invalidate the refresh token immediately
+        if claims.common.did.is_some()
+            && let Ok(rt) = RefreshTokenDevice::find(validation_str).await
+        {
+            rt.delete().await?;
+        } else if let Ok(rt) = RefreshToken::find(validation_str).await {
+            rt.delete().await?;
+        };
+
+        return Err(ErrorResponse::new(
+            ErrorResponseType::Forbidden,
+            "Mismatch in client.id",
+        ));
+    }
+
     let header_origin = client.get_validated_origin_header(req)?;
 
     // validate DPoP proof
@@ -106,7 +118,6 @@ pub async fn validate_and_refresh_token(
     client.validate_user_groups(&user)?;
 
     // validate that it exists in the db and invalidate it afterward
-    let (_, validation_str) = refresh_token.split_at(refresh_token.len() - 49);
     let now = Utc::now().timestamp();
     let exp_at_secs = now + RauthyConfig::get().vars.lifetimes.refresh_token_grace_time as i64;
     let rt_scope = if let Some(device_id) = &claims.common.did {


### PR DESCRIPTION
Adds an additiona check for `client.id == refresh_token.azp` and removes a matching DB entry on mismatch.