### PR TITLE
RFC 8707: carry `resource` through upstream-provider logins (#1702)

### DIFF
--- a/frontend/src/api/types/auth_provider.ts
+++ b/frontend/src/api/types/auth_provider.ts
@@ -71,6 +71,8 @@ export interface ProviderLoginRequest {
     /// Validation: PATTERN_CODE_CHALLENGE
     code_challenge?: string;
     code_challenge_method?: CodeChallengeMethod;
+    /// Validation: PATTERN_RESOURCE — RFC 8707 resource indicator
+    resource?: string;
 
     // values for the callback from upstream
     /// Validation: PATTERN_URI

--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -456,6 +456,7 @@
             nonce: nonce,
             code_challenge: challenge,
             code_challenge_method: challengeMethod,
+            resource: resource || undefined,
             provider_id: id,
             pkce_challenge: '',
             pow: '',

--- a/src/api_types/src/auth_providers.rs
+++ b/src/api_types/src/auth_providers.rs
@@ -1,7 +1,7 @@
 use crate::cust_validation::validate_vec_scopes;
 use rauthy_common::regex::{
-    RE_ALNUM, RE_ATPROTO_HANDLE, RE_CLIENT_ID, RE_CLIENT_NAME, RE_CODE_CHALLENGE, RE_SCOPE_SPACE,
-    RE_URI,
+    RE_ALNUM, RE_ATPROTO_HANDLE, RE_CLIENT_ID, RE_CLIENT_NAME, RE_CODE_CHALLENGE, RE_RESOURCE,
+    RE_SCOPE_SPACE, RE_URI,
 };
 use rauthy_derive::FromPgRow;
 use serde::{Deserialize, Serialize};
@@ -125,6 +125,13 @@ pub struct ProviderLoginRequest {
     /// Validation: `[a-zA-Z0-9]`
     #[validate(regex(path = "*RE_ALNUM", code = "[a-zA-Z0-9]"))]
     pub code_challenge_method: Option<String>,
+    /// RFC 8707 resource indicator from the authorization request. Carried
+    /// through the upstream-provider round trip and into the auth code, exactly
+    /// like `LoginRequest.resource`, so the token request may repeat it.
+    ///
+    /// Validation: `[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$` (no `#`; RFC 8707 forbids a fragment)
+    #[validate(regex(path = "*RE_RESOURCE", code = "[a-zA-Z0-9,.:/_-&?=~!$'()*+%@]+$"))]
+    pub resource: Option<String>,
     /// Validation: `^[a-zA-Z0-9,.:/_\-&?=~#!$'()*+%]{2,128}$`
     #[validate(regex(
         path = "*RE_CLIENT_ID",
@@ -205,4 +212,52 @@ pub struct ProviderLookupResponse {
     pub use_pkce: bool,
     pub client_secret_basic: bool,
     pub client_secret_post: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use validator::Validate;
+
+    // Regression tests for RFC 8707 `resource` being dropped on upstream-provider
+    // logins (#1702). The provider login request must carry a `resource` just like
+    // `LoginRequest` / `LoginRefreshRequest`, so the auth code minted after the
+    // upstream round trip is audience-bound and the token request may repeat it.
+    #[test]
+    fn provider_login_request_carries_valid_resource() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "https://mcp.example.com/mcp",
+            "pow": "abc123",
+            "provider_id": "google",
+            "pkce_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        }"#;
+
+        let req: ProviderLoginRequest =
+            serde_json::from_str(json).expect("must deserialize the resource field");
+        assert_eq!(req.resource.as_deref(), Some("https://mcp.example.com/mcp"));
+        assert!(
+            req.validate().is_ok(),
+            "a valid absolute-URI resource must pass validation"
+        );
+    }
+
+    #[test]
+    fn provider_login_request_rejects_invalid_resource() {
+        let json = r#"{
+            "client_id": "my-client",
+            "redirect_uri": "https://app.example.com/callback",
+            "resource": "https://mcp.example.com/mcp#fragment",
+            "pow": "abc123",
+            "provider_id": "google",
+            "pkce_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        }"#;
+
+        let req: ProviderLoginRequest = serde_json::from_str(json).expect("must deserialize");
+        assert!(
+            req.validate().is_err(),
+            "RFC 8707 forbids a fragment in `resource`; validation must reject it"
+        );
+    }
 }

--- a/src/data/src/entity/auth_providers.rs
+++ b/src/data/src/entity/auth_providers.rs
@@ -648,6 +648,11 @@ pub struct AuthProviderCallback {
     pub req_nonce: Option<String>,
     pub req_code_challenge: Option<String>,
     pub req_code_challenge_method: Option<String>,
+    /// RFC 8707 resource indicator from the authorization request (#1702).
+    /// `default` so a callback cached by the previous version still decodes
+    /// during a rolling upgrade.
+    #[serde(default)]
+    pub req_resource: Option<String>,
 
     pub provider_id: String,
 

--- a/src/service/src/oidc/auth_providers/login_finish.rs
+++ b/src/service/src/oidc/auth_providers/login_finish.rs
@@ -120,9 +120,7 @@ pub async fn login_finish<'a>(
             nonce: slf.req_nonce,
             code_challenge: slf.req_code_challenge,
             code_challenge_method: slf.req_code_challenge_method,
-            // brokered logins via an upstream IdP do not propagate RFC 8707 resource
-            // indicators yet
-            resource: None,
+            resource: slf.req_resource,
             header_origin,
             require_webauthn,
         },

--- a/src/service/src/oidc/auth_providers/login_start.rs
+++ b/src/service/src/oidc/auth_providers/login_start.rs
@@ -42,6 +42,7 @@ pub async fn login_start<'a>(
         req_nonce: payload.nonce,
         req_code_challenge: payload.code_challenge,
         req_code_challenge_method: payload.code_challenge_method,
+        req_resource: payload.resource,
 
         provider_id: provider.id,
 


### PR DESCRIPTION
Closes #1702.

A brokered login (upstream auth provider) built its `AuthorizeData` with a literal `resource: None`, so the auth code never carried the RFC 8707 resource indicator and the token request that repeats it was refused with `the requested "resource" was not granted at the authorization request`. Password, passkey and `/oidc/authorize/refresh` (#1645) logins already carried it — only the provider round trip lost it.

**Change**, the same shape as the other request parameters:
- `ProviderLoginRequest.resource: Option<String>` validated with `RE_RESOURCE` (identical rule and doc comment to `LoginRequest.resource`);
- `AuthProviderCallback.req_resource`, `#[serde(default)]` so a callback cached by the previous version still decodes during a rolling upgrade;
- `login_start` stores it, `login_finish` passes `slf.req_resource` to `finish_authorize` (the `allowed_resources` check already lives there, nothing new to validate);
- frontend: the authorize page adds `resource` to the provider-login payload next to the PKCE values, and the TS type gains the field.

**Tests**: two unit tests on `ProviderLoginRequest` mirroring the #1645 ones (a valid resource deserializes and validates; a fragment is rejected). `cargo fmt`, `cargo check` and `cargo clippy` clean on `rauthy-api-types`, `rauthy-data`, `rauthy-service`.

Seen in the wild with claude.ai's MCP connector: a user whose first Rauthy login runs through "Login with Google" cannot finish the connector setup; the same flow through a password/passkey login works.
