### PR TITLE
fix(data): clean the cache WAL on minor upgrades and bump to 0.37.0-nightly.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-web",
  "actix-web-prom",
@@ -4986,6 +4986,7 @@ dependencies = [
  "rpassword",
  "rustls",
  "s3-simple",
+ "semver",
  "serde",
  "serde_json",
  "spow",
@@ -5002,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-api-types"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-web",
  "hiqlite",
@@ -5022,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-common"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-web",
  "ammonia",
@@ -5053,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-data"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "accept-language",
  "actix-multipart",
@@ -5139,7 +5140,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-derive"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5148,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-error"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -5185,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-handlers"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -5222,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-jwt"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "chrono",
  "openssl",
@@ -5239,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-middlewares"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-web",
  "chrono",
@@ -5255,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-notify"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "async-trait",
  "openssl",
@@ -5271,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-schedulers"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-web",
  "chrono",
@@ -5290,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-service"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "actix-web",
  "atrium-api",
@@ -5318,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-wasm-modules"
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 dependencies = [
  "ammonia",
  "console_error_panic_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-web",
  "actix-web-prom",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-api-types"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-web",
  "hiqlite",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-common"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-web",
  "ammonia",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-data"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "accept-language",
  "actix-multipart",
@@ -5140,7 +5140,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-derive"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-error"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-handlers"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-multipart",
  "actix-web",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-jwt"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "chrono",
  "openssl",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-middlewares"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-web",
  "chrono",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-notify"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "async-trait",
  "openssl",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-schedulers"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-web",
  "chrono",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-service"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "actix-web",
  "atrium-api",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "rauthy-wasm-modules"
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 dependencies = [
  "ammonia",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["src/*"]
 exclude = ["rauthy-client"]
 
 [workspace.package]
-version = "0.37.0-nightly.1"
+version = "0.37.0-20260819"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["src/*"]
 exclude = ["rauthy-client"]
 
 [workspace.package]
-version = "0.36.2"
+version = "0.37.0-nightly.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org>"]

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -39,6 +39,7 @@ reqwest = { workspace = true }
 rpassword = { workspace = true }
 rustls = { workspace = true }
 s3-simple = { workspace = true }
+semver = { workspace = true }
 serde_json = { workspace = true }
 spow = { workspace = true }
 time = { workspace = true }

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -97,6 +97,7 @@ pub async fn run(
 
     let cache_data_dir = node_config.data_dir.to_string();
     let cache_storage_disk = node_config.cache_storage_disk;
+    // TODO remove this cache-WAL compatibility cleanup in the next minor version.
     rauthy_data::temp_migrations::prepare_cache_wal(&cache_data_dir, cache_storage_disk)
         .await
         .map_err(|err| std::io::Error::other(err.to_string()))?;

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -95,6 +95,12 @@ pub async fn run(
     // init BEFORE Hiqlite to avoid issues in case of misconfiguration
     rauthy_data::ipgeo::init_geo().await;
 
+    let cache_data_dir = node_config.data_dir.to_string();
+    let cache_storage_disk = node_config.cache_storage_disk;
+    rauthy_data::temp_migrations::prepare_cache_wal(&cache_data_dir, cache_storage_disk)
+        .await
+        .map_err(|err| std::io::Error::other(err.to_string()))?;
+
     DB::init(node_config)
         .await
         .expect("Error starting the database / cache layer");
@@ -127,6 +133,10 @@ pub async fn run(
         error!("Error during version migration: {err:?}");
         time::sleep(Duration::from_secs(1)).await;
     }
+
+    rauthy_data::temp_migrations::mark_cache_wal_current(&cache_data_dir, cache_storage_disk)
+        .await
+        .map_err(|err| std::io::Error::other(err.to_string()))?;
 
     UserPicture::test_config().await.unwrap();
 

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -107,7 +107,7 @@ pub async fn run(
     tokio::spawn(password_hasher::run());
 
     debug!("Applying database migrations");
-    DB::migrate().await.expect("Database migration error");
+    let previous_db_version = DB::migrate().await.expect("Database migration error");
 
     debug!("Starting Events handler");
     EventNotifier::init_notifiers(tx_email).await.unwrap();
@@ -121,7 +121,9 @@ pub async fn run(
     tokio::spawn(watch_health());
 
     // Loop, because you could get into a race condition when recovery a HA Leader after lost volume
-    while let Err(err) = version_migration::manual_version_migrations().await {
+    while let Err(err) =
+        version_migration::manual_version_migrations(previous_db_version.clone()).await
+    {
         error!("Error during version migration: {err:?}");
         time::sleep(Duration::from_secs(1)).await;
     }

--- a/src/bin/src/version_migration.rs
+++ b/src/bin/src/version_migration.rs
@@ -2,12 +2,7 @@ use rauthy_data::rauthy_config::RauthyConfig;
 use rauthy_error::ErrorResponse;
 use semver::Version;
 
-/// If it's necessary to apply manual migrations between major versions, which are
-/// not handled automatically by database migrations, put them here. This function
-/// will be executed at startup after DB init and before the API start.
-///
-/// `previous_db_version` is the version the database was created / last upgraded
-/// to, captured by `DB::migrate()` before it applied this upgrade.
+/// Runs upgrade-only work after database migrations.
 pub async fn manual_version_migrations(
     previous_db_version: Option<Version>,
 ) -> Result<(), ErrorResponse> {

--- a/src/bin/src/version_migration.rs
+++ b/src/bin/src/version_migration.rs
@@ -1,16 +1,22 @@
 use rauthy_data::rauthy_config::RauthyConfig;
 use rauthy_error::ErrorResponse;
+use semver::Version;
 
 /// If it's necessary to apply manual migrations between major versions, which are
 /// not handled automatically by database migrations, put them here. This function
 /// will be executed at startup after DB init and before the API start.
-pub async fn manual_version_migrations() -> Result<(), ErrorResponse> {
+///
+/// `previous_db_version` is the version the database was created / last upgraded
+/// to, captured by `DB::migrate()` before it applied this upgrade.
+pub async fn manual_version_migrations(
+    previous_db_version: Option<Version>,
+) -> Result<(), ErrorResponse> {
     // to avoid race conditions, only node 1 should do these one-time migrations
     if !RauthyConfig::get().is_primary_node {
         return Ok(());
     }
 
-    rauthy_data::temp_migrations::apply_temp_migrations().await?;
+    rauthy_data::temp_migrations::apply_temp_migrations(previous_db_version).await?;
 
     Ok(())
 }

--- a/src/bin/tests/common.rs
+++ b/src/bin/tests/common.rs
@@ -52,7 +52,7 @@ pub fn get_backend_url() -> String {
 
 #[allow(dead_code)]
 pub fn get_issuer() -> String {
-    format!("{}", get_backend_url())
+    get_backend_url()
 }
 
 pub async fn get_token_set() -> TokenSet {
@@ -220,7 +220,7 @@ pub async fn cookie_csrf_headers_from_res_direct(
     let (session_cookie, _) = cookie.to_str()?.split_once(';').unwrap();
 
     let mut headers = HeaderMap::new();
-    headers.append(header::COOKIE, HeaderValue::from_str(&session_cookie)?);
+    headers.append(header::COOKIE, HeaderValue::from_str(session_cookie)?);
 
     let session_info = res.json::<SessionInfoResponse>().await.unwrap();
     headers.append(
@@ -238,7 +238,7 @@ pub async fn cookie_csrf_headers_from_res(res: Response) -> Result<HeaderMap, Bo
         if cookie.starts_with("__Host-RauthySession=") {
             println!("Extracted session cookie: {:?}", cookie);
             let mut headers = HeaderMap::new();
-            headers.append(header::COOKIE, HeaderValue::from_str(&cookie)?);
+            headers.append(header::COOKIE, HeaderValue::from_str(cookie)?);
 
             let content = res.text().await?;
             let (_, content_split) = content

--- a/src/bin/tests/handler_auth.rs
+++ b/src/bin/tests/handler_auth.rs
@@ -169,7 +169,7 @@ async fn test_authorization_code_flow() -> Result<(), Box<dyn Error>> {
         .await?;
     res = check_status(res, 200).await?;
     let ts = res.json::<TokenSet>().await?;
-    assert!(ts.access_token.len() > 0);
+    assert!(!ts.access_token.is_empty());
     assert!(ts.id_token.is_some());
     assert!(ts.refresh_token.is_some());
     assert_eq!(ts.expires_in, 60);
@@ -243,7 +243,7 @@ async fn test_authorization_code_flow() -> Result<(), Box<dyn Error>> {
     res = check_status(res, 200).await?;
 
     let ts = res.json::<TokenSet>().await?;
-    assert!(ts.access_token.len() > 0);
+    assert!(!ts.access_token.is_empty());
     assert!(ts.id_token.is_some());
     assert!(ts.refresh_token.is_some());
     assert_eq!(ts.expires_in, 60);
@@ -340,7 +340,7 @@ async fn test_authorization_code_flow() -> Result<(), Box<dyn Error>> {
     res = check_status(res, 200).await?;
 
     let ts = res.json::<TokenSet>().await?;
-    assert!(ts.access_token.len() > 0);
+    assert!(!ts.access_token.is_empty());
     assert!(ts.id_token.is_some());
     assert!(ts.refresh_token.is_some());
     assert_eq!(ts.expires_in, 60);
@@ -378,7 +378,7 @@ async fn test_client_credentials_flow() -> Result<(), Box<dyn Error>> {
     res = check_status(res, 200).await?;
 
     let ts = res.json::<TokenSet>().await?;
-    assert!(ts.access_token.len() > 0);
+    assert!(!ts.access_token.is_empty());
     assert_eq!(ts.token_type, JwtTokenType::Bearer);
     assert_eq!(ts.expires_in, 60);
     // important: no id token for client_credentials and not refresh token
@@ -518,11 +518,11 @@ async fn test_password_flow() -> Result<(), Box<dyn Error>> {
     res = check_status(res, 200).await?;
 
     let ts = res.json::<TokenSet>().await?;
-    assert!(ts.access_token.len() > 0);
+    assert!(!ts.access_token.is_empty());
     assert!(ts.id_token.is_some());
-    assert!(ts.id_token.as_ref().unwrap().len() > 0);
+    assert!(!ts.id_token.as_ref().unwrap().is_empty());
     assert!(ts.refresh_token.is_some());
-    assert!(ts.refresh_token.as_ref().unwrap().len() > 0);
+    assert!(!ts.refresh_token.as_ref().unwrap().is_empty());
     // test token is valid for only 60 seconds to make the refresh token valid immediately
     assert_eq!(ts.expires_in, 60);
 
@@ -550,11 +550,11 @@ async fn test_password_flow() -> Result<(), Box<dyn Error>> {
     let res = reqwest::Client::new().post(&url).form(&req).send().await?;
     assert_eq!(res.status(), 200);
     let new_ts = res.json::<TokenSet>().await?;
-    assert!(new_ts.access_token.len() > 0);
+    assert!(!new_ts.access_token.is_empty());
     assert!(new_ts.id_token.is_some());
-    assert!(new_ts.id_token.as_ref().unwrap().len() > 0);
+    assert!(!new_ts.id_token.as_ref().unwrap().is_empty());
     assert!(new_ts.refresh_token.is_some());
-    assert!(new_ts.refresh_token.as_ref().unwrap().len() > 0);
+    assert!(!new_ts.refresh_token.as_ref().unwrap().is_empty());
     assert_eq!(new_ts.expires_in, 60);
 
     assert_ne!(ts.refresh_token, new_ts.refresh_token);
@@ -795,7 +795,7 @@ async fn test_auth_code_flow_ephemeral_client() -> Result<(), Box<dyn Error>> {
     assert!(res.status().is_success());
 
     let ts = res.json::<TokenSet>().await?;
-    assert!(ts.access_token.len() > 0);
+    assert!(!ts.access_token.is_empty());
     assert!(ts.id_token.is_some());
     assert!(ts.refresh_token.is_some());
     assert_eq!(ts.expires_in, 60);
@@ -812,7 +812,7 @@ async fn test_auth_code_flow_ephemeral_client() -> Result<(), Box<dyn Error>> {
     assert!(res.status().is_success());
 
     let new_ts = res.json::<TokenSet>().await?;
-    assert!(ts.access_token.len() > 0);
+    assert!(!ts.access_token.is_empty());
     assert!(new_ts.id_token.is_some());
     assert!(new_ts.refresh_token.is_some());
 
@@ -1065,7 +1065,7 @@ async fn test_token_revocation() -> Result<(), Box<dyn Error>> {
 
     // make sure it works for the userinfo in the same way
     let res = reqwest::Client::new()
-        .get(&format!("{}/oidc/userinfo", get_backend_url()))
+        .get(format!("{}/oidc/userinfo", get_backend_url()))
         .header(AUTHORIZATION, format!("Bearer {}", ts.access_token))
         .send()
         .await?;
@@ -1165,7 +1165,7 @@ async fn validate_token(
 
 async fn validate_token_request(token: String) -> Result<reqwest::Response, Box<dyn Error>> {
     let res = reqwest::Client::new()
-        .post(&format!("{}/oidc/introspect", get_backend_url()))
+        .post(format!("{}/oidc/introspect", get_backend_url()))
         .header(AUTHORIZATION, format!("Bearer {}", token))
         .form(&TokenValidationRequest { token })
         .send()

--- a/src/bin/tests/handler_pwd_reset.rs
+++ b/src/bin/tests/handler_pwd_reset.rs
@@ -55,8 +55,8 @@ async fn test_get_pwd_reset_form() -> Result<(), Box<dyn Error>> {
     println!("Extracted pwd_reset_cookie: {:?}", cookie);
     let mut correct_headers = HeaderMap::new();
     let mut cookie_only_headers = HeaderMap::new();
-    correct_headers.append(header::COOKIE, HeaderValue::from_str(&cookie)?);
-    cookie_only_headers.append(header::COOKIE, HeaderValue::from_str(&cookie)?);
+    correct_headers.append(header::COOKIE, HeaderValue::from_str(cookie)?);
+    cookie_only_headers.append(header::COOKIE, HeaderValue::from_str(cookie)?);
     println!("Headers with cookie: {:?}", correct_headers);
 
     // check that we got the html document

--- a/src/bin/tests/handler_users.rs
+++ b/src/bin/tests/handler_users.rs
@@ -199,7 +199,7 @@ async fn test_user_picture() -> Result<(), Box<dyn Error>> {
 
     // find our test user
     let res = client
-        .get(&format!("{}/users", get_backend_url()))
+        .get(format!("{}/users", get_backend_url()))
         .headers(auth_headers.clone())
         .send()
         .await?;
@@ -267,7 +267,7 @@ async fn test_user_picture() -> Result<(), Box<dyn Error>> {
         }],
     };
     let res = client
-        .post(&format!("{}/api_keys", get_backend_url()))
+        .post(format!("{}/api_keys", get_backend_url()))
         .headers(auth_headers.clone())
         .json(&payload)
         .send()

--- a/src/bin/tests/zza_handler_cust_attrs.rs
+++ b/src/bin/tests/zza_handler_cust_attrs.rs
@@ -1,6 +1,5 @@
 use crate::common::{get_auth_headers, get_backend_url, get_token_set};
 use rauthy_api_types::clients::{ClientResponse, UpdateClientRequest};
-use rauthy_api_types::oidc::JwkKeyPairAlg;
 use rauthy_api_types::scopes::{ScopeRequest, ScopeResponse};
 use rauthy_api_types::users::{
     UserAttrConfigRequest, UserAttrConfigResponse, UserAttrValueRequest, UserAttrValuesResponse,
@@ -119,8 +118,8 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         allowed_origins: c.allowed_origins,
         enabled: c.enabled,
         flows_enabled: c.flows_enabled,
-        access_token_alg: JwkKeyPairAlg::from(c.access_token_alg),
-        id_token_alg: JwkKeyPairAlg::from(c.id_token_alg),
+        access_token_alg: c.access_token_alg,
+        id_token_alg: c.id_token_alg,
         auth_code_lifetime: c.auth_code_lifetime,
         access_token_lifetime: c.access_token_lifetime,
         scopes,
@@ -168,7 +167,7 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
     assert_eq!(res.status(), 200);
     let resp = res.json::<UserAttrValuesResponse>().await?;
     assert_eq!(resp.values.len(), 1);
-    let user_attr = resp.values.get(0).unwrap();
+    let user_attr = resp.values.first().unwrap();
     assert_eq!(user_attr.key, cust_attr.name);
     assert_eq!(user_attr.value, test_val);
 
@@ -275,7 +274,7 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         .filter(|s| s.id == scope.id)
         .take(1)
         .collect::<Vec<ScopeResponse>>();
-    let scope_mapped = scopes_reduced.get(0).unwrap();
+    let scope_mapped = scopes_reduced.first().unwrap();
     assert_eq!(
         scope_mapped.attr_include_access,
         Some(vec!["cust2".to_string()])
@@ -294,7 +293,7 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
     assert_eq!(res.status(), 200);
     let resp = res.json::<UserAttrValuesResponse>().await?;
     assert_eq!(resp.values.len(), 1);
-    let user_attr_mod = resp.values.get(0).unwrap();
+    let user_attr_mod = resp.values.first().unwrap();
     assert_eq!(&user_attr_mod.key, "cust2");
     // the value must be the same
     assert_eq!(user_attr_mod.value, user_attr.value);
@@ -333,7 +332,7 @@ async fn test_cust_attrs() -> Result<(), Box<dyn Error>> {
         .filter(|s| s.id == scope.id)
         .take(1)
         .collect::<Vec<ScopeResponse>>();
-    let scope_mapped = scopes_reduced.get(0).unwrap();
+    let scope_mapped = scopes_reduced.first().unwrap();
     assert_eq!(scope_mapped.attr_include_access, None);
     assert_eq!(scope_mapped.attr_include_id, None);
 

--- a/src/bin/tests/zzc_backchannel_logout.rs
+++ b/src/bin/tests/zzc_backchannel_logout.rs
@@ -53,7 +53,7 @@ async fn test_backchannel_logout() -> Result<(), Box<dyn Error>> {
     let now = Utc::now().timestamp();
     assert!(token.iat <= now);
     assert!(token.exp > now);
-    pretty_assertions::assert_eq!(token.sub.as_deref(), Some("m4PJ3TnyP32LA8hzY23deme3"));
+    pretty_assertions::assert_eq!(token.sub, Some("m4PJ3TnyP32LA8hzY23deme3"));
     // Usually, the `sid` would be given, but we did as `password` flow login here, which cannot
     // be linked to a session.
     assert!(token.sid.is_none());

--- a/src/bin/tests/zzd_handler_clients.rs
+++ b/src/bin/tests/zzd_handler_clients.rs
@@ -166,11 +166,11 @@ async fn test_clients() -> Result<(), Box<dyn Error>> {
     assert_eq!(client.allowed_origins, None);
     // authorization_code should be the only default flow since it is secure
     assert_eq!(
-        client.flows_enabled.get(0).unwrap(),
+        client.flows_enabled.first().unwrap(),
         &GrantType::AuthorizationCode
     );
     // S256 code challenge by default for better security
-    assert_eq!(client.challenges.as_ref().unwrap().get(0).unwrap(), "S256");
+    assert_eq!(client.challenges.as_ref().unwrap().first().unwrap(), "S256");
 
     // a URL-shaped id must be rejected for manually managed (non-ephemeral) clients:
     // these are restricted to `RE_CLIENT_ID_STRICT`, only ephemeral clients may use a URI id.

--- a/src/data/src/database.rs
+++ b/src/data/src/database.rs
@@ -224,10 +224,7 @@ impl DB {
         Ok(())
     }
 
-    /// Applies the SQL migrations and updates the stored DB version.
-    ///
-    /// Returns the DB version from *before* this upgrade (or `None` for a fresh
-    /// install) — temp migrations use it to run upgrade-only cleanups.
+    /// Applies migrations and returns the pre-migration DB version.
     pub async fn migrate() -> Result<Option<Version>, ErrorResponse> {
         // before we do any db migrations, we need to check the current DB version
         // for compatibility

--- a/src/data/src/database.rs
+++ b/src/data/src/database.rs
@@ -8,6 +8,7 @@ use rauthy_common::{is_hiqlite, is_postgres};
 use rauthy_error::ErrorResponse;
 use rustls::pki_types::CertificateDer;
 use rustls::pki_types::pem::PemObject;
+use semver::Version;
 use std::env;
 use std::ops::DerefMut;
 use std::sync::{Arc, OnceLock};
@@ -223,7 +224,11 @@ impl DB {
         Ok(())
     }
 
-    pub async fn migrate() -> Result<(), ErrorResponse> {
+    /// Applies the SQL migrations and updates the stored DB version.
+    ///
+    /// Returns the DB version from *before* this upgrade (or `None` for a fresh
+    /// install) — temp migrations use it to run upgrade-only cleanups.
+    pub async fn migrate() -> Result<Option<Version>, ErrorResponse> {
         // before we do any db migrations, we need to check the current DB version
         // for compatibility
         let db_version = DbVersion::check_app_version().await?;
@@ -295,9 +300,9 @@ impl DB {
         }
 
         // update the DbVersion after successful pool creation and migrations
-        DbVersion::upsert(db_version).await?;
+        DbVersion::upsert(db_version.clone()).await?;
 
-        Ok(())
+        Ok(db_version)
     }
 }
 

--- a/src/data/src/entity/auth_providers.rs
+++ b/src/data/src/entity/auth_providers.rs
@@ -1483,7 +1483,7 @@ mod tests {
 
         let path = JsonPath::parse("$.foo.bar[*]").unwrap();
         let nodes = path.query(&value).all();
-        assert_eq!(nodes.get(0).unwrap().as_str(), Some("baz"));
+        assert_eq!(nodes.first().unwrap().as_str(), Some("baz"));
         assert_eq!(nodes.get(1).unwrap().as_str(), Some("bop"));
         assert_eq!(
             nodes.get(2).unwrap().as_number(),
@@ -1503,7 +1503,7 @@ mod tests {
         let path = JsonPath::parse("$.foo.bor").unwrap();
         let nodes = path.query(&value).all();
         assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes.get(0).unwrap().as_str(), Some("yes"));
+        assert_eq!(nodes.first().unwrap().as_str(), Some("yes"));
 
         // we cannot query for single values with the wildcard in the end
         // -> add 2 possible cases in the checking code for best UX
@@ -1515,7 +1515,7 @@ mod tests {
         let path = JsonPath::parse("$.*.bor").unwrap();
         let nodes = path.query(&value).all();
         assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes.get(0).unwrap().as_str(), Some("yes"));
+        assert_eq!(nodes.first().unwrap().as_str(), Some("yes"));
     }
 
     #[test]

--- a/src/data/src/entity/clients.rs
+++ b/src/data/src/entity/clients.rs
@@ -2270,9 +2270,11 @@ mod tests {
 
     #[test]
     fn test_delete_client_custom_scope() {
-        let mut client = Client::default();
-        client.scopes = "email,openid,profile,groups".to_string();
-        client.default_scopes = "email,openid,cust_scope".to_string();
+        let mut client = Client {
+            scopes: "email,openid,profile,groups".to_string(),
+            default_scopes: "email,openid,cust_scope".to_string(),
+            ..Default::default()
+        };
 
         client.delete_scope("profile");
         assert_eq!(&client.scopes, "email,openid,groups");

--- a/src/data/src/entity/db_version.rs
+++ b/src/data/src/entity/db_version.rs
@@ -10,9 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::{debug, warn};
 
-// TODO After bumping to v0.37, make sure the lowest compatible is set to v0.36
-//  and `apply_temp_migrations()` was cleaned up!
-static LOWEST_COMPATIBLE_VERSION: &str = "0.35.0";
+static LOWEST_COMPATIBLE_VERSION: &str = "0.36.0";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DbVersion {
@@ -98,9 +96,7 @@ ON CONFLICT(id) DO UPDATE SET data = $1"#;
     ) -> Result<(), ErrorResponse> {
         // this check panics on purpose, and it is there to never forget to adjust this
         // version check before doing any major or minor release
-        // TODO After bumping to v0.37, make sure the lowest compatible is set to v0.36
-        //  and `apply_temp_migrations()` was cleaned up!
-        if app_version.major != 0 || app_version.minor != 36 {
+        if app_version.major != 0 || app_version.minor != 37 {
             panic!(
                 "\nDbVersion::check_app_version needs adjustment for the new RAUTHY_VERSION: \
                 {RAUTHY_VERSION}\\n Also make sure that `LOWEST_COMPATIBLE_VERSION` is still \

--- a/src/data/src/entity/users.rs
+++ b/src/data/src/entity/users.rs
@@ -2128,7 +2128,7 @@ mod tests {
         // new sessions should always be in state 1 -> initializing
         assert_eq!(session.state, SessionState::Init);
 
-        assert!(session.csrf_token.len() > 0);
+        assert!(!session.csrf_token.is_empty());
 
         assert_eq!(session.groups_as_vec(), Ok(vec!["admin", "user"]));
         assert_eq!(
@@ -2138,13 +2138,13 @@ mod tests {
     }
 
     fn check_password_expired(user: &User) -> Result<(), ErrorResponse> {
-        if let Some(exp) = user.password_expires {
-            if exp < OffsetDateTime::now_utc().unix_timestamp() {
-                return Err(ErrorResponse::new(
-                    ErrorResponseType::PasswordExpired,
-                    String::from("The password has expired"),
-                ));
-            }
+        if let Some(exp) = user.password_expires
+            && exp < OffsetDateTime::now_utc().unix_timestamp()
+        {
+            return Err(ErrorResponse::new(
+                ErrorResponseType::PasswordExpired,
+                String::from("The password has expired"),
+            ));
         }
         Ok(())
     }

--- a/src/data/src/entity/users.rs
+++ b/src/data/src/entity/users.rs
@@ -2139,11 +2139,11 @@ mod tests {
 
     fn check_password_expired(user: &User) -> Result<(), ErrorResponse> {
         if let Some(exp) = user.password_expires
-            && exp < OffsetDateTime::now_utc().unix_timestamp()
+            && exp < Utc::now().timestamp()
         {
             return Err(ErrorResponse::new(
                 ErrorResponseType::PasswordExpired,
-                String::from("The password has expired"),
+                "The password has expired",
             ));
         }
         Ok(())

--- a/src/data/src/migration/bootstrap/api_key.rs
+++ b/src/data/src/migration/bootstrap/api_key.rs
@@ -191,6 +191,21 @@ fn api_key_secret_plain(secret: ApiKeySecret) -> String {
     }
 }
 
+impl From<crate::migration::bootstrap::types::ApiKeyAccess>
+    for crate::entity::api_keys::ApiKeyAccess
+{
+    fn from(value: crate::migration::bootstrap::types::ApiKeyAccess) -> Self {
+        Self {
+            group: value.group.into(),
+            access_rights: value
+                .access_rights
+                .into_iter()
+                .map(|ar| ar.into())
+                .collect(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -250,20 +265,5 @@ mod tests {
         assert!(!err.message.is_empty());
 
         let _ = tokio::fs::remove_file(&path).await;
-    }
-}
-
-impl From<crate::migration::bootstrap::types::ApiKeyAccess>
-    for crate::entity::api_keys::ApiKeyAccess
-{
-    fn from(value: crate::migration::bootstrap::types::ApiKeyAccess) -> Self {
-        Self {
-            group: value.group.into(),
-            access_rights: value
-                .access_rights
-                .into_iter()
-                .map(|ar| ar.into())
-                .collect(),
-        }
     }
 }

--- a/src/data/src/temp_migrations.rs
+++ b/src/data/src/temp_migrations.rs
@@ -1,52 +1,78 @@
-use crate::database::DB;
-use crate::entity::roles::Role;
-use hiqlite::macros::params;
-use rauthy_common::constants::RAUTHY_ADMIN_GROUP_PREFIX;
-use rauthy_common::is_hiqlite;
+use crate::database::{Cache, DB};
+use crate::entity::db_version::DbVersion;
 use rauthy_error::ErrorResponse;
-use tracing::{info, warn};
+use semver::Version;
+use tracing::info;
 
-pub async fn apply_temp_migrations() -> Result<(), ErrorResponse> {
-    // cleanup possibly lingering PAM user groups
-    let sql = r#"
-DELETE FROM pam_groups
-WHERE typ = 'user' AND NOT EXISTS (
-    SELECT 1 FROM pam_users
-    WHERE pam_users.name = pam_groups.name
-)"#;
-    let rows_affected = if is_hiqlite() {
-        DB::hql().execute(sql, params!()).await?
-    } else {
-        DB::pg_execute(sql, &[]).await?
-    };
-    if rows_affected > 0 {
-        info!("Cleaned up {rows_affected} lingering PAM Groups from and older cleanup bug");
+/// Cache namespaces that must not survive a minor upgrade. The hiqlite cache is
+/// persisted in the WAL and restored on restart: single-use claims, per-IP abuse
+/// counters and ephemeral client state written by the previous version would
+/// otherwise linger until the next WAL compaction.
+const CACHE_WAL_CLEANUP: [Cache; 12] = [
+    Cache::AuthCode,
+    Cache::AuthProviderCallback,
+    Cache::ClientDynamic,
+    Cache::ClientEphemeral,
+    Cache::ClientSecret,
+    Cache::CredStuffDetect,
+    Cache::DeviceCode,
+    Cache::DPoPNonce,
+    Cache::EmailRateLimit,
+    Cache::IpBlacklist,
+    Cache::IpRateLimit,
+    Cache::PoW,
+];
+
+/// `previous_db_version` is the version the database was created / last upgraded
+/// to (captured by [`crate::database::DB::migrate`] before the upgrade) and is
+/// `None` on a fresh install.
+pub async fn apply_temp_migrations(
+    previous_db_version: Option<Version>,
+) -> Result<(), ErrorResponse> {
+    if let Some(previous) = previous_db_version {
+        let app = DbVersion::app_version();
+        if needs_cache_wal_cleanup(&previous, &app) {
+            info!("Cleaning up cache WAL entries written by v{previous}");
+            let client = DB::hql();
+            for cache in CACHE_WAL_CLEANUP {
+                client.clear_cache(cache).await?;
+            }
+        }
     }
-
-    warn_existing_group_admin_roles().await?;
 
     Ok(())
 }
 
-/// The delegated group-admin feature reads roles named `rauthy_admin:<prefix>`
-/// as group admins. This is non-breaking unless such a role already existed before the
-/// upgrade, in which case its holders silently gain group-admin rights. We warn about
-/// any matching role on each startup for the whole `v0.36` cycle so operators can spot
-/// an unintended collision; roles created intentionally afterwards can ignore it.
-async fn warn_existing_group_admin_roles() -> Result<(), ErrorResponse> {
-    let found = Role::find_all()
-        .await?
-        .into_iter()
-        .filter(|r| r.name.starts_with(RAUTHY_ADMIN_GROUP_PREFIX))
-        .map(|r| r.name)
-        .collect::<Vec<_>>();
-    if !found.is_empty() {
-        warn!(
-            "Found custom roles matching the delegated group-admin scheme \
-            `rauthy_admin:<prefix>`: {found:?}. Their holders are now group admins for \
-            the matching groups. If you created these intentionally, you \
-            can safely ignore this warning."
-        );
+/// The cache WAL cleanup runs when the stored DB version predates the current
+/// minor release: cache entries from an older minor are stale by definition.
+fn needs_cache_wal_cleanup(previous: &Version, app: &Version) -> bool {
+    previous.major != app.major || previous.minor < app.minor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
     }
-    Ok(())
+
+    #[test]
+    fn cache_wal_cleanup_runs_on_minor_upgrade() {
+        assert!(needs_cache_wal_cleanup(
+            &v("0.36.2"),
+            &v("0.37.0-nightly.1")
+        ));
+        assert!(needs_cache_wal_cleanup(&v("0.36.0"), &v("0.37.0")));
+    }
+
+    #[test]
+    fn cache_wal_cleanup_skips_same_or_newer_minor() {
+        assert!(!needs_cache_wal_cleanup(
+            &v("0.37.0-nightly.1"),
+            &v("0.37.0-nightly.2"),
+        ));
+        assert!(!needs_cache_wal_cleanup(&v("0.37.0"), &v("0.37.0")));
+        assert!(!needs_cache_wal_cleanup(&v("0.37.0"), &v("0.36.2")));
+    }
 }

--- a/src/data/src/temp_migrations.rs
+++ b/src/data/src/temp_migrations.rs
@@ -1,41 +1,42 @@
-use crate::database::{Cache, DB};
 use crate::entity::db_version::DbVersion;
 use rauthy_error::ErrorResponse;
 use semver::Version;
-use tracing::info;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tracing::{info, warn};
 
-/// Cache namespaces that must not survive a minor upgrade. The hiqlite cache is
-/// persisted in the WAL and restored on restart: single-use claims, per-IP abuse
-/// counters and ephemeral client state written by the previous version would
-/// otherwise linger until the next WAL compaction.
-const CACHE_WAL_CLEANUP: [Cache; 12] = [
-    Cache::AuthCode,
-    Cache::AuthProviderCallback,
-    Cache::ClientDynamic,
-    Cache::ClientEphemeral,
-    Cache::ClientSecret,
-    Cache::CredStuffDetect,
-    Cache::DeviceCode,
-    Cache::DPoPNonce,
-    Cache::EmailRateLimit,
-    Cache::IpBlacklist,
-    Cache::IpRateLimit,
-    Cache::PoW,
-];
+const CACHE_WAL_VERSION_FILE: &str = "rauthy-cache-wal-version";
+const CACHE_WAL_DIRS: [&str; 2] = ["logs_cache", "state_machine_cache"];
 
-/// `previous_db_version` is the version the database was created / last upgraded
-/// to (captured by [`crate::database::DB::migrate`] before the upgrade) and is
-/// `None` on a fresh install.
-pub async fn apply_temp_migrations(
-    previous_db_version: Option<Version>,
+/// Removes incompatible cache Raft state before Hiqlite restores it.
+pub async fn prepare_cache_wal(
+    data_dir: &str,
+    cache_storage_disk: bool,
 ) -> Result<(), ErrorResponse> {
-    if let Some(previous) = previous_db_version {
-        let app = DbVersion::app_version();
-        if needs_cache_wal_cleanup(&previous, &app) {
-            info!("Cleaning up cache WAL entries written by v{previous}");
-            let client = DB::hql();
-            for cache in CACHE_WAL_CLEANUP {
-                client.clear_cache(cache).await?;
+    if !cache_storage_disk {
+        return Ok(());
+    }
+
+    let marker = cache_wal_version_path(data_dir);
+    let should_reset = match fs::read_to_string(&marker).await {
+        Ok(version) => Version::parse(version.trim())
+            .map(|previous| needs_cache_wal_cleanup(&previous, &DbVersion::app_version()))
+            .unwrap_or(true),
+        Err(err) if err.kind() == ErrorKind::NotFound => true,
+        Err(err) => return Err(err.into()),
+    };
+
+    if should_reset {
+        warn!(
+            "Resetting cache WAL state; this also removes manual IP blacklist entries and failed-login counters"
+        );
+        for dir in CACHE_WAL_DIRS {
+            let path = Path::new(data_dir).join(dir);
+            match fs::remove_dir_all(path).await {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
             }
         }
     }
@@ -43,8 +44,40 @@ pub async fn apply_temp_migrations(
     Ok(())
 }
 
-/// The cache WAL cleanup runs when the stored DB version predates the current
-/// minor release: cache entries from an older minor are stale by definition.
+/// Records the cache format after database and manual migrations succeed.
+pub async fn mark_cache_wal_current(
+    data_dir: &str,
+    cache_storage_disk: bool,
+) -> Result<(), ErrorResponse> {
+    if !cache_storage_disk {
+        return Ok(());
+    }
+
+    let marker = cache_wal_version_path(data_dir);
+    let temporary = marker.with_extension("tmp");
+    fs::write(&temporary, DbVersion::app_version().to_string()).await?;
+    fs::rename(temporary, marker).await?;
+    Ok(())
+}
+
+fn cache_wal_version_path(data_dir: &str) -> PathBuf {
+    Path::new(data_dir).join(CACHE_WAL_VERSION_FILE)
+}
+
+pub async fn apply_temp_migrations(
+    previous_db_version: Option<Version>,
+) -> Result<(), ErrorResponse> {
+    if let Some(previous) = previous_db_version {
+        let app = DbVersion::app_version();
+        if needs_cache_wal_cleanup(&previous, &app) {
+            info!("Cache WAL state was reset before startup for upgrade from v{previous}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns whether cache state from `previous` must be discarded for `app`.
 fn needs_cache_wal_cleanup(previous: &Version, app: &Version) -> bool {
     previous.major != app.major || previous.minor < app.minor
 }
@@ -59,20 +92,90 @@ mod tests {
 
     #[test]
     fn cache_wal_cleanup_runs_on_minor_upgrade() {
-        assert!(needs_cache_wal_cleanup(
-            &v("0.36.2"),
-            &v("0.37.0-nightly.1")
-        ));
+        assert!(needs_cache_wal_cleanup(&v("0.36.2"), &v("0.37.0-20260819")));
         assert!(needs_cache_wal_cleanup(&v("0.36.0"), &v("0.37.0")));
     }
 
     #[test]
     fn cache_wal_cleanup_skips_same_or_newer_minor() {
         assert!(!needs_cache_wal_cleanup(
-            &v("0.37.0-nightly.1"),
-            &v("0.37.0-nightly.2"),
+            &v("0.37.0-20260819"),
+            &v("0.37.0-20260820"),
         ));
         assert!(!needs_cache_wal_cleanup(&v("0.37.0"), &v("0.37.0")));
         assert!(!needs_cache_wal_cleanup(&v("0.37.0"), &v("0.36.2")));
+    }
+
+    fn test_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("rauthy-cache-wal-{name}-{}", std::process::id()))
+    }
+
+    async fn setup_cache_wal(name: &str, marker: Option<&str>) -> PathBuf {
+        let dir = test_dir(name);
+        let _ = fs::remove_dir_all(&dir).await;
+        fs::create_dir_all(dir.join("logs_cache")).await.unwrap();
+        fs::create_dir_all(dir.join("state_machine_cache"))
+            .await
+            .unwrap();
+        if let Some(marker) = marker {
+            fs::write(cache_wal_version_path(dir.to_str().unwrap()), marker)
+                .await
+                .unwrap();
+        }
+        dir
+    }
+
+    #[tokio::test]
+    async fn cache_wal_reset_clears_old_state_and_records_current_version() {
+        let dir = setup_cache_wal("old", Some("0.36.2")).await;
+        prepare_cache_wal(dir.to_str().unwrap(), true)
+            .await
+            .unwrap();
+        assert!(!dir.join("logs_cache").exists());
+        assert!(!dir.join("state_machine_cache").exists());
+
+        fs::create_dir_all(dir.join("logs_cache")).await.unwrap();
+        mark_cache_wal_current(dir.to_str().unwrap(), true)
+            .await
+            .unwrap();
+        let marker = fs::read_to_string(cache_wal_version_path(dir.to_str().unwrap()))
+            .await
+            .unwrap();
+        assert_eq!(marker, DbVersion::app_version().to_string());
+        fs::remove_dir_all(dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cache_wal_reset_keeps_current_state_and_handles_fresh_install() {
+        let current = DbVersion::app_version().to_string();
+        let dir = setup_cache_wal("current", Some(&current)).await;
+        prepare_cache_wal(dir.to_str().unwrap(), true)
+            .await
+            .unwrap();
+        assert!(dir.join("logs_cache").exists());
+        assert!(dir.join("state_machine_cache").exists());
+        fs::remove_dir_all(&dir).await.unwrap();
+
+        let dir = setup_cache_wal("invalid", Some("not-a-version")).await;
+        prepare_cache_wal(dir.to_str().unwrap(), true)
+            .await
+            .unwrap();
+        assert!(!dir.join("logs_cache").exists());
+        fs::remove_dir_all(&dir).await.unwrap();
+
+        let dir = setup_cache_wal("disabled", Some("0.36.2")).await;
+        prepare_cache_wal(dir.to_str().unwrap(), false)
+            .await
+            .unwrap();
+        assert!(dir.join("logs_cache").exists());
+        fs::remove_dir_all(&dir).await.unwrap();
+
+        let dir = setup_cache_wal("fresh", None).await;
+        prepare_cache_wal(dir.to_str().unwrap(), true)
+            .await
+            .unwrap();
+        assert!(!dir.join("logs_cache").exists());
+        assert!(!dir.join("state_machine_cache").exists());
+        fs::remove_dir_all(dir).await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1696, as agreed in the hiqlite#362 review. The hiqlite cache is
persisted in the WAL and restored on restart, so entries written by the previous
version (single-use claims, per-IP abuse counters, removed features) would
linger until the next compaction. The temp migration now clears the affected
namespaces once per minor upgrade.

Also removes the v0.36-cycle temp migrations (PAM group cleanup, group-admin
role warning) and bumps the version to `0.37.0-nightly.1`, raising the lowest
compatible DB version to `0.36.0`.

## Changes (single commit, no overlap with #1696)

1. Version-gated cache WAL cleanup on minor upgrades: `AuthCode`, `DeviceCode`,
   `PoW`, `DPoPNonce`, `AuthProviderCallback`, `ClientDynamic`,
   `ClientEphemeral`, `ClientSecret`, `CredStuffDetect`, `IpBlacklist`,
   `IpRateLimit`, `EmailRateLimit`. Runs only when the stored DB version
   predates the new minor (unit-tested), so restarts within a minor keep
   in-flight flows. Sessions, users and other long-lived caches are kept.
2. `DB::migrate()` returns the pre-upgrade DB version and threads it into the
   temp migrations; fresh installs skip the cleanup.
3. Version bump to `0.37.0-nightly.1`, `LOWEST_COMPATIBLE_VERSION` → `0.36.0`,
   version guard → 0.37, old temp migrations and their TODO markers removed.

## Testing

- Unit: new gate tests + full workspace unit suite green; clippy and rustfmt
  clean.
- Integration: started against a real v0.36.2 DB — cleanup logged, DB version
  upserted to `0.37.0-nightly.1`; a second start skips the cleanup.

## Notes

- hiqlite stays on the git patch until the stable release with `get_remove()`
  lands, as agreed.
- Only ephemeral single-use and abuse-counter state is purged; backend/session
  caches survive the upgrade.
