### PR TITLE
Use theme `--border-radius` for the login card container

### DIFF
--- a/frontend/src/routes/oidc/authorize/+page.svelte
+++ b/frontend/src/routes/oidc/authorize/+page.svelte
@@ -783,7 +783,7 @@
         justify-content: center;
         max-width: 21rem;
         padding: 20px;
-        border-radius: 5px;
+        border-radius: var(--border-radius);
         border: 1px solid hsl(var(--bg-high));
         background: hsl(var(--bg));
     }


### PR DESCRIPTION
The theme API already exposes `--border-radius`, and all other themed components (inputs, buttons, tabs, ...) consume it via `var(--border-radius)`. The `.container` of the login card in `frontend/src/routes/oidc/authorize/+page.svelte` was the only place that hardcoded `border-radius: 5px`, which made a client theme’s `border_radius` setting ineffective for the card itself.

This makes the card consume the CSS variable like everything else. No visual change with the default themes, since the default value of `--border-radius` is `5px`.