### PR TITLE
fix: Atomically claim refresh tokens and revoke the family on replay

### DIFF
--- a/src/data/src/entity/refresh_tokens.rs
+++ b/src/data/src/entity/refresh_tokens.rs
@@ -168,6 +168,23 @@ impl RefreshToken {
         Ok(slf)
     }
 
+    /// Atomically claims this refresh token for one-time use. Returns `true` if the claim
+    /// succeeded (the token was still valid and this caller won), `false` if it was already
+    /// claimed or expired. The conditional UPDATE (`exp > now`) makes the claim atomic, so
+    /// two concurrent refreshes with the same token cannot both succeed, and a stolen token
+    /// cannot be replayed after legitimate use.
+    pub async fn claim(id: &str, now: i64) -> Result<bool, ErrorResponse> {
+        let sql = "UPDATE refresh_tokens SET exp = $1 WHERE id = $2 AND exp > $1";
+
+        let rows_affected = if is_hiqlite() {
+            DB::hql().execute(sql, params!(now, id)).await?
+        } else {
+            DB::pg_execute(sql, &[&now, &id]).await?
+        };
+
+        Ok(rows_affected == 1)
+    }
+
     pub async fn save(&self) -> Result<(), ErrorResponse> {
         let sql = r#"
 INSERT INTO refresh_tokens (id, user_id, nbf, exp, scope, is_mfa, session_id, access_token_jti)

--- a/src/data/src/entity/refresh_tokens_devices.rs
+++ b/src/data/src/entity/refresh_tokens_devices.rs
@@ -92,17 +92,17 @@ impl RefreshTokenDevice {
         Ok(())
     }
 
-    // pub async fn invalidate_for_user(user_id: &str) -> Result<(), ErrorResponse> {
-    //     let now = Utc::now().timestamp();
-    //     let sql = "UPDATE refresh_tokens_devices SET exp = $1 WHERE exp > $1 AND user_id = $2";
-    //     if is_hiqlite() {
-    //         DB::hql().execute(sql, params!(now, user_id)).await?;
-    //     } else {
-    //         DB::pg_execute(sql, &[&now, &user_id]).await?;
-    //     }
-    //
-    //     Ok(())
-    // }
+    pub async fn invalidate_for_user(user_id: &str) -> Result<(), ErrorResponse> {
+        let now = Utc::now().timestamp();
+        let sql = "UPDATE refresh_tokens_devices SET exp = $1 WHERE exp > $1 AND user_id = $2";
+        if is_hiqlite() {
+            DB::hql().execute(sql, params!(now, user_id)).await?;
+        } else {
+            DB::pg_execute(sql, &[&now, &user_id]).await?;
+        }
+
+        Ok(())
+    }
 
     pub async fn find(id: &str) -> Result<Self, ErrorResponse> {
         let now = Utc::now().timestamp();
@@ -138,6 +138,19 @@ impl RefreshTokenDevice {
         };
 
         Ok(slf)
+    }
+
+    /// Atomically claims this device refresh token for one-time use. See `RefreshToken::claim`.
+    pub async fn claim(id: &str, now: i64) -> Result<bool, ErrorResponse> {
+        let sql = "UPDATE refresh_tokens_devices SET exp = $1 WHERE id = $2 AND exp > $1";
+
+        let rows_affected = if is_hiqlite() {
+            DB::hql().execute(sql, params!(now, id)).await?
+        } else {
+            DB::pg_execute(sql, &[&now, &id]).await?
+        };
+
+        Ok(rows_affected == 1)
     }
 
     pub async fn find_by_user_id_jti(

--- a/src/service/src/oidc/validation.rs
+++ b/src/service/src/oidc/validation.rs
@@ -7,15 +7,17 @@ use chrono::Utc;
 use rauthy_common::constants::REFRESH_TOKEN_VALIDATION_LEN;
 use rauthy_data::entity::clients::Client;
 use rauthy_data::entity::dpop_proof::DPoPProof;
+use rauthy_data::entity::issued_tokens::IssuedToken;
 use rauthy_data::entity::refresh_tokens::RefreshToken;
 use rauthy_data::entity::refresh_tokens_devices::RefreshTokenDevice;
+use rauthy_data::entity::sessions::Session;
 use rauthy_data::entity::users::User;
 use rauthy_data::events::event::Event;
 use rauthy_data::rauthy_config::RauthyConfig;
 use rauthy_error::{ErrorResponse, ErrorResponseType};
 use rauthy_jwt::claims::{JwtRefreshClaims, JwtTokenType};
 use rauthy_jwt::token::JwtToken;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Validates request parameters for the authorization and refresh endpoints
 pub async fn validate_auth_req_param(
@@ -58,6 +60,17 @@ pub async fn validate_auth_req_param(
     }
 
     Ok((client, header))
+}
+
+/// Revokes the whole refresh-token family for a user after a detected replay: all refresh
+/// tokens (regular + device), all issued tokens and all sessions. RFC 6819 §5.2.1.3: on
+/// token reuse the authorization server SHOULD revoke the grant family.
+async fn revoke_refresh_family(user_id: &str) -> Result<(), ErrorResponse> {
+    RefreshToken::invalidate_for_user(user_id).await?;
+    RefreshTokenDevice::invalidate_for_user(user_id).await?;
+    IssuedToken::revoke_for_user(user_id, true).await?;
+    Session::invalidate_for_user(user_id).await?;
+    Ok(())
 }
 
 pub async fn validate_and_refresh_token(
@@ -128,11 +141,14 @@ pub async fn validate_and_refresh_token(
     user.check_expired()?;
     client.validate_user_groups(&user)?;
 
-    // validate that it exists in the db and invalidate it afterward
+    // validate that it exists in the db and atomically claim it for one-time use.
+    // The old token is expired by the claim (rotation), so a stolen token cannot be replayed
+    // after legitimate use and two concurrent refreshes with the same token cannot both win.
+    // Note: this supersedes the previous grace-period extension
+    // (`refresh_token_grace_time` no longer keeps the old token usable after a refresh).
     let now = Utc::now().timestamp();
-    let exp_at_secs = now + RauthyConfig::get().vars.lifetimes.refresh_token_grace_time as i64;
     let rt_scope = if let Some(device_id) = &claims.common.did {
-        let mut rt = RefreshTokenDevice::find(validation_str).await?;
+        let rt = RefreshTokenDevice::find(validation_str).await?;
 
         if &rt.device_id != device_id {
             return Err(ErrorResponse::new(
@@ -147,16 +163,33 @@ pub async fn validate_and_refresh_token(
             ));
         }
 
-        if rt.exp > exp_at_secs + 1 {
-            rt.exp = exp_at_secs;
-            rt.save().await?;
+        if !RefreshTokenDevice::claim(validation_str, now).await? {
+            // Replay / reuse of an already-used refresh token — treat as theft
+            // (RFC 6819 §5.2.1.3): revoke the whole token family for the user.
+            warn!(
+                "Detected device refresh token reuse for user '{}' - revoking token family",
+                user.id
+            );
+            revoke_refresh_family(&user.id).await?;
+            return Err(ErrorResponse::new(
+                ErrorResponseType::Forbidden,
+                "Refresh token has already been used - all sessions for this user have been revoked",
+            ));
         }
         rt.scope
     } else {
-        let mut rt = RefreshToken::find(validation_str).await?;
-        if rt.exp > exp_at_secs + 1 {
-            rt.exp = exp_at_secs;
-            rt.save().await?;
+        let rt = RefreshToken::find(validation_str).await?;
+        if !RefreshToken::claim(validation_str, now).await? {
+            // see above — replay of an already-used refresh token
+            warn!(
+                "Detected refresh token reuse for user '{}' - revoking token family",
+                user.id
+            );
+            revoke_refresh_family(&user.id).await?;
+            return Err(ErrorResponse::new(
+                ErrorResponseType::Forbidden,
+                "Refresh token has already been used - all sessions for this user have been revoked",
+            ));
         }
         rt.scope
     };


### PR DESCRIPTION
## Summary

The refresh grant did a non-atomic find-then-extend: two concurrent refreshes with one token could both pass, and a stolen token stayed usable for the grace window. Replace with an atomic conditional claim (`UPDATE … WHERE exp > now`) on both `refresh_tokens` and `refresh_tokens_devices`, so only the first use wins and the old token dies on rotation.

Behavior note: `refresh_token_grace_time` no longer keeps the old token usable after a refresh — clients must use the rotated token.

Replay handling: when the atomic claim fails, the presented token was already used — the standard replay / theft signal (RFC 6819 §5.2.1.3). Instead of only rejecting the request, the whole family is revoked: all refresh tokens (regular + device), all issued tokens and all sessions for the user, forcing a clean re-authentication. Tradeoff: a legit client that retries an old refresh token after losing the rotated response also triggers the revocation — clients must use the token from the last response.

## Verification

`cargo fmt --check` clean; `cargo clippy -- -D warnings` (CI form) — 0 warnings; workspace lib tests: 80 passed / 0 failed.

Developed with carefully directed, manually reviewed AI assistance.