### PR TITLE
allow-list RFC 8707 resources for dynamic and ephemeral clients

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1112,6 +1112,17 @@ enable = true
 # overwritten by: DYN_CLIENT_ALLOWED_SCOPES - single String, \n separated values
 allowed_scopes = ['openid', 'profile', 'email', 'groups']
 
+# RFC 8707 resource indicators a dynamically registered client may request. A
+# dynamic client cannot declare `allowed_resources` itself, so without this it can
+# never request a `resource`; an MCP client, which must send one, would otherwise
+# get `invalid_target`. Resolved from the live config on every request and never
+# stored with the client. Entries are matched verbatim. An empty list keeps the
+# default deny.
+#
+# default: []
+# overwritten by: DYN_CLIENT_ALLOWED_RESOURCES - single String, \n separated values
+#allowed_resources = []
+
 # The default scopes separated by ' ' for dynamic clients.
 #
 # default: ['openid']
@@ -1494,6 +1505,16 @@ cache_lifetime = 3600
 # default: false
 # overwritten by: EPHEMERAL_CLIENTS_DANGER_ALLOW_UNVALIDATED_RESOURCE
 #danger_allow_unvalidated_resource = false
+
+# RFC 8707 resource indicators allowed when an ephemeral client document declares
+# none of its own (a CIMD document you do not control cannot declare them). Keeps
+# the default deny without the blunt `danger_allow_unvalidated_resource`. A document
+# that declares its own resources still wins. Resolved from the live config on every
+# request. Entries are matched verbatim.
+#
+# default: []
+# overwritten by: EPHEMERAL_CLIENTS_ALLOWED_RESOURCES - single String, \n separated values
+#allowed_resources = []
 
 # A dynamic client registration is always rejected when it advertises a grant
 # type Rauthy does not support. Some spec-valid CIMD clients (e.g. claude.ai)

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -960,8 +960,11 @@ impl Client {
 
     /// Validates an RFC 8707 `resource` request value against this client's policy: it
     /// must match one of the client's configured `allowed_resources`. The entries are
-    /// matched verbatim, so an operator decides what a valid value looks like. Ephemeral
-    /// clients without their own allow-list are only permitted when
+    /// matched verbatim, so an operator decides what a valid value looks like. Dynamic
+    /// clients, and ephemeral clients whose document declares no allow-list of its own,
+    /// are matched against `dynamic_clients.allowed_resources` /
+    /// `ephemeral_clients.allowed_resources` instead, resolved from the live config and
+    /// never stored with the client; ephemeral clients are otherwise only permitted when
     /// `ephemeral_clients.danger_allow_unvalidated_resource` is enabled. On any failure
     /// an `invalid_target` error (RFC 8707 §2) is returned.
     pub fn validate_resource_request(&self, resource: &str) -> Result<(), ErrorResponse> {
@@ -972,14 +975,26 @@ impl Client {
             ));
         }
 
-        // A dynamic client is never allowed to set `allowed_resources` in the first place, so it
-        // can never have a match below. Rejecting it explicitly is cheap and keeps this robust if
-        // anything about the dynamic registration rules changes in the future.
+        // A dynamic client is never allowed to set `allowed_resources` in the first place, so
+        // it can never have a match below. The operator may allow-list specific resources for
+        // dynamic clients via `dynamic_clients.allowed_resources`, which is resolved from the
+        // live config on every request and never stored with the client. The list is empty by
+        // default, which keeps rejecting these requests like before.
         if self.is_dynamic() {
-            return Err(ErrorResponse::new(
-                ErrorResponseType::InvalidTarget,
-                "dynamic clients must not request a `resource`",
-            ));
+            let allowed = &RauthyConfig::get().vars.dynamic_clients.allowed_resources;
+            return if allowed.is_empty() {
+                Err(ErrorResponse::new(
+                    ErrorResponseType::InvalidTarget,
+                    "dynamic clients must not request a `resource`",
+                ))
+            } else if allowed.iter().any(|r| r == resource) {
+                Ok(())
+            } else {
+                Err(ErrorResponse::new(
+                    ErrorResponseType::InvalidTarget,
+                    "the requested `resource` is not allowed for this client",
+                ))
+            };
         }
 
         let mut allowed = self.allowed_resources_iter().peekable();
@@ -993,10 +1008,20 @@ impl Client {
                 ))
             }
         } else if self.is_ephemeral()
