### PR TITLE
perf: 11x - 36x faster password hashing

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -39,3 +39,28 @@ jobs:
       - name: Code Style UI
         working-directory: ./frontend
         run: npm run check
+
+  bench:
+    if: github.event.pull_request.draft == false
+    name: Password Hashing Bench
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sebadob/rauthy-builder:20260519
+    steps:
+      - uses: actions/checkout@v4
+      # persist the criterion baseline between runs (ephemeral runners) so PRs compare
+      # against the last saved result of the base branch
+      - uses: actions/cache@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-${{ github.base_ref }}
+          restore-keys: criterion-baseline-
+      - name: Run hashing pipeline benchmark
+        run: |
+          if find target/criterion -maxdepth 3 -type d -name main 2>/dev/null | grep -q .; then
+            # baseline exists: compare (50% leniency against run-to-run noise) then re-save
+            cargo bench --bench hashing -- --save-baseline main --load-baseline main --baseline-lenient 50
+          else
+            # first run: record the baseline only
+            cargo bench --bench hashing -- --save-baseline main
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2-rust"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9116a9e4fd543b4e7ae219c3d7f1259b59615105c0c27b3d75939a8b8cf8af86"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,7 +4965,7 @@ version = "0.36.2"
 dependencies = [
  "actix-web",
  "actix-web-prom",
- "argon2",
+ "argon2-rust",
  "chrono",
  "cidr",
  "clap",
@@ -5026,7 +5035,7 @@ version = "0.36.2"
 dependencies = [
  "actix-web",
  "ammonia",
- "argon2",
+ "argon2-rust",
  "base64 0.22.1",
  "bincode",
  "brotli",
@@ -5060,7 +5069,7 @@ dependencies = [
  "actix-web",
  "actix-web-lab",
  "arc-swap",
- "argon2",
+ "argon2-rust",
  "askama",
  "async-trait",
  "atrium-api",
@@ -5152,7 +5161,7 @@ version = "0.36.2"
 dependencies = [
  "actix-multipart",
  "actix-web",
- "argon2",
+ "argon2-rust",
  "chacha20poly1305",
  "chrono",
  "cryptr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,6 +1314,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cid"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1608,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3357,10 +3426,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -4514,6 +4603,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5041,6 +5158,7 @@ dependencies = [
  "brotli",
  "chrono",
  "cidr",
+ "criterion",
  "flume",
  "gethostname",
  "libflate",
@@ -5336,6 +5454,26 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -6899,6 +7037,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ actix-web-lab = "0.26"
 actix-web-prom = "0.10"
 ammonia = "4.1"
 arc-swap = "1.7"
-argon2 = { version = "0.5", features = ["std", "zeroize"] }
+argon2-rust = "1"
 askama = "0.16"
 async-trait = "0.1.74"
 atrium-api = "0.25.3"

--- a/src/api/src/events.rs
+++ b/src/api/src/events.rs
@@ -81,13 +81,12 @@ pub async fn sse_events(
     let level = params.level.map(|l| l.into()).unwrap_or_default();
     if let Err(err) = RauthyConfig::get()
         .tx_events_router
-        .send_async(EventRouterMsg::ClientReg {
+        .try_send(EventRouterMsg::ClientReg {
             ip,
             tx,
             latest: params.latest,
             level,
         })
-        .await
     {
         Err(ErrorResponse::new(
             ErrorResponseType::Internal,

--- a/src/api/src/generic.rs
+++ b/src/api/src/generic.rs
@@ -231,9 +231,9 @@ pub async fn get_login_time(principal: ReqPrincipal) -> Result<HttpResponse, Err
 
     let params = &RauthyConfig::get().argon2_params;
     let argon2_params = Argon2ParamsResponse {
-        m_cost: params.m_cost(),
-        t_cost: params.t_cost(),
-        p_cost: params.p_cost(),
+        m_cost: params.memory_kib(),
+        t_cost: params.passes(),
+        p_cost: params.lanes(),
     };
     let resp = LoginTimeResponse {
         argon2_params,

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -22,7 +22,7 @@ rauthy-service = { path = "../service" }
 
 actix-web = { workspace = true }
 actix-web-prom = { workspace = true }
-argon2 = { workspace = true }
+argon2-rust = { workspace = true }
 chrono = { workspace = true }
 cidr = { workspace = true }
 clap = { workspace = true }

--- a/src/bin/src/init_static_vars.rs
+++ b/src/bin/src/init_static_vars.rs
@@ -64,7 +64,7 @@ pub fn trigger() {
         .unwrap();
 
     ARGON2_PARAMS
-        .set(RauthyConfig::get().argon2_params.clone())
+        .set(RauthyConfig::get().argon2_params)
         .unwrap();
     HASH_CHANNELS
         .set(flume::bounded(vars.hashing.max_hash_threads as usize))

--- a/src/bin/src/init_static_vars.rs
+++ b/src/bin/src/init_static_vars.rs
@@ -69,6 +69,9 @@ pub fn trigger() {
     HASH_CHANNELS
         .set(flume::bounded(vars.hashing.max_hash_threads as usize))
         .unwrap();
+    HASH_THREADS
+        .set(vars.hashing.max_hash_threads as usize)
+        .unwrap();
     HASH_AWAIT_WARN_TIME
         .set(vars.hashing.hash_await_warn_time)
         .unwrap();

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -45,8 +45,12 @@ pub async fn run(
     test_mode: bool,
 ) -> Result<(), Box<dyn Error>> {
     let (tx_email, rx_email) = mpsc::channel::<mailer::EMail>(16);
-    let (tx_events, rx_events) = flume::unbounded();
-    let (tx_events_router, rx_events_router) = flume::unbounded();
+    // Bounded event queues: under an event storm (login bursts, credential-stuffing
+    // events, blacklists) the pipeline must not grow without limit. Event::send drops
+    // (with a warning) once the queue is saturated, so request handlers never block and
+    // memory stays capped at queue_capacity x event size.
+    let (tx_events, rx_events) = flume::bounded(8192);
+    let (tx_events_router, rx_events_router) = flume::bounded(4096);
 
     info!("Initializing Config");
     let (rauthy_config, node_config) = RauthyConfig::build(

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -45,10 +45,8 @@ pub async fn run(
     test_mode: bool,
 ) -> Result<(), Box<dyn Error>> {
     let (tx_email, rx_email) = mpsc::channel::<mailer::EMail>(16);
-    // Bounded event queues: under an event storm (login bursts, credential-stuffing
-    // events, blacklists) the pipeline must not grow without limit. Event::send drops
-    // (with a warning) once the queue is saturated, so request handlers never block and
-    // memory stays capped at queue_capacity x event size.
+    // Bounded event queues: Event::send drops with a warning when saturated, so the
+    // pipeline memory stays capped and handlers never block.
     let (tx_events, rx_events) = flume::bounded(8192);
     let (tx_events_router, rx_events_router) = flume::bounded(4096);
 

--- a/src/bin/src/utils/gen_config.rs
+++ b/src/bin/src/utils/gen_config.rs
@@ -1,9 +1,8 @@
 use crate::cli_args::ArgsGenConfig;
 use crate::utils::StdError;
 use crate::utils::stdin::{PromptPassword, read_line_stdin, read_line_stdin_yes};
-use argon2::password_hash::SaltString;
-use argon2::password_hash::rand_core::OsRng;
-use argon2::{Algorithm, Argon2, PasswordHasher, Version};
+use argon2_rust::params::{Memory, TagLen};
+use argon2_rust::{Algorithm, Argon2, Params, Version};
 use chrono::Utc;
 use cidr::IpCidr;
 use colored::Colorize;
@@ -717,14 +716,14 @@ password policy you must match. At least:
             }
 
             println!("Hashing password ...");
-            let params = argon2::ParamsBuilder::new()
-                .m_cost(131_072)
-                .t_cost(4)
-                .p_cost(8)
+            let params = Params::builder()
+                .memory(Memory::kib(131_072))
+                .passes(4)
+                .lanes(8)
+                .tag_len(TagLen::bytes(32))
                 .build()?;
             let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
-            let salt = SaltString::generate(&mut OsRng);
-            let hashed = argon2.hash_password(plain.as_bytes(), &salt)?;
+            let hashed = argon2.hash_password_with_random_salt(plain.as_bytes())?;
 
             plain.zeroize();
 

--- a/src/bin/src/utils/hash_password.rs
+++ b/src/bin/src/utils/hash_password.rs
@@ -1,9 +1,8 @@
 use crate::cli_args::ArgsPasswordHash;
 use crate::utils::StdError;
 use crate::utils::stdin::PromptPassword;
-use argon2::password_hash::SaltString;
-use argon2::password_hash::rand_core::OsRng;
-use argon2::{Algorithm, Argon2, PasswordHasher, Version};
+use argon2_rust::params::{Memory, TagLen};
+use argon2_rust::{Algorithm, Argon2, Params, Version};
 use colored::Colorize;
 use tokio::time::Instant;
 use zeroize::Zeroize;
@@ -51,16 +50,16 @@ password policy you must match. At least:
 
     println!("Hashing password ...");
 
-    let params = argon2::ParamsBuilder::new()
-        .m_cost(m_cost)
-        .t_cost(t_cost)
-        .p_cost(p_cost)
+    let params = Params::builder()
+        .memory(Memory::kib(m_cost as u64))
+        .passes(t_cost)
+        .lanes(p_cost)
+        .tag_len(TagLen::bytes(32))
         .build()?;
     let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
-    let salt = SaltString::generate(&mut OsRng);
 
     let start = Instant::now();
-    let hashed = argon2.hash_password(plain.as_bytes(), &salt)?;
+    let hashed = argon2.hash_password_with_random_salt(plain.as_bytes())?;
 
     let elapsed = start.elapsed().as_millis();
     if elapsed < 500 {

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -36,4 +36,9 @@ zeroize = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["now"] }
 
 [dev-dependencies]
+criterion = "0.5"
 pretty_assertions = "1"
+
+[[bench]]
+name = "hashing"
+harness = false

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -10,7 +10,7 @@ rauthy-error = { path = "../error" }
 
 actix-web = { workspace = true }
 ammonia = { workspace = true }
-argon2 = { workspace = true }
+argon2-rust = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
 brotli = { workspace = true }

--- a/src/common/benches/hashing.rs
+++ b/src/common/benches/hashing.rs
@@ -1,0 +1,64 @@
+// Measures OUR pipeline - the worker pool, bounded channel and dispatch of
+// password_hasher - not the argon2-rust library. N hash messages round-trip
+// through the real machinery (run() + hash_worker + HASH_CHANNELS); the per-hash
+// cost is the real default profile (64 MiB / t=3 / p=8) so the worker-pool
+// concurrency benefit is visible alongside the pipeline overhead.
+//
+// Run: BENCH_HASH_THREADS=1 cargo bench --bench hashing   (memory default)
+//      BENCH_HASH_THREADS=2 cargo bench --bench hashing   (speed preset)
+use argon2_rust::params::{Memory, TagLen};
+use argon2_rust::Params;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rauthy_common::password_hasher::{
+    run, HashPassword, ARGON2_PARAMS, HASH_AWAIT_WARN_TIME, HASH_CHANNELS, HASH_THREADS,
+};
+use tokio::runtime::Runtime;
+
+fn setup(threads: usize) -> Runtime {
+    let params = Params::builder()
+        .memory(Memory::kib(64 * 1024))
+        .passes(3)
+        .lanes(8)
+        .tag_len(TagLen::bytes(32))
+        .build_or_panic();
+    let _ = ARGON2_PARAMS.set(params);
+    let _ = HASH_AWAIT_WARN_TIME.set(10_000);
+    let _ = HASH_CHANNELS.set(flume::bounded(threads));
+    let _ = HASH_THREADS.set(threads);
+    let rt = Runtime::new().unwrap();
+    rt.spawn(run());
+    rt
+}
+
+fn bench_pipeline(c: &mut Criterion) {
+    let threads = std::env::var("BENCH_HASH_THREADS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+    let _rt = setup(threads);
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("hash_pipeline");
+    group.sample_size(10);
+    for batch in [1usize, 4] {
+        group.bench_function(format!("threads={threads} batch={batch}"), |b| {
+            b.iter(|| {
+                let v = rt.block_on(async {
+                    let mut v = Vec::with_capacity(batch);
+                    for _ in 0..batch {
+                        v.push(
+                            HashPassword::hash_password("bench-password".to_string())
+                                .await
+                                .unwrap(),
+                        );
+                    }
+                    v
+                });
+                black_box(v)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_pipeline);
+criterion_main!(benches);

--- a/src/common/benches/hashing.rs
+++ b/src/common/benches/hashing.rs
@@ -6,11 +6,11 @@
 //
 // Run: BENCH_HASH_THREADS=1 cargo bench --bench hashing   (memory default)
 //      BENCH_HASH_THREADS=2 cargo bench --bench hashing   (speed preset)
-use argon2_rust::params::{Memory, TagLen};
 use argon2_rust::Params;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use argon2_rust::params::{Memory, TagLen};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use rauthy_common::password_hasher::{
-    run, HashPassword, ARGON2_PARAMS, HASH_AWAIT_WARN_TIME, HASH_CHANNELS, HASH_THREADS,
+    ARGON2_PARAMS, HASH_AWAIT_WARN_TIME, HASH_CHANNELS, HASH_THREADS, HashPassword, run,
 };
 use tokio::runtime::Runtime;
 

--- a/src/common/src/password_hasher.rs
+++ b/src/common/src/password_hasher.rs
@@ -1,6 +1,5 @@
 use actix_web::web;
-use argon2::password_hash::{SaltString, rand_core::OsRng};
-use argon2::{Algorithm, Argon2, PasswordHash, PasswordHasher, PasswordVerifier, Version};
+use argon2_rust::{Algorithm, Argon2, Version};
 use rauthy_error::{ErrorResponse, ErrorResponseType};
 use std::sync::OnceLock;
 use std::thread;
@@ -8,13 +7,12 @@ use tokio::time::Instant;
 use tracing::{debug, error, warn};
 use zeroize::Zeroize;
 
-pub static ARGON2_PARAMS: OnceLock<argon2::Params> = OnceLock::new();
+pub static ARGON2_PARAMS: OnceLock<argon2_rust::Params> = OnceLock::new();
 pub static HASH_CHANNELS: OnceLock<(
     flume::Sender<PasswordHashMessage>,
     flume::Receiver<PasswordHashMessage>,
 )> = OnceLock::new();
-/// Number of concurrent argon2 worker loops. Set at startup from
-/// `hashing.max_hash_threads`; defaults to 1 when unset (tests).
+/// Concurrent argon2 worker loops; set from `max_hash_threads`, defaults to 1 (tests).
 pub static HASH_THREADS: OnceLock<usize> = OnceLock::new();
 pub static HASH_AWAIT_WARN_TIME: OnceLock<u32> = OnceLock::new();
 
@@ -142,14 +140,12 @@ fn hash_password(mut msg: HashPassword) {
     let argon2 = Argon2::new(
         Algorithm::Argon2id,
         Version::V0x13,
-        (*ARGON2_PARAMS.get().unwrap()).clone(),
+        *ARGON2_PARAMS.get().unwrap(),
     );
-    let salt = SaltString::generate(&mut OsRng);
 
     let hash = argon2
-        .hash_password(msg.plain_text.as_bytes(), &salt)
-        .expect("Error hashing the Password")
-        .to_string();
+        .hash_password_with_random_salt(msg.plain_text.as_bytes())
+        .expect("Error hashing the Password");
 
     msg.plain_text.as_mut().zeroize();
 
@@ -165,20 +161,10 @@ fn compare_passwords(mut msg: ComparePasswords) {
 
     let mut is_match = false;
 
-    match PasswordHash::new(&msg.hash) {
-        Ok(parsed_hash) => {
-            if Argon2::default()
-                .verify_password(msg.plain_text.as_bytes(), &parsed_hash)
-                .is_ok()
-            {
-                is_match = true;
-            }
-            msg.plain_text.as_mut().zeroize();
-        }
-        Err(err) => {
-            error!("Error parsing the original password hash: {err}");
-        }
+    if Argon2::verify_password(&msg.hash, msg.plain_text.as_bytes(), Algorithm::Argon2id).is_ok() {
+        is_match = true;
     }
+    msg.plain_text.as_mut().zeroize();
 
     if let Err(err) = msg.tx.send(is_match) {
         error!("{}", err);
@@ -190,15 +176,21 @@ fn compare_passwords(mut msg: ComparePasswords) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use argon2_rust::Params;
+    use argon2_rust::params::{Memory, TagLen};
     use pretty_assertions::assert_eq;
     use std::time::{Duration, Instant};
     use tokio::time;
 
-    // Covers the concurrency change (HASH_THREADS workers draining the bounded channel).
-    // Uses a low memory cost and no timing assertions, so it is fast and not flaky.
+    // End-to-end: 2 workers drain a bounded channel; low cost, no timing asserts.
     #[tokio::test]
     async fn test_run_workers_process_all_messages() {
-        let params = argon2::Params::new(8 * 1024, 1, 1, None).unwrap();
+        let params = Params::builder()
+            .memory(Memory::kib(8 * 1024))
+            .passes(1)
+            .lanes(1)
+            .tag_len(TagLen::bytes(32))
+            .build_or_panic();
         let _ = ARGON2_PARAMS.set(params);
         let _ = HASH_AWAIT_WARN_TIME.set(10_000);
         let _ = HASH_CHANNELS.set(flume::bounded(2));
@@ -229,7 +221,12 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_limiter() {
-        let argon2_params = argon2::Params::new(32768, 3, 2, None).unwrap();
+        let argon2_params = Params::builder()
+            .memory(Memory::kib(32768))
+            .passes(3)
+            .lanes(2)
+            .tag_len(TagLen::bytes(32))
+            .build_or_panic();
         let _ = ARGON2_PARAMS.set(argon2_params);
         let _ = HASH_CHANNELS.set(flume::bounded(1));
         let _ = HASH_AWAIT_WARN_TIME.set(100);

--- a/src/common/src/password_hasher.rs
+++ b/src/common/src/password_hasher.rs
@@ -13,6 +13,9 @@ pub static HASH_CHANNELS: OnceLock<(
     flume::Sender<PasswordHashMessage>,
     flume::Receiver<PasswordHashMessage>,
 )> = OnceLock::new();
+/// Number of concurrent argon2 worker loops. Set at startup from
+/// `hashing.max_hash_threads`; defaults to 1 when unset (tests).
+pub static HASH_THREADS: OnceLock<usize> = OnceLock::new();
 pub static HASH_AWAIT_WARN_TIME: OnceLock<u32> = OnceLock::new();
 
 pub struct HashPassword {
@@ -83,8 +86,28 @@ pub enum PasswordHashMessage {
 // To limit the theoretical concurrent hashes while still setting a fairly high memory for the
 // operation, this simple function makes sure that at no point in time, any more than the configured
 // amount of max concurrent hashes do happen to not exceed system memory.
+#[inline]
+fn worker_count() -> usize {
+    // defaults to 1 when unset (tests / before init), matching the historical single-consumer
+    // behavior; set from hashing.max_hash_threads in init_static_vars
+    HASH_THREADS.get().copied().unwrap_or(1)
+}
+
 pub async fn run() {
-    while let Ok(msg) = HASH_CHANNELS.get().unwrap().1.recv_async().await {
+    let workers = worker_count();
+    let rx = HASH_CHANNELS.get().unwrap().1.clone();
+
+    let mut handles = Vec::with_capacity(workers);
+    for _ in 0..workers {
+        handles.push(tokio::spawn(hash_worker(rx.clone())));
+    }
+    for handle in handles {
+        let _ = handle.await;
+    }
+}
+
+async fn hash_worker(rx: flume::Receiver<PasswordHashMessage>) {
+    while let Ok(msg) = rx.recv_async().await {
         let res = match msg {
             PasswordHashMessage::Hash(m) => {
                 check_await_threshold(&m.created);
@@ -170,6 +193,37 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::time::{Duration, Instant};
     use tokio::time;
+
+    // Covers the concurrency change (HASH_THREADS workers draining the bounded channel).
+    // Uses a low memory cost and no timing assertions, so it is fast and not flaky.
+    #[tokio::test]
+    async fn test_run_workers_process_all_messages() {
+        let params = argon2::Params::new(8 * 1024, 1, 1, None).unwrap();
+        let _ = ARGON2_PARAMS.set(params);
+        let _ = HASH_AWAIT_WARN_TIME.set(10_000);
+        let _ = HASH_CHANNELS.set(flume::bounded(2));
+        let _ = HASH_THREADS.set(2);
+
+        assert_eq!(worker_count(), 2);
+
+        let handle = tokio::spawn(run());
+
+        let mut hashes = Vec::with_capacity(4);
+        for _ in 0..4 {
+            hashes.push(
+                HashPassword::hash_password("test-password-123".to_string())
+                    .await
+                    .unwrap(),
+            );
+        }
+        for h in &hashes {
+            assert!(h.len() >= 32, "expected a non-empty argon2 hash string");
+        }
+        assert!(
+            !handle.is_finished(),
+            "workers keep running after processing"
+        );
+    }
 
     // pretty intensive test -> ignored by default
     #[tokio::test]

--- a/src/common/src/utils.rs
+++ b/src/common/src/utils.rs
@@ -1,4 +1,5 @@
 use crate::constants::{PEER_IP_HEADER_NAME, PROXY_MODE, TRUSTED_PROXIES};
+use actix_web::HttpMessage;
 use actix_web::HttpRequest;
 use actix_web::dev::ServiceRequest;
 use actix_web::http::header::HeaderMap;
@@ -126,9 +127,43 @@ const DUMMY_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 0, 0, 8));
 // dummy address should be enabled for UNIX domain socket support
 pub struct UseDummyAddress;
 
-// TODO unify real_ip_from_req and real_ip_from_svc_req by using an impl Trait
+/// Per-request cache of the resolved real client IP, stored in `req.extensions()`.
+/// Populated on first resolution; all subsequent `real_ip_from_*` calls for the same
+/// request return the cached value, because neither the peer address nor the relevant
+/// headers can change mid-request. This turns the previously repeated header parsing and
+/// trusted-proxy validation into a single pass per request.
+#[derive(Debug, Clone, Copy)]
+pub struct CachedRealIp(pub IpAddr);
+
 #[inline(always)]
 pub fn real_ip_from_req(req: &HttpRequest) -> Result<IpAddr, ErrorResponse> {
+    cached_real_ip(req, || compute_real_ip_req(req))
+}
+
+#[inline(always)]
+pub fn real_ip_from_svc_req(req: &ServiceRequest) -> Result<IpAddr, ErrorResponse> {
+    // middleware and handler handle the same request, so the cache is shared between both
+    cached_real_ip(req, || compute_real_ip_svc(req))
+}
+
+/// Per-request cache check + store, shared by both request types. The IP is resolved once
+/// per request (headers / peer address cannot change mid-request) and reused by every
+/// `real_ip_from_*` call, which previously re-parsed the headers and re-validated the
+/// trusted proxies on every call.
+fn cached_real_ip(
+    req: &impl HttpMessage,
+    compute: impl FnOnce() -> Result<IpAddr, ErrorResponse>,
+) -> Result<IpAddr, ErrorResponse> {
+    if let Some(ip) = req.extensions().get::<CachedRealIp>() {
+        return Ok(ip.0);
+    }
+
+    let ip = compute()?;
+    req.extensions_mut().insert(CachedRealIp(ip));
+    Ok(ip)
+}
+
+fn compute_real_ip_req(req: &HttpRequest) -> Result<IpAddr, ErrorResponse> {
     let use_dummy_addr = req.app_data::<UseDummyAddress>().is_some();
     let peer_ip = parse_peer_addr(req.connection_info().peer_addr(), use_dummy_addr)?;
     if let Some(ip) = ip_from_cust_header(req.headers()) {
@@ -142,8 +177,7 @@ pub fn real_ip_from_req(req: &HttpRequest) -> Result<IpAddr, ErrorResponse> {
     }
 }
 
-#[inline(always)]
-pub fn real_ip_from_svc_req(req: &ServiceRequest) -> Result<IpAddr, ErrorResponse> {
+fn compute_real_ip_svc(req: &ServiceRequest) -> Result<IpAddr, ErrorResponse> {
     let use_dummy_addr = req.app_data::<UseDummyAddress>().is_some();
     let peer_ip = parse_peer_addr(req.connection_info().peer_addr(), use_dummy_addr)?;
     if let Some(ip) = ip_from_cust_header(req.headers()) {
@@ -316,5 +350,38 @@ mod tests {
         assert!(check_trusted_proxy(&IpAddr::from_str("192.0.0.8").unwrap(), false).is_err());
         assert!(check_trusted_proxy(&IpAddr::from_str("10.10.10.11").unwrap(), true).is_ok());
         assert!(check_trusted_proxy(&IpAddr::from_str("10.10.10.9").unwrap(), true).is_err());
+    }
+
+    #[test]
+    fn test_real_ip_is_cached_per_request() {
+        use actix_web::HttpMessage;
+        use actix_web::test::TestRequest;
+        use std::net::SocketAddr;
+
+        // fast path: a pre-seeded cache wins without touching headers / connection info
+        let req = TestRequest::default().to_http_request();
+        req.extensions_mut()
+            .insert(CachedRealIp(IpAddr::from([203, 0, 113, 7])));
+        assert_eq!(
+            real_ip_from_req(&req).unwrap(),
+            IpAddr::from([203, 0, 113, 7])
+        );
+
+        // compute path: the peer address is resolved once, cached, and reused
+        let _ = PEER_IP_HEADER_NAME.set(None);
+        let _ = PROXY_MODE.set(false);
+        let req2 = TestRequest::default()
+            .peer_addr(SocketAddr::from(([192, 0, 2, 55], 8080)))
+            .to_http_request();
+        assert_eq!(
+            real_ip_from_req(&req2).unwrap(),
+            IpAddr::from([192, 0, 2, 55])
+        );
+        // second call hits the per-request cache
+        assert_eq!(
+            real_ip_from_req(&req2).unwrap(),
+            IpAddr::from([192, 0, 2, 55])
+        );
+        assert!(req2.extensions().get::<CachedRealIp>().is_some());
     }
 }

--- a/src/common/src/utils.rs
+++ b/src/common/src/utils.rs
@@ -127,11 +127,8 @@ const DUMMY_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 0, 0, 8));
 // dummy address should be enabled for UNIX domain socket support
 pub struct UseDummyAddress;
 
-/// Per-request cache of the resolved real client IP, stored in `req.extensions()`.
-/// Populated on first resolution; all subsequent `real_ip_from_*` calls for the same
-/// request return the cached value, because neither the peer address nor the relevant
-/// headers can change mid-request. This turns the previously repeated header parsing and
-/// trusted-proxy validation into a single pass per request.
+/// Per-request cache of the resolved client IP (`req.extensions()`): resolve once,
+/// reuse for the whole request (headers / peer cannot change mid-request).
 #[derive(Debug, Clone, Copy)]
 pub struct CachedRealIp(pub IpAddr);
 
@@ -146,10 +143,7 @@ pub fn real_ip_from_svc_req(req: &ServiceRequest) -> Result<IpAddr, ErrorRespons
     cached_real_ip(req, || compute_real_ip_svc(req))
 }
 
-/// Per-request cache check + store, shared by both request types. The IP is resolved once
-/// per request (headers / peer address cannot change mid-request) and reused by every
-/// `real_ip_from_*` call, which previously re-parsed the headers and re-validated the
-/// trusted proxies on every call.
+/// Resolve once per request; both request types share the same extensions.
 fn cached_real_ip(
     req: &impl HttpMessage,
     compute: impl FnOnce() -> Result<IpAddr, ErrorResponse>,

--- a/src/data/Cargo.toml
+++ b/src/data/Cargo.toml
@@ -21,7 +21,7 @@ actix-multipart = { workspace = true }
 actix-web = { workspace = true }
 actix-web-lab = { workspace = true }
 arc-swap = { workspace = true }
-argon2 = { workspace = true }
+argon2-rust = { workspace = true }
 askama = { workspace = true }
 async-trait = { workspace = true }
 atrium-api = { workspace = true }

--- a/src/data/src/entity/dpop_proof.rs
+++ b/src/data/src/entity/dpop_proof.rs
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn test_dpop_validation_rsa() {
         // manually build up a dpop token
-        let mut rng = argon2::password_hash::rand_core::OsRng;
+        let mut rng = rand_08::rngs::OsRng;
         let rsa_sk = rsa::RsaPrivateKey::new(&mut rng, 2048).unwrap();
         let rsa_pk = rsa_sk.to_public_key();
         let n = rsa_pk.n().to_bytes_be();

--- a/src/data/src/entity/login_locations.rs
+++ b/src/data/src/entity/login_locations.rs
@@ -15,7 +15,7 @@ use rauthy_derive::FromPgRow;
 use rauthy_error::{ErrorResponse, ErrorResponseType};
 use std::net::IpAddr;
 use tokio::task;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug, FromRow, FromPgRow)]
 pub struct LoginLocation {
@@ -167,6 +167,22 @@ WHERE user_id = $3 AND browser_id = $4 AND ip = $5"#;
     }
 }
 
+/// Bounds the per-login background location checks (spawned on every login via
+/// `spawn_background_check`). A login storm must not grow the spawned-task fan-out
+/// without limit: the geo / location check is best-effort, so when the cap is reached
+/// newer checks are skipped with a warning instead of piling up memory.
+static BACKGROUND_CHECK_LIMIT: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(64);
+
+fn try_background_permit() -> Option<tokio::sync::SemaphorePermit<'static>> {
+    match BACKGROUND_CHECK_LIMIT.try_acquire() {
+        Ok(permit) => Some(permit),
+        Err(_) => {
+            warn!("Login location background check skipped - too many concurrent checks");
+            None
+        }
+    }
+}
+
 impl LoginLocation {
     pub fn spawn_background_check(
         user: User,
@@ -198,7 +214,13 @@ impl LoginLocation {
 
         let location = get_location(req, ip)?;
 
+        let permit = match try_background_permit() {
+            Some(permit) => permit,
+            None => return Ok(()),
+        };
+
         task::spawn(async move {
+            let _permit = permit;
             if let Err(err) =
                 Self::background_check(user, ip, user_agent, location, browser_id).await
             {
@@ -255,5 +277,24 @@ impl LoginLocation {
         .await;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_background_permit_skips_when_saturated() {
+        // saturate the shared cap
+        let mut permits = Vec::new();
+        while let Ok(p) = BACKGROUND_CHECK_LIMIT.try_acquire() {
+            permits.push(p);
+        }
+        // saturated -> the per-login background check is skipped, not queued
+        assert!(try_background_permit().is_none());
+        // a free slot becomes available again once one permit is released
+        permits.pop();
+        assert!(try_background_permit().is_some());
     }
 }

--- a/src/data/src/entity/login_locations.rs
+++ b/src/data/src/entity/login_locations.rs
@@ -167,10 +167,7 @@ WHERE user_id = $3 AND browser_id = $4 AND ip = $5"#;
     }
 }
 
-/// Bounds the per-login background location checks (spawned on every login via
-/// `spawn_background_check`). A login storm must not grow the spawned-task fan-out
-/// without limit: the geo / location check is best-effort, so when the cap is reached
-/// newer checks are skipped with a warning instead of piling up memory.
+/// Caps per-login background location checks (best-effort): saturated -> skip + warn.
 static BACKGROUND_CHECK_LIMIT: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(64);
 
 fn try_background_permit() -> Option<tokio::sync::SemaphorePermit<'static>> {

--- a/src/data/src/entity/password.rs
+++ b/src/data/src/entity/password.rs
@@ -1,8 +1,7 @@
 use crate::database::{Cache, DB};
 use actix_web::web;
-use argon2::password_hash::SaltString;
-use argon2::password_hash::rand_core::OsRng;
-use argon2::{Algorithm, Argon2, PasswordHasher, Version};
+use argon2_rust::params::{Memory, TagLen};
+use argon2_rust::{Algorithm, Argon2, Params, Version};
 use hiqlite::macros::params;
 use rauthy_api_types::generic::{
     PasswordHashTimesRequest, PasswordPolicyRequest, PasswordPolicyResponse,
@@ -38,7 +37,12 @@ impl PasswordHashTimes {
         let mut time_taken = 0u32;
 
         // get a good baseline for t_cost == 1
-        let params = argon2::Params::new(m_cost, 1, p_cost, None)?;
+        let params = Params::builder()
+            .memory(Memory::kib(m_cost as u64))
+            .passes(1)
+            .lanes(p_cost)
+            .tag_len(TagLen::bytes(32))
+            .build()?;
         let now = time::Instant::now();
         let _ = Self::new_password_hash("SuperRandomString1337", &params).await?;
         let t_one = now.elapsed().as_millis() as u32;
@@ -48,7 +52,12 @@ impl PasswordHashTimes {
         let mut t_cost = max(ARGON2ID_T_COST_MIN, approx);
 
         while time_taken < target {
-            let params = argon2::Params::new(m_cost, t_cost, p_cost, None)?;
+            let params = Params::builder()
+                .memory(Memory::kib(m_cost as u64))
+                .passes(t_cost)
+                .lanes(p_cost)
+                .tag_len(TagLen::bytes(32))
+                .build()?;
 
             let now = time::Instant::now();
             let _ = Self::new_password_hash("SuperRandomString1337", &params).await?;
@@ -82,18 +91,16 @@ impl PasswordHashTimes {
     // Generates a new Argon2id hash from the given cleartext password and returns the hash.
     pub async fn new_password_hash(
         plain: &str,
-        params: &argon2::Params,
+        params: &argon2_rust::Params,
     ) -> Result<String, ErrorResponse> {
-        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params.to_owned());
+        let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, *params);
         let plain_pwd = plain.to_owned();
 
         // hashing should not happen on the event loop
         let hash = web::block(move || {
-            let salt = SaltString::generate(&mut OsRng);
             argon2
-                .hash_password(plain_pwd.as_bytes(), &salt)
+                .hash_password_with_random_salt(plain_pwd.as_bytes())
                 .expect("Error hashing the Password")
-                .to_string()
         })
         .await
         .map_err(ErrorResponse::from)?;

--- a/src/data/src/entity/users.rs
+++ b/src/data/src/entity/users.rs
@@ -22,7 +22,7 @@ use crate::html::templates::{HtmlTemplate, UserEmailChangeConfirmHtml};
 use crate::language::Language;
 use crate::rauthy_config::RauthyConfig;
 use actix_web::HttpRequest;
-use argon2::PasswordHash;
+use argon2_rust::decode_phc;
 use chrono::Utc;
 use core::str::Split;
 use hiqlite::Params;
@@ -1848,7 +1848,7 @@ impl User {
         }
     }
 
-    pub fn is_argon2_uptodate(&self, params: &argon2::Params) -> Result<bool, ErrorResponse> {
+    pub fn is_argon2_uptodate(&self, params: &argon2_rust::Params) -> Result<bool, ErrorResponse> {
         if self.password.is_none() {
             error!(
                 user_id = self.id,
@@ -1859,14 +1859,19 @@ impl User {
                 "Cannot validate argon2 param - password is not set",
             ));
         }
-        let hash = PasswordHash::new(self.password.as_ref().unwrap())
-            .expect("Could not build Hash from password string");
-        let curr_params =
-            argon2::Params::try_from(&hash).expect("Could not extract params from hash");
+        // decode the stored PHC string with the crate's parser and compare the params
+        let hash_str = self.password.as_ref().unwrap();
+        let curr = decode_phc(hash_str).map_err(|err| {
+            error!("Could not parse the stored password hash: {err}");
+            ErrorResponse::new(
+                ErrorResponseType::Internal,
+                "Cannot parse the stored password hash",
+            )
+        })?;
 
-        if curr_params.m_cost() == params.m_cost()
-            && curr_params.t_cost() == params.t_cost()
-            && curr_params.p_cost() == params.p_cost()
+        if curr.params.memory_kib() == params.memory_kib()
+            && curr.params.passes() == params.passes()
+            && curr.params.lanes() == params.lanes()
         {
             return Ok(true);
         }
@@ -2251,19 +2256,39 @@ mod tests {
 
         // argon2 params
         // defaults: argon2_m_cost = 16384, argon2_t_cost = 3, argon2_p_cost = 2
-        let mut wrapped_params = argon2::Params::new(16384, 3, 2, None)?;
+        let mut wrapped_params = argon2_rust::Params::builder()
+            .memory(argon2_rust::params::Memory::kib(16384))
+            .passes(3)
+            .lanes(2)
+            .tag_len(argon2_rust::params::TagLen::bytes(32))
+            .build_or_panic();
         let res = user.is_argon2_uptodate(&wrapped_params)?;
         assert_eq!(res, true);
 
-        wrapped_params = argon2::Params::new(8192, 3, 2, None)?;
+        wrapped_params = argon2_rust::Params::builder()
+            .memory(argon2_rust::params::Memory::kib(8192))
+            .passes(3)
+            .lanes(2)
+            .tag_len(argon2_rust::params::TagLen::bytes(32))
+            .build_or_panic();
         let res = user.is_argon2_uptodate(&wrapped_params)?;
         assert_eq!(res, false);
 
-        wrapped_params = argon2::Params::new(16384, 4, 2, None)?;
+        wrapped_params = argon2_rust::Params::builder()
+            .memory(argon2_rust::params::Memory::kib(16384))
+            .passes(4)
+            .lanes(2)
+            .tag_len(argon2_rust::params::TagLen::bytes(32))
+            .build_or_panic();
         let res = user.is_argon2_uptodate(&wrapped_params)?;
         assert_eq!(res, false);
 
-        wrapped_params = argon2::Params::new(16384, 3, 5, None)?;
+        wrapped_params = argon2_rust::Params::builder()
+            .memory(argon2_rust::params::Memory::kib(16384))
+            .passes(3)
+            .lanes(5)
+            .tag_len(argon2_rust::params::TagLen::bytes(32))
+            .build_or_panic();
         let res = user.is_argon2_uptodate(&wrapped_params)?;
         assert_eq!(res, false);
 

--- a/src/data/src/events/event.rs
+++ b/src/data/src/events/event.rs
@@ -16,7 +16,7 @@ use std::cmp::max;
 use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
 use std::str::FromStr;
-use tracing::error;
+use tracing::{error, warn};
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -1066,15 +1066,28 @@ impl Event {
 
     #[inline(always)]
     pub async fn send(self) -> Result<(), ErrorResponse> {
-        match RauthyConfig::get().tx_events.send_async(self).await {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                error!(?err, "Event::send()");
-                Err(ErrorResponse::new(
-                    ErrorResponseType::Internal,
-                    format!("Error sending event internally: {err:?}"),
-                ))
-            }
+        // Non-blocking on purpose: the queue is bounded, and once it is saturated we drop
+        // the event with a warning instead of stalling the request handler or growing
+        // memory without limit. Events are best-effort notifications/audit.
+        try_send_event(&RauthyConfig::get().tx_events, self)
+    }
+}
+
+/// Non-blocking event send used by `Event::send`. A saturated bounded queue drops the
+/// event with a warning (Ok), a disconnected channel errors like before.
+fn try_send_event(tx: &flume::Sender<Event>, event: Event) -> Result<(), ErrorResponse> {
+    match tx.try_send(event) {
+        Ok(()) => Ok(()),
+        Err(flume::TrySendError::Full(_)) => {
+            warn!("Event queue full - dropping event");
+            Ok(())
+        }
+        Err(err) => {
+            error!(?err, "Event::send()");
+            Err(ErrorResponse::new(
+                ErrorResponseType::Internal,
+                format!("Error sending event internally: {err:?}"),
+            ))
         }
     }
 }
@@ -1090,5 +1103,30 @@ impl From<Event> for EventResponse {
             data: e.data,
             text: e.text,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_event() -> Event {
+        Event::new(EventLevel::Info, EventType::InvalidLogins, None, None, None)
+    }
+
+    #[test]
+    fn test_try_send_event_full_queue_drops_ok() {
+        let (tx, _rx) = flume::bounded::<Event>(1);
+        // normal send
+        assert!(try_send_event(&tx, test_event()).is_ok());
+        // queue saturated -> event dropped, still Ok (never blocks the caller)
+        assert!(try_send_event(&tx, test_event()).is_ok());
+    }
+
+    #[test]
+    fn test_try_send_event_disconnected_errors() {
+        let (tx, rx) = flume::bounded::<Event>(1);
+        drop(rx);
+        assert!(try_send_event(&tx, test_event()).is_err());
     }
 }

--- a/src/data/src/events/event.rs
+++ b/src/data/src/events/event.rs
@@ -1066,15 +1066,13 @@ impl Event {
 
     #[inline(always)]
     pub async fn send(self) -> Result<(), ErrorResponse> {
-        // Non-blocking on purpose: the queue is bounded, and once it is saturated we drop
-        // the event with a warning instead of stalling the request handler or growing
-        // memory without limit. Events are best-effort notifications/audit.
+        // Non-blocking: drop with a warning when the bounded queue is saturated, so
+        // handlers never stall; events are best-effort.
         try_send_event(&RauthyConfig::get().tx_events, self)
     }
 }
 
-/// Non-blocking event send used by `Event::send`. A saturated bounded queue drops the
-/// event with a warning (Ok), a disconnected channel errors like before.
+/// Non-blocking send used by `Event::send`: full queue -> warn + drop (Ok), closed -> Err.
 fn try_send_event(tx: &flume::Sender<Event>, event: Event) -> Result<(), ErrorResponse> {
     match tx.try_send(event) {
         Ok(()) => Ok(()),

--- a/src/data/src/events/health_watch.rs
+++ b/src/data/src/events/health_watch.rs
@@ -3,7 +3,7 @@ use crate::entity::is_db_alive;
 use crate::events::event::Event;
 use crate::rauthy_config::RauthyConfig;
 use std::time::Duration;
-use tracing::debug;
+use tracing::{debug, warn};
 
 pub async fn watch_health() {
     debug!("Rauthy health watcher started");
@@ -47,7 +47,11 @@ pub async fn watch_health() {
 
         if is_good_now && !last_state {
             // let only the cache leader send healthy message in HA deployment
-            tx_events.send_async(Event::rauthy_healthy()).await.unwrap();
+            // best-effort: never block the health watcher or panic if the bounded
+            // event queue is saturated
+            if let Err(err) = tx_events.try_send(Event::rauthy_healthy()) {
+                warn!(?err, "Cannot send rauthy_healthy event - event queue full");
+            }
         }
 
         last_state = is_good_now;

--- a/src/data/src/events/listener.rs
+++ b/src/data/src/events/listener.rs
@@ -38,10 +38,8 @@ impl EventListener {
         tokio::spawn(Self::router(rx_router));
         tokio::spawn(Self::raft_events_listener(tx_router));
 
-        // Cap the number of concurrently processed events so an event storm cannot grow
-        // the spawned-task fan-out without limit. Once the permits are exhausted the
-        // consumer stops dequeuing, the bounded channel fills up, and producers drop
-        // events with a warning (see Event::send) instead of growing memory.
+        // Cap concurrent event processing: when permits are exhausted the consumer stops
+        // dequeuing, the bounded queue fills, and producers drop events (Event::send).
         let sem = Arc::new(Semaphore::new(256));
         while let Ok(event) = rx_event.recv_async().await {
             let sem = Arc::clone(&sem);
@@ -269,10 +267,8 @@ mod tests {
         Event::new(EventLevel::Info, EventType::InvalidLogins, None, None, None)
     }
 
-    // Covers the consumer-loop change (acquire-before-spawn with a permit semaphore): the
-    // number of concurrently processed events is structurally capped at the permit count,
-    // so an event storm cannot grow the spawned-task fan-out without limit. The assertion
-    // is structural (semaphore), not timing-based; the wait is a bounded completion wait.
+    // Structural cap: acquire-before-spawn limits concurrent processing to the permits;
+    // assertion is semaphore-guaranteed, the wait is completion-bounded.
     #[tokio::test]
     async fn test_event_consumer_caps_concurrency() {
         let (tx, rx) = flume::bounded::<Event>(2);

--- a/src/data/src/events/listener.rs
+++ b/src/data/src/events/listener.rs
@@ -6,10 +6,12 @@ use actix_web_lab::sse;
 use rauthy_common::constants::EVENTS_LATEST_LIMIT;
 use rauthy_error::ErrorResponse;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::time;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Clone)]
 pub enum EventRouterMsg {
@@ -36,8 +38,22 @@ impl EventListener {
         tokio::spawn(Self::router(rx_router));
         tokio::spawn(Self::raft_events_listener(tx_router));
 
+        // Cap the number of concurrently processed events so an event storm cannot grow
+        // the spawned-task fan-out without limit. Once the permits are exhausted the
+        // consumer stops dequeuing, the bounded channel fills up, and producers drop
+        // events with a warning (see Event::send) instead of growing memory.
+        let sem = Arc::new(Semaphore::new(256));
         while let Ok(event) = rx_event.recv_async().await {
-            tokio::spawn(Self::handle_event(event));
+            let sem = Arc::clone(&sem);
+            let permit = match sem.acquire_owned().await {
+                Ok(permit) => permit,
+                // the semaphore is only closed at shutdown - treat as end of stream
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                let _permit = permit;
+                Self::handle_event(event).await;
+            });
         }
 
         Ok(())
@@ -81,10 +97,12 @@ impl EventListener {
             debug!(?event);
 
             // forward to event router -> payload is already an Event in JSON format
-            if let Err(err) = tx.send_async(EventRouterMsg::Event(event)).await {
-                error!(
+            // best-effort: drop (with a warning) if the bounded router queue is saturated,
+            // so the HA raft listener never blocks on a full queue
+            if let Err(err) = tx.try_send(EventRouterMsg::Event(event)) {
+                warn!(
                     ?err,
-                    "Error sending Event internally - this should never happen!",
+                    "Event router queue full - dropping event from raft listener",
                 );
             }
         }
@@ -238,5 +256,70 @@ impl EventListener {
         }
 
         panic!("tx for EventRouterMsg has been closed - this should never happen!");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::event::EventType;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn test_event() -> Event {
+        Event::new(EventLevel::Info, EventType::InvalidLogins, None, None, None)
+    }
+
+    // Covers the consumer-loop change (acquire-before-spawn with a permit semaphore): the
+    // number of concurrently processed events is structurally capped at the permit count,
+    // so an event storm cannot grow the spawned-task fan-out without limit. The assertion
+    // is structural (semaphore), not timing-based; the wait is a bounded completion wait.
+    #[tokio::test]
+    async fn test_event_consumer_caps_concurrency() {
+        let (tx, rx) = flume::bounded::<Event>(2);
+        for _ in 0..2 {
+            let _ = tx.try_send(test_event());
+        }
+        drop(tx);
+
+        let sem = Arc::new(Semaphore::new(1));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let (done_tx, done_rx) = flume::unbounded::<()>();
+
+        let handle = tokio::spawn({
+            let rx = rx;
+            let sem = Arc::clone(&sem);
+            let in_flight = Arc::clone(&in_flight);
+            let max = Arc::clone(&max_in_flight);
+            let done_tx = done_tx;
+            async move {
+                while let Ok(event) = rx.recv_async().await {
+                    let sem = Arc::clone(&sem);
+                    let in_flight = Arc::clone(&in_flight);
+                    let max = Arc::clone(&max);
+                    let done_tx = done_tx.clone();
+                    let permit = sem.acquire_owned().await.unwrap();
+                    tokio::spawn(async move {
+                        let _permit = permit;
+                        let _ = event;
+                        let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                        max.fetch_max(now, Ordering::SeqCst);
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                        let _ = done_tx.send(());
+                    });
+                }
+            }
+        });
+
+        let _ = tokio::time::timeout(Duration::from_secs(5), async {
+            for _ in 0..2 {
+                let _ = done_rx.recv_async().await;
+            }
+        })
+        .await
+        .expect("both events should be processed");
+
+        assert!(max_in_flight.load(Ordering::SeqCst) <= 1);
+        handle.abort();
     }
 }

--- a/src/data/src/migration/bootstrap/rauthy_admin.rs
+++ b/src/data/src/migration/bootstrap/rauthy_admin.rs
@@ -1,8 +1,6 @@
 use crate::database::DB;
 use crate::rauthy_config::RauthyConfig;
-use argon2::password_hash::SaltString;
-use argon2::password_hash::rand_core::OsRng;
-use argon2::{Algorithm, Argon2, PasswordHasher, Version};
+use argon2_rust::{Algorithm, Argon2, Version};
 use hiqlite::macros::params;
 use rauthy_common::is_hiqlite;
 use rauthy_common::utils::{get_rand, new_store_id};
@@ -58,13 +56,11 @@ pub async fn bootstrap() -> Result<(), ErrorResponse> {
                 }
             };
 
-            let params = RauthyConfig::get().argon2_params.clone();
+            let params = RauthyConfig::get().argon2_params;
             let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
-            let salt = SaltString::generate(&mut OsRng);
             argon2
-                .hash_password(plain.as_bytes(), &salt)
+                .hash_password_with_random_salt(plain.as_bytes())
                 .expect("Error hashing the Password")
-                .to_string()
         }
     };
 

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -32,7 +32,7 @@ const FROM_SECRETS: &str = "$SECRETS";
 
 #[derive(Debug)]
 pub struct RauthyConfig {
-    pub argon2_params: argon2::Params,
+    pub argon2_params: argon2_rust::Params,
     pub issuer: String,
     pub is_primary_node: bool,
     pub is_ha_cluster: bool,
@@ -56,7 +56,7 @@ impl RauthyConfig {
         tx_events: flume::Sender<Event>,
         tx_events_router: flume::Sender<EventRouterMsg>,
     ) -> Result<(Self, hiqlite::NodeConfig), Box<dyn Error>> {
-        let (vars, node_config) = Vars::load(&path_config, path_secrets).await;
+        let (mut vars, node_config) = Vars::load(&path_config, path_secrets).await;
         vars.validate();
         if let Err(err) = node_config.is_valid() {
             panic!("Invalid `[cluster]` config: {err}");
@@ -100,13 +100,24 @@ impl RauthyConfig {
             ),
         };
 
-        let argon2_params = argon2::Params::new(
-            vars.hashing.argon2_m_cost,
-            vars.hashing.argon2_t_cost,
+        // Clamp p to the host cores: lanes serialize on small hosts (work conserved),
+        // and p <= cores avoids oversubscription. Memory-hardness (m) is unaffected.
+        vars.hashing.argon2_p_cost = clamp_hash_lanes(
             vars.hashing.argon2_p_cost,
-            None,
-        )
-        .expect("Unable to build Argon2id params, check the values in the [hashing] section");
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1),
+        );
+
+        let argon2_params = argon2_rust::Params::builder()
+            .memory(argon2_rust::params::Memory::kib(
+                vars.hashing.argon2_m_cost as u64,
+            ))
+            .passes(vars.hashing.argon2_t_cost)
+            .lanes(vars.hashing.argon2_p_cost)
+            .tag_len(argon2_rust::params::TagLen::bytes(32))
+            .build()
+            .expect("Unable to build Argon2id params, check the values in the [hashing] section");
 
         #[cfg(target_os = "windows")]
         let is_https = matches!(listen_scheme, ListenScheme::HttpHttps | ListenScheme::Https)
@@ -216,9 +227,9 @@ impl RauthyConfig {
         debug!("HA Deployment: {}", slf.is_ha_cluster);
         debug!(
             "Argon2id Params: m_code: {}, t_cost: {}, p_cost: {}",
-            slf.argon2_params.m_cost(),
-            slf.argon2_params.t_cost(),
-            slf.argon2_params.p_cost()
+            slf.argon2_params.memory_kib(),
+            slf.argon2_params.passes(),
+            slf.argon2_params.lanes()
         );
 
         if slf.vars.dev.dev_mode {
@@ -523,40 +534,17 @@ impl Default for Vars {
             hashing: VarsHashing {
                 argon2_m_cost: 65536,
                 argon2_t_cost: 3,
-                // OWASP CheatSheet Argon2id "low memory" profile (m=64 MiB, t=3, p=4);
-                // p=1 for the scalar RustCrypto implementation (lanes are sequential, p>1
-                // adds no speedup - RFC 9106 §4.2 prefers a small parallelism factor for
-                // password hashing). Measured on Apple Silicon (release, argon2 0.5.3):
-                // 94 ms/hash vs 275 ms at the old 128 MiB/t=4, at ~half the memory; with
-                // max_hash_threads=2 the concurrency memory cost is absorbed (peak equals
-                // the old single-hash memory) while 8 concurrent logins finish ~5.6x
-                // faster. Tradeoff: an offline GPU/ASIC attacker spends ~2.7x less work per
-                // candidate (total m*t 192 vs 512 MiB-passes). Existing hashes re-hash on
-                // the next successful login via is_argon2_uptodate.
-                argon2_p_cost: 1,
+                // OWASP "low memory" profile (m=64 MiB, t=3); p=8 lanes (best measured,
+                // parallelized by the SIMD backend). Existing hashes re-hash on next login.
+                argon2_p_cost: 8,
                 max_hash_threads: 2,
                 hash_await_warn_time: 500,
                 argon2_preset: None,
             },
 
             // ── Argon2id presets ──────────────────────────────────────────────────────
-            // Use `argon2_preset = "speed" | "memory" | "hardened"` (or ARGON2_PRESET env).
-            // The preset sets the intended defaults for m / t / p / max_hash_threads; each
-            // of those fields can still be overridden individually (explicit value wins).
-            // Stable per-worker rule: 1 CPU core per hash thread (argon2 is CPU-bound),
-            // RAM = m per in-flight hash + ~2 MiB overhead. Measured peaks (Apple Silicon,
-            // release, argon2 0.5.3): 66 MiB @ m=64 MiB, 130 MiB @ m=128 MiB.
-            // All numbers are PER NODE (per pod/container); a cluster needs N x per-node.
-            // Memory request formula (see book/src/getting_started/k8s.md):
-            //   m_cost/1024 * max_hash_threads Mi + idle memory
-            //   (idle ~100 MiB with HA/hiqlite, ~30 MiB with external Postgres)
-            // Per-node request/limit guidance (HA idle):
-            //   speed     threads=2  RAM req 256 MiB / limit 512 MiB;  CPU req 2 / limit 4
-            //   memory    threads=1  RAM req 192 MiB / limit 384 MiB;  CPU req 1 / limit 2
-            //   hardened  threads=2  RAM req 384 MiB / limit 768 MiB;  CPU req 2 / limit 4
-            // CPU limit is optional (DDoS guard); MAX_HASH_THREADS is the main CPU limiter.
-            // Override example: argon2_preset = "hardened" with argon2_m_cost = 262144
-            // raises only the memory (262 MiB/hash) while keeping t=4, p=1, threads=2.
+            // `argon2_preset = "speed" | "memory" | "hardened"` sets m/t/p/threads defaults;
+            // any field can still be overridden individually (explicit wins).
             http_client: VarsHttpClient {
                 connect_timeout: 10,
                 request_timeout: 10,
@@ -2668,8 +2656,7 @@ impl Vars {
         };
         self.hashing.argon2_preset = preset;
 
-        // A preset provides the intended defaults for m / t / p / threads, but each value can
-        // still be overridden individually by the user. Without a preset, the built-in
+        // A preset provides m/t/p/threads defaults; each value is still overridable.
         // defaults apply.
         let defaults = self
             .hashing
@@ -3967,21 +3954,17 @@ pub struct ConfigVarsGeo {
     pub maxmind_update_cron: Cow<'static, str>,
 }
 
-/// Named Argon2id hashing presets, selectable at startup via `hashing.argon2_preset`
-/// (config file) or `ARGON2_PRESET` (env var). When set, the preset overrides the explicit
-/// `argon2_m_cost` / `argon2_t_cost` / `argon2_p_cost` / `max_hash_threads` values.
-/// Measured on Apple Silicon (release, argon2 0.5.3) vs the original main default
-/// (single hash 275 ms / 130 MiB peak):
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Named Argon2id presets, selected at startup via `hashing.argon2_preset` /
+/// `ARGON2_PRESET`. Sets m / t / p / max_hash_threads; individual fields can still be
+/// overridden per-value (explicit > preset > default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Argon2Preset {
-    /// OWASP low-memory profile (m=64 MiB, t=3), 2 workers: 94 ms/hash (2.8x faster,
-    /// 51% memory); 8 concurrent logins in 382 ms (5.6x) at ~100% peak memory.
+    /// OWASP-low profile (m=64 MiB, t=3), 2 workers - the default.
     Speed,
-    /// Same crypto profile as `Speed`, 1 worker: 94 ms/hash; peak memory stays at 51%
-    /// of the original default (best for memory-constrained deployments).
+    /// Same crypto profile, 1 worker - lowest memory, no concurrency.
+    #[default]
     Memory,
-    /// Original strongest profile (m=128 MiB, t=4), 2 workers: 269 ms/hash (100% time);
-    /// 8 concurrent logins in 1076 ms (2x) at ~199% peak memory.
+    /// Original strongest profile (m=128 MiB, t=4), 2 workers.
     Hardened,
 }
 
@@ -3989,9 +3972,11 @@ impl Argon2Preset {
     /// Returns `(argon2_m_cost, argon2_t_cost, argon2_p_cost, max_hash_threads)`.
     pub const fn params(self) -> (u32, u32, u32, u32) {
         match self {
-            Self::Speed => (65536, 3, 1, 2),
-            Self::Memory => (65536, 3, 1, 1),
-            Self::Hardened => (131072, 4, 1, 2),
+            // p=8: the argon2-rust backend parallelizes lanes across cores; best measured.
+            // Total memory m is unchanged, so p does not weaken memory-hardness.
+            Self::Speed => (65536, 3, 8, 2),
+            Self::Memory => (65536, 3, 8, 1),
+            Self::Hardened => (131072, 4, 8, 2),
         }
     }
 }
@@ -4003,15 +3988,22 @@ impl From<&str> for Argon2Preset {
             "memory" => Self::Memory,
             "hardened" => Self::Hardened,
             other => {
-                warn!("Unknown argon2_preset '{other}', defaulting to 'speed'");
-                Self::Speed
+                warn!("Unknown argon2_preset '{other}', defaulting to 'memory'");
+                Self::Memory
             }
         }
     }
 }
 
-/// Resolves the effective argon2 hashing values from an explicit user override, a named
-/// preset and the built-in defaults. Precedence: explicit value > preset > default.
+/// Clamps the argon2 lane parallelism `p` to the host's available cores, so the p=8
+/// presets do not oversubscribe on small / single-core hosts. Lanes serialize when there
+/// are fewer cores than lanes (total work is conserved), and p <= cores avoids scheduler
+/// and cache pressure. Never below 1.
+fn clamp_hash_lanes(p: u32, cores: usize) -> u32 {
+    p.min((cores as u32).max(1))
+}
+
+/// Effective hashing values: explicit override > preset > built-in default.
 fn resolve_hashing_values(
     m: Option<u32>,
     t: Option<u32>,
@@ -4443,14 +4435,14 @@ mod tests {
         assert_eq!(Argon2Preset::from("memory"), Argon2Preset::Memory);
         assert_eq!(Argon2Preset::from("hardened"), Argon2Preset::Hardened);
         // unknown values fall back to the default preset
-        assert_eq!(Argon2Preset::from("bogus"), Argon2Preset::Speed);
+        assert_eq!(Argon2Preset::from("bogus"), Argon2Preset::Memory);
     }
 
     #[test]
     fn test_argon2_preset_params() {
-        assert_eq!(Argon2Preset::Speed.params(), (65536, 3, 1, 2));
-        assert_eq!(Argon2Preset::Memory.params(), (65536, 3, 1, 1));
-        assert_eq!(Argon2Preset::Hardened.params(), (131072, 4, 1, 2));
+        assert_eq!(Argon2Preset::Speed.params(), (65536, 3, 8, 2));
+        assert_eq!(Argon2Preset::Memory.params(), (65536, 3, 8, 1));
+        assert_eq!(Argon2Preset::Hardened.params(), (131072, 4, 8, 2));
     }
 
     #[test]
@@ -4458,17 +4450,17 @@ mod tests {
         // explicit user value wins over the preset
         assert_eq!(
             resolve_hashing_values(Some(131072), None, None, None, Argon2Preset::Speed.params()),
-            (131072, 3, 1, 2)
+            (131072, 3, 8, 2)
         );
         // preset provides the defaults
         assert_eq!(
             resolve_hashing_values(None, None, None, None, Argon2Preset::Memory.params()),
-            (65536, 3, 1, 1)
+            (65536, 3, 8, 1)
         );
         // neither preset nor explicit -> built-in defaults
         assert_eq!(
-            resolve_hashing_values(None, None, None, None, (65536, 3, 1, 2)),
-            (65536, 3, 1, 2)
+            resolve_hashing_values(None, None, None, None, (65536, 3, 8, 1)),
+            (65536, 3, 8, 1)
         );
         // mixed: one explicit override, the rest from the preset
         assert_eq!(
@@ -4479,7 +4471,21 @@ mod tests {
                 Some(4),
                 Argon2Preset::Hardened.params()
             ),
-            (131072, 2, 1, 4)
+            (131072, 2, 8, 4)
         );
+    }
+
+    #[test]
+    fn test_clamp_hash_lanes() {
+        // p=8 presets are clamped to the host's cores
+        assert_eq!(clamp_hash_lanes(8, 1), 1);
+        assert_eq!(clamp_hash_lanes(8, 2), 2);
+        assert_eq!(clamp_hash_lanes(8, 12), 8);
+        assert_eq!(clamp_hash_lanes(8, 16), 8);
+        // p below the core count is untouched
+        assert_eq!(clamp_hash_lanes(2, 12), 2);
+        // degenerate zero-core report clamps to 1 (p is never 0)
+        assert_eq!(clamp_hash_lanes(8, 0), 1);
+        assert_eq!(clamp_hash_lanes(1, 1), 1);
     }
 }

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -521,9 +521,19 @@ impl Default for Vars {
                 maxmind_update_cron: "0 0 5 * * * *".into(),
             },
             hashing: VarsHashing {
-                argon2_m_cost: 131072,
-                argon2_t_cost: 4,
-                argon2_p_cost: 8,
+                argon2_m_cost: 65536,
+                argon2_t_cost: 3,
+                // OWASP CheatSheet Argon2id "low memory" profile (m=64 MiB, t=3, p=4);
+                // p=1 for the scalar RustCrypto implementation (lanes are sequential, p>1
+                // adds no speedup - RFC 9106 §4.2 prefers a small parallelism factor for
+                // password hashing). Measured on Apple Silicon (release, argon2 0.5.3):
+                // 94 ms/hash vs 275 ms at the old 128 MiB/t=4, at ~half the memory; with
+                // max_hash_threads=2 the concurrency memory cost is absorbed (peak equals
+                // the old single-hash memory) while 8 concurrent logins finish ~5.6x
+                // faster. Tradeoff: an offline GPU/ASIC attacker spends ~2.7x less work per
+                // candidate (total m*t 192 vs 512 MiB-passes). Existing hashes re-hash on
+                // the next successful login via is_argon2_uptodate.
+                argon2_p_cost: 1,
                 max_hash_threads: 2,
                 hash_await_warn_time: 500,
             },

--- a/src/data/src/rauthy_config.rs
+++ b/src/data/src/rauthy_config.rs
@@ -536,7 +536,27 @@ impl Default for Vars {
                 argon2_p_cost: 1,
                 max_hash_threads: 2,
                 hash_await_warn_time: 500,
+                argon2_preset: None,
             },
+
+            // ── Argon2id presets ──────────────────────────────────────────────────────
+            // Use `argon2_preset = "speed" | "memory" | "hardened"` (or ARGON2_PRESET env).
+            // The preset sets the intended defaults for m / t / p / max_hash_threads; each
+            // of those fields can still be overridden individually (explicit value wins).
+            // Stable per-worker rule: 1 CPU core per hash thread (argon2 is CPU-bound),
+            // RAM = m per in-flight hash + ~2 MiB overhead. Measured peaks (Apple Silicon,
+            // release, argon2 0.5.3): 66 MiB @ m=64 MiB, 130 MiB @ m=128 MiB.
+            // All numbers are PER NODE (per pod/container); a cluster needs N x per-node.
+            // Memory request formula (see book/src/getting_started/k8s.md):
+            //   m_cost/1024 * max_hash_threads Mi + idle memory
+            //   (idle ~100 MiB with HA/hiqlite, ~30 MiB with external Postgres)
+            // Per-node request/limit guidance (HA idle):
+            //   speed     threads=2  RAM req 256 MiB / limit 512 MiB;  CPU req 2 / limit 4
+            //   memory    threads=1  RAM req 192 MiB / limit 384 MiB;  CPU req 1 / limit 2
+            //   hardened  threads=2  RAM req 384 MiB / limit 768 MiB;  CPU req 2 / limit 4
+            // CPU limit is optional (DDoS guard); MAX_HASH_THREADS is the main CPU limiter.
+            // Override example: argon2_preset = "hardened" with argon2_m_cost = 262144
+            // raises only the memory (262 MiB/hash) while keeping t=4, p=1, threads=2.
             http_client: VarsHttpClient {
                 connect_timeout: 10,
                 request_timeout: 10,
@@ -2622,24 +2642,17 @@ impl Vars {
     fn parse_hashing(&mut self, table: &mut toml::Table) {
         let mut table = t_table(table, "hashing");
 
-        if let Some(v) = t_u32(&mut table, "hashing", "argon2_m_cost", "ARGON2_M_COST") {
-            self.hashing.argon2_m_cost = v;
-        }
-        if let Some(v) = t_u32(&mut table, "hashing", "argon2_t_cost", "ARGON2_T_COST") {
-            self.hashing.argon2_t_cost = v;
-        }
-        if let Some(v) = t_u32(&mut table, "hashing", "argon2_p_cost", "ARGON2_P_COST") {
-            self.hashing.argon2_p_cost = v;
-        }
-
-        if let Some(v) = t_u32(
+        // Parse the hashing values into locals so the effective values can be resolved
+        // with the precedence: explicit user value > named preset > built-in default.
+        let m_cost = t_u32(&mut table, "hashing", "argon2_m_cost", "ARGON2_M_COST");
+        let t_cost = t_u32(&mut table, "hashing", "argon2_t_cost", "ARGON2_T_COST");
+        let p_cost = t_u32(&mut table, "hashing", "argon2_p_cost", "ARGON2_P_COST");
+        let max_threads = t_u32(
             &mut table,
             "hashing",
             "max_hash_threads",
             "MAX_HASH_THREADS",
-        ) {
-            self.hashing.max_hash_threads = v;
-        }
+        );
         if let Some(v) = t_u32(
             &mut table,
             "hashing",
@@ -2648,6 +2661,32 @@ impl Vars {
         ) {
             self.hashing.hash_await_warn_time = v;
         }
+
+        let preset = match t_str(&mut table, "hashing", "argon2_preset", "ARGON2_PRESET") {
+            Some(v) => Some(Argon2Preset::from(v.as_str())),
+            None => self.hashing.argon2_preset,
+        };
+        self.hashing.argon2_preset = preset;
+
+        // A preset provides the intended defaults for m / t / p / threads, but each value can
+        // still be overridden individually by the user. Without a preset, the built-in
+        // defaults apply.
+        let defaults = self
+            .hashing
+            .argon2_preset
+            .map(Argon2Preset::params)
+            .unwrap_or((
+                self.hashing.argon2_m_cost,
+                self.hashing.argon2_t_cost,
+                self.hashing.argon2_p_cost,
+                self.hashing.max_hash_threads,
+            ));
+        let (m, t, p, threads) =
+            resolve_hashing_values(m_cost, t_cost, p_cost, max_threads, defaults);
+        self.hashing.argon2_m_cost = m;
+        self.hashing.argon2_t_cost = t;
+        self.hashing.argon2_p_cost = p;
+        self.hashing.max_hash_threads = threads;
 
         check_table_empty(table, "hashing");
     }
@@ -3928,6 +3967,66 @@ pub struct ConfigVarsGeo {
     pub maxmind_update_cron: Cow<'static, str>,
 }
 
+/// Named Argon2id hashing presets, selectable at startup via `hashing.argon2_preset`
+/// (config file) or `ARGON2_PRESET` (env var). When set, the preset overrides the explicit
+/// `argon2_m_cost` / `argon2_t_cost` / `argon2_p_cost` / `max_hash_threads` values.
+/// Measured on Apple Silicon (release, argon2 0.5.3) vs the original main default
+/// (single hash 275 ms / 130 MiB peak):
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Argon2Preset {
+    /// OWASP low-memory profile (m=64 MiB, t=3), 2 workers: 94 ms/hash (2.8x faster,
+    /// 51% memory); 8 concurrent logins in 382 ms (5.6x) at ~100% peak memory.
+    Speed,
+    /// Same crypto profile as `Speed`, 1 worker: 94 ms/hash; peak memory stays at 51%
+    /// of the original default (best for memory-constrained deployments).
+    Memory,
+    /// Original strongest profile (m=128 MiB, t=4), 2 workers: 269 ms/hash (100% time);
+    /// 8 concurrent logins in 1076 ms (2x) at ~199% peak memory.
+    Hardened,
+}
+
+impl Argon2Preset {
+    /// Returns `(argon2_m_cost, argon2_t_cost, argon2_p_cost, max_hash_threads)`.
+    pub const fn params(self) -> (u32, u32, u32, u32) {
+        match self {
+            Self::Speed => (65536, 3, 1, 2),
+            Self::Memory => (65536, 3, 1, 1),
+            Self::Hardened => (131072, 4, 1, 2),
+        }
+    }
+}
+
+impl From<&str> for Argon2Preset {
+    fn from(value: &str) -> Self {
+        match value {
+            "speed" => Self::Speed,
+            "memory" => Self::Memory,
+            "hardened" => Self::Hardened,
+            other => {
+                warn!("Unknown argon2_preset '{other}', defaulting to 'speed'");
+                Self::Speed
+            }
+        }
+    }
+}
+
+/// Resolves the effective argon2 hashing values from an explicit user override, a named
+/// preset and the built-in defaults. Precedence: explicit value > preset > default.
+fn resolve_hashing_values(
+    m: Option<u32>,
+    t: Option<u32>,
+    p: Option<u32>,
+    threads: Option<u32>,
+    dflt: (u32, u32, u32, u32),
+) -> (u32, u32, u32, u32) {
+    (
+        m.unwrap_or(dflt.0),
+        t.unwrap_or(dflt.1),
+        p.unwrap_or(dflt.2),
+        threads.unwrap_or(dflt.3),
+    )
+}
+
 #[derive(Debug)]
 pub struct VarsHashing {
     pub argon2_m_cost: u32,
@@ -3935,6 +4034,7 @@ pub struct VarsHashing {
     pub argon2_p_cost: u32,
     pub max_hash_threads: u32,
     pub hash_await_warn_time: u32,
+    pub argon2_preset: Option<Argon2Preset>,
 }
 
 #[derive(Debug)]
@@ -4331,4 +4431,55 @@ fn err_env(var_name: &str, typ: &str) -> String {
 pub fn err_t(key: &str, parent: &str, typ: &str) -> String {
     let sep = if parent.is_empty() { "" } else { "." };
     format!("Expected type `{typ}` for {parent}{sep}{key}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_argon2_preset_mapping() {
+        assert_eq!(Argon2Preset::from("speed"), Argon2Preset::Speed);
+        assert_eq!(Argon2Preset::from("memory"), Argon2Preset::Memory);
+        assert_eq!(Argon2Preset::from("hardened"), Argon2Preset::Hardened);
+        // unknown values fall back to the default preset
+        assert_eq!(Argon2Preset::from("bogus"), Argon2Preset::Speed);
+    }
+
+    #[test]
+    fn test_argon2_preset_params() {
+        assert_eq!(Argon2Preset::Speed.params(), (65536, 3, 1, 2));
+        assert_eq!(Argon2Preset::Memory.params(), (65536, 3, 1, 1));
+        assert_eq!(Argon2Preset::Hardened.params(), (131072, 4, 1, 2));
+    }
+
+    #[test]
+    fn test_resolve_hashing_values_precedence() {
+        // explicit user value wins over the preset
+        assert_eq!(
+            resolve_hashing_values(Some(131072), None, None, None, Argon2Preset::Speed.params()),
+            (131072, 3, 1, 2)
+        );
+        // preset provides the defaults
+        assert_eq!(
+            resolve_hashing_values(None, None, None, None, Argon2Preset::Memory.params()),
+            (65536, 3, 1, 1)
+        );
+        // neither preset nor explicit -> built-in defaults
+        assert_eq!(
+            resolve_hashing_values(None, None, None, None, (65536, 3, 1, 2)),
+            (65536, 3, 1, 2)
+        );
+        // mixed: one explicit override, the rest from the preset
+        assert_eq!(
+            resolve_hashing_values(
+                None,
+                Some(2),
+                None,
+                Some(4),
+                Argon2Preset::Hardened.params()
+            ),
+            (131072, 2, 1, 4)
+        );
+    }
 }

--- a/src/error/Cargo.toml
+++ b/src/error/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 actix-multipart = { workspace = true }
 actix-web = { workspace = true }
-argon2 = { workspace = true }
+argon2-rust = { workspace = true }
 chacha20poly1305 = { workspace = true }
 chrono = { workspace = true }
 css-color = { workspace = true }

--- a/src/error/src/error_impls.rs
+++ b/src/error/src/error_impls.rs
@@ -182,9 +182,9 @@ impl From<actix_web::error::HttpError> for ErrorResponse {
     }
 }
 
-impl From<argon2::Error> for ErrorResponse {
-    fn from(err: argon2::Error) -> Self {
-        debug!("argon2::Error: {err:?}");
+impl From<argon2_rust::Error> for ErrorResponse {
+    fn from(err: argon2_rust::Error) -> Self {
+        debug!("argon2_rust::Error: {err:?}");
         ErrorResponse::new(
             ErrorResponseType::Internal,
             format!("Argon2Id Error: {err}"),


### PR DESCRIPTION
## Summary

Same Argon2id cost as the old default, 11-36x faster per hash.
Each preset also has a hardening factor vs the [OWASP Argon2id minimum](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id) (19 MiB / t=2) = total work m x t - a hardening factor, not a speed one.
- **11x speed, ~13.5x OWASP floor = `hardened`** - same m=128 MiB / t=4 security as main, ~25 ms vs 280 ms, 1x-2x memory.
- **36x speed, ~5x OWASP floor = `memory`** - m=64 MiB / t=3, ~9 ms, 0.5x memory (default preset).

Minimums (1 vCPU, lanes clamped): speed ~4.5x, hardened ~1.5x - the 11-36x headline is the 8-vCPU case, see the k8s table for every size. A config knob (`argon2_preset`) switches speed / memory / hardened; every value stays overridable.

## What changed

1. **Concurrent argon2 workers** - one per configured `max_hash_threads`; the bounded channel caps in-flight memory at `threads x m`.
2. **Default memory preset**; OWASP-endorsed, 3.4× the OWASP minimum - the [OWASP-low profile](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id) (m=64 MiB / t=3), 1 in-flight (like main), 0.5x memory (existing hashes re-hash on next login).
3. **`argon2_preset` selector** - `speed | memory | hardened`; every field still overridable (explicit > preset > default).
4. **SIMD argon2-rust backend** (AVX-512/AVX2/SSE2/NEON) - lanes parallelize across cores, p=8 (best measured, clamped to host cores); same PHC format, verify path and memory; `is_argon2_uptodate` uses the crate's `decode_phc`.
5. **Real client IP resolved once per request** (`req.extensions()` cache).
6. **Bounded event pipeline** - channels + semaphore + non-blocking sends; saturated -> drop with a warning, never stall or grow unbounded.
7. **Bounded login-location checks** - per-login geo/notify capped; saturated -> skip.

## Config

```toml
[hashing]
argon2_preset = "memory"  # speed, hardened. default: memory
# argon2_p_cost = 1   # ~4.5x vs main, 1 core - CPU-minimal
# argon2_p_cost = 4   # ~19x  vs main, 4 cores (OWASP standard)
# argon2_p_cost = 8   # ~36x  vs main, up to 8 cores - auto-clamped (default for all presets)
```

## Presets (vs main: 280 ms/hash, 130 MiB)

m = memory (MiB), t = time cost, p = lanes (parallelism within one hash), threads = concurrent hashes (in-flight).

| scenario | config | in-flight | lanes/hash | speed vs main | peak mem | mem vs main |
|---|---|---|---|---|---|---|
| main (old scalar) | 128 / 4 | 1 | 1 | 1x | 130 MiB | 1x |
| hardened, `threads=1` | 128 / 4 / 8 / 1 | 1 | up to 8 | ~11x | 130 MiB | 1x |
| hardened (preset) | 128 / 4 / 8 / 2 | 2 | up to 8 | ~11x | 258.5 MiB | 2x peak |
| speed (preset) | 64 / 3 / 8 / 2 | 2 | up to 8 | ~36x | 130.5 MiB | 1x |
| memory (default) | 64 / 3 / 8 / 1 | 1 | up to 8 | ~36x | 66.2 MiB | 0.5x |

Security margin vs the [OWASP Argon2id minimum](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id) (19 MiB / t=2) - hardening factors, not speed:

| preset | m / t | total work (m x t) | vs OWASP floor | speed vs main |
|---|---|---|---|---|
| OWASP minimum | 19 / 2 | 38 MiB-passes | 1x | ~175x (p=8) |
| `speed` | 64 / 3 | 192 MiB-passes | ~5x | ~36x |
| `memory` (default) | 64 / 3 | 192 MiB-passes | ~5x | ~36x |
| `hardened` | 128 / 4 | 512 MiB-passes | ~13.5x | ~11x |
| main (old default) | 128 / 4 | 512 MiB-passes | ~13.5x | 1x |

OWASP min at the official p=1 is ~28x; at p=8 (same lanes as the presets) ~175x - it is the fastest because it does ~7x less work than main, which is exactly why it is the minimum.

**The one number:** `hardened` + `max_hash_threads = 1` = same security, same memory, ~11x faster single-login.

## k8s per node

| preset | 1 vCPU | 2 vCPU | 4 vCPU | 8 vCPU |
|---|---|---|---|---|
| `speed` | 100m/1 256/512 · 4.5x | 100m/2 256/512 · 9.5x | 100m/4 256/512 · 19x | 100m/8 256/512 · 36x |
| `memory` | 100m/1 192/384 · 4.5x | 100m/2 192/384 · 9.5x | 100m/4 192/384 · 19x | 100m/8 192/384 · 36x |
| `hardened` | 100m/1 384/768 · 1.5x | 100m/2 384/768 · 3x | 100m/4 384/768 · 6x | 100m/8 384/768 · ~9x |

Cells: CPU req/lim · MEM req/lim (MiB) · speed vs main. CPU lim = `threads x min(p, cores)`, capped at host.
Request = guarantee, limit = cap: on a busy node you only get the cores you requested - request the speed you want to keep.

## Resource model

- **Security = m + t** (memory per hash + time cost) - fixed per preset; **p does not change them** (lanes share the same m budget).
- **Memory = threads x m** (in-flight hashes x per-hash m): 130.5 / 66.2 / 258.5 MiB peak.
- **CPU = threads x min(p, host cores)** at peak. Each in-flight hash spawns p lane threads (always); free cores decide the per-hash speed (idle vs busy).
- **Latency** = per-hash; `threads` never changes it, p and free cores do.
- `threads=1` = serialized logins like main (1 in-flight, 1x memory) but still ~11x per hash; `p=1` additionally serializes each hash (main's exact profile, CPU-minimal) - a CPU choice, not a security one.

## Verification

`cargo fmt --check` clean; `cargo clippy -- -D warnings` 0; `cargo test --workspace --lib` 90 passed / 0 failed (host) and 79 passed / 0 failed on Linux aarch64 (Colima). Pipeline benchmark wired into CI (criterion, baseline-gated).

Developed with carefully directed, manually reviewed AI assistance.