-            && RauthyConfig::get()
+            // An ephemeral client document that declares its own `allowed_resources` has
+            // matched above; for one that declares none the operator's
+            // `ephemeral_clients.allowed_resources` is resolved from the live config the
+            // same way, without the blunt `danger_allow_unvalidated_resource`.
+            && (RauthyConfig::get()
                 .vars
                 .ephemeral_clients
-                .danger_allow_unvalidated_resource
+                .allowed_resources
+                .iter()
+                .any(|r| r == resource)
+                || RauthyConfig::get()
+                    .vars
+                    .ephemeral_clients
+                    .danger_allow_unvalidated_resource)
         {
             Ok(())
         } else {

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -401,6 +401,7 @@ impl Default for Vars {
                 cleanup_minutes: 60,
                 cleanup_inactive_days: 0,
                 rate_limit_sec: 60,
+                allowed_resources: Vec::default(),
             },
             email: VarsEmail {
                 rauthy_admin_email: None,
@@ -458,6 +459,7 @@ impl Default for Vars {
                 cache_lifetime: 3600,
                 danger_allow_unvalidated_resource: false,
                 ignore_unknown_auth_flows: false,
+                allowed_resources: Vec::default(),
             },
             events: VarsEvents {
                 email: None,
@@ -1817,6 +1819,14 @@ impl Vars {
         ) {
             self.dynamic_clients.rate_limit_sec = v;
         }
+        if let Some(v) = t_str_vec(
+            &mut table,
+            "dynamic_clients",
+            "allowed_resources",
+            "DYN_CLIENT_ALLOWED_RESOURCES",
+        ) {
+            self.dynamic_clients.allowed_resources = v;
+        }
 
         check_table_empty(table, "dynamic_clients");
     }
@@ -2095,6 +2105,15 @@ impl Vars {
             "EPHEMERAL_CLIENTS_IGNORE_UNKNOWN_AUTH_FLOWS",
         ) {
             self.ephemeral_clients.ignore_unknown_auth_flows = v;
+        }
+
+        if let Some(v) = t_str_vec(
+            &mut table,
+            "ephemeral_clients",
+            "allowed_resources",
+            "EPHEMERAL_CLIENTS_ALLOWED_RESOURCES",
+        ) {
+            self.ephemeral_clients.allowed_resources = v;
         }
 
         check_table_empty(table, "ephemeral_clients");
@@ -3766,6 +3785,10 @@ pub struct VarsDynamicClients {
     pub cleanup_minutes: u32,
     pub cleanup_inactive_days: u32,
     pub rate_limit_sec: u32,
+    /// RFC 8707 allow-list for dynamic clients, which cannot declare `allowed_resources`
+    /// themselves. Resolved from the live config on every request, never stored with the
+    /// client. Empty by default, which keeps deny-by-default.
+    pub allowed_resources: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -3843,6 +3866,10 @@ pub struct VarsEphemeralClients {
     /// clients; dynamic client registration (DCR) and admin-managed clients keep rejecting
     /// unknown grant types. Default reject.
     pub ignore_unknown_auth_flows: bool,
+    /// RFC 8707 allow-list applied when an ephemeral client document declares no
+    /// `allowed_resources` of its own. Keeps deny-by-default while letting an operator
+    /// permit specific resources without `danger_allow_unvalidated_resource`.
+    pub allowed_resources: Vec<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
MCP clients send an RFC 8707 `resource`, and a lot of them either self-register over DCR or come in as CIMD documents I don't control, so they can't carry `allowed_resources` themselves. On 0.36.1 that means `/authorize` always ends in `invalid_target` for them: dynamic clients get rejected outright, and a CIMD doc that lists no resources only gets through with `danger_allow_unvalidated_resource`.

This adds `allowed_resources` to `[dynamic_clients]` and `[ephemeral_clients]`, same shape as the `allowed_scopes` you already apply to these clients. It's seeded onto the client at registration; a CIMD doc that declares its own still wins. Empty by default, so nothing changes unless an operator sets it: dynamic clients stay rejected and ephemeral ones still need the danger flag. When it is set, a self-registered client can only request what's on the list.

The trusted party you noted a dynamic client lacks is the operator's config here, same as it already is for scopes and flows on these clients.

Also fixes `create_dynamic` inserting 22 columns vs `Client::create`'s 24, so `allowed_resources` and `default_aud` were silently dropped for dynamic clients regardless of this change.

Happy to split the insert fix out or adjust the shape if you'd rather have it another way.
