### PR TITLE
Write theme saturation and lightness with explicit % units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,12 @@ theme's timestamp, which is what busts the long-lived client-side cache for the 
 
 [#1706](https://github.com/sebadob/rauthy/pull/1706)
 
+### Bugfix
+
+- The last color stop of the hue slider in the Admin UI branding editor used a hue of `3600`
+  instead of `360`, so the gradient ended on red instead of spanning the full spectrum.
+  [#1706](https://github.com/sebadob/rauthy/pull/1706)
+
 ## v0.36.2
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@ theme's timestamp, which is what busts the long-lived client-side cache for the 
 - The last color stop of the hue slider in the Admin UI branding editor used a hue of `3600`
   instead of `360`, so the gradient ended on red instead of spanning the full spectrum.
   [#1706](https://github.com/sebadob/rauthy/pull/1706)
+- Theme validation checked `accent` twice and never validated `action`.
+  [#1706](https://github.com/sebadob/rauthy/pull/1706)
 
 ## v0.36.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,20 @@ RE_CLIENT_NAME: ^[\p{L}\p{M}\p{N}\p{Zs}()._-]{2,128}$
 
 [#1708](https://github.com/sebadob/rauthy/pull/1708)
 
+#### Theme CSS uses explicit percent units
+
+The generated theme CSS now writes saturation and lightness with an explicit `%`, so a color is
+emitted as `--action: 34 100% 40%` rather than `--action: 34 100 40`. Unitless values inside `hsl()`
+are a CSS Color 4 addition supported from Safari 18, Chrome 121 and Firefox 122. Browsers below that
+drop the whole declaration, which left buttons with no background while `--btn-text` still applied,
+rendering them invisible. It affects every iOS below 18, where no alternative browser engine is
+available.
+
+If you use a custom theme, save it once after upgrading even if you change nothing. That updates the
+theme's timestamp, which is what busts the long-lived client-side cache for the generated CSS.
+
+[#1706](https://github.com/sebadob/rauthy/pull/1706)
+
 ## v0.36.2
 
 ### Security

--- a/frontend/src/lib/admin/clients/branding/BrandingPreview.svelte
+++ b/frontend/src/lib/admin/clients/branding/BrandingPreview.svelte
@@ -17,6 +17,8 @@
         typ: 'light' | 'dark';
     } = $props();
 
+    const hslVar = (v: number[]) => `${v[0]} ${v[1]}% ${v[2]}%`;
+
     let isLoading = $state(false);
     let showDefault = $state(false);
 
@@ -38,13 +40,13 @@
 <div
     aria-label="Preview: All components inside are only for theme and colors preview and have no effect or interaction"
     style:--border-radius={borderRadius}
-    style:--text={theme.text.join(' ')}
-    style:--text-high={theme.text_high.join(' ')}
-    style:--bg={theme.bg.join(' ')}
-    style:--bg-high={theme.bg_high.join(' ')}
-    style:--action={theme.action.join(' ')}
-    style:--accent={theme.accent.join(' ')}
-    style:--error={theme.error.join(' ')}
+    style:--text={hslVar(theme.text)}
+    style:--text-high={hslVar(theme.text_high)}
+    style:--bg={hslVar(theme.bg)}
+    style:--bg-high={hslVar(theme.bg_high)}
+    style:--action={hslVar(theme.action)}
+    style:--accent={hslVar(theme.accent)}
+    style:--error={hslVar(theme.error)}
     style:--btn-text={theme.btn_text}
     style:--theme-sun={theme.theme_sun}
     style:--theme-moon={theme.theme_moon}

--- a/frontend/src/lib/admin/clients/branding/HSLInputRange.svelte
+++ b/frontend/src/lib/admin/clients/branding/HSLInputRange.svelte
@@ -17,7 +17,7 @@
     const id = genKey();
     const widthRange = '15rem';
 
-    let hsl = $derived(`hsl(${h} ${s} ${l})`);
+    let hsl = $derived(`hsl(${h} ${s}% ${l}%)`);
 </script>
 
 <div class="outer">

--- a/frontend/src/lib/form/InputRange.svelte
+++ b/frontend/src/lib/form/InputRange.svelte
@@ -36,20 +36,20 @@
             if (bgMode === 'hue') {
                 return `linear-gradient(
                     to right,
-                    hsl(0 ${sat} ${lum}) 0%,
-                    hsl(60 ${sat} ${lum}) 17%,
-                    hsl(120 ${sat} ${lum}) 33%,
-                    hsl(180 ${sat} ${lum}) 50%,
-                    hsl(240 ${sat} ${lum}) 67%,
-                    hsl(300 ${sat} ${lum}) 83%,
-                    hsl(3600 ${sat} ${lum}) 100%
+                    hsl(0 ${sat}% ${lum}%) 0%,
+                    hsl(60 ${sat}% ${lum}%) 17%,
+                    hsl(120 ${sat}% ${lum}%) 33%,
+                    hsl(180 ${sat}% ${lum}%) 50%,
+                    hsl(240 ${sat}% ${lum}%) 67%,
+                    hsl(300 ${sat}% ${lum}%) 83%,
+                    hsl(3600 ${sat}% ${lum}%) 100%
                 )`;
             }
             if (bgMode === 'sat') {
-                return `linear-gradient(to right, hsl(${hue} 0 ${lum}), hsl(${hue} 100 ${lum}))`;
+                return `linear-gradient(to right, hsl(${hue} 0% ${lum}%), hsl(${hue} 100% ${lum}%))`;
             }
             if (bgMode === 'lum') {
-                return `linear-gradient(to right, hsl(${hue} ${sat} 0), hsl(${hue} ${sat} 100))`;
+                return `linear-gradient(to right, hsl(${hue} ${sat}% 0%), hsl(${hue} ${sat}% 100%))`;
             }
         }
 

--- a/frontend/src/lib/form/InputRange.svelte
+++ b/frontend/src/lib/form/InputRange.svelte
@@ -42,7 +42,7 @@
                     hsl(180 ${sat}% ${lum}%) 50%,
                     hsl(240 ${sat}% ${lum}%) 67%,
                     hsl(300 ${sat}% ${lum}%) 83%,
-                    hsl(3600 ${sat}% ${lum}%) 100%
+                    hsl(360 ${sat}% ${lum}%) 100%
                 )`;
             }
             if (bgMode === 'sat') {

--- a/src/api_types/src/themes.rs
+++ b/src/api_types/src/themes.rs
@@ -35,7 +35,7 @@ impl ThemeCss {
         Self::validate_hsl(self.text_high)?;
         Self::validate_hsl(self.bg)?;
         Self::validate_hsl(self.bg_high)?;
-        Self::validate_hsl(self.accent)?;
+        Self::validate_hsl(self.action)?;
         Self::validate_hsl(self.accent)?;
         Self::validate_hsl(self.error)?;
 

--- a/src/data/src/entity/fed_cm.rs
+++ b/src/data/src/entity/fed_cm.rs
@@ -115,11 +115,11 @@ impl FedCMIdPBranding {
         // this is pretty inefficient, but FedCM is in experimental testing only anyway
         let css = ThemeCssFull::find_with_default("rauthy".to_string()).await?;
         let background_color = format!(
-            "hsl({} {} {})",
+            "hsl({} {}% {}%)",
             css.light.bg[0], css.light.bg[1], css.light.bg[2]
         );
         let color = format!(
-            "hsl({} {} {})",
+            "hsl({} {}% {}%)",
             css.light.text[0], css.light.text[1], css.light.text[2]
         );
 

--- a/src/data/src/entity/theme.rs
+++ b/src/data/src/entity/theme.rs
@@ -412,36 +412,39 @@ impl From<&[u8]> for ThemeCss {
 }
 
 impl ThemeCss {
+    /// Saturation and lightness must be written with an explicit `%`. Unitless values
+    /// are CSS Color 4 only, and browsers without it drop the whole declaration,
+    /// leaving elements styled with `hsl(var(--action))` without a background.
     pub fn append_css(&self, s: &mut String) -> Result<(), ErrorResponse> {
         write!(
             s,
-            "--text:{} {} {};",
+            "--text:{} {}% {}%;",
             self.text[0], self.text[1], self.text[2]
         )?;
         write!(
             s,
-            "--text-high:{} {} {};",
+            "--text-high:{} {}% {}%;",
             self.text_high[0], self.text_high[1], self.text_high[2]
         )?;
-        write!(s, "--bg:{} {} {};", self.bg[0], self.bg[1], self.bg[2])?;
+        write!(s, "--bg:{} {}% {}%;", self.bg[0], self.bg[1], self.bg[2])?;
         write!(
             s,
-            "--bg-high:{} {} {};",
+            "--bg-high:{} {}% {}%;",
             self.bg_high[0], self.bg_high[1], self.bg_high[2]
         )?;
         write!(
             s,
-            "--action:{} {} {};",
+            "--action:{} {}% {}%;",
             self.action[0], self.action[1], self.action[2]
         )?;
         write!(
             s,
-            "--accent:{} {} {};",
+            "--accent:{} {}% {}%;",
             self.accent[0], self.accent[1], self.accent[2]
         )?;
         write!(
             s,
-            "--error:{} {} {};",
+            "--error:{} {}% {}%;",
             self.error[0], self.error[1], self.error[2]
         )?;
 


### PR DESCRIPTION
Thanks for Rauthy — it's been robust to run and straightforward to operate, and
the device-code flow made our mobile sign-in much simpler than it would
otherwise have been.

We use it as the OIDC provider for a small notes app. On mobile, users leave the
app and land on Rauthy's device and login pages. While testing our iOS build on
an older iPhone (iOS 15.8), the buttons on those pages were invisible — present
and tappable, but with nothing drawn.

`append_css` writes `--action:0 45 33`, and the stylesheets use that as
`hsl(var(--action))` and `hsla(var(--action) / .93)`. Unitless saturation and
lightness are a CSS Color 4 addition, and where it isn't supported the whole
declaration is dropped — so the button loses its background while
`--btn-text: white` still applies, giving white on white.

`frontend/src/css/theme.css` already writes the percent form
(`--action: 34 100% 40%`), so this brings the generated CSS in line with the
checked-in stylesheet rather than introducing a new convention.

Measured on the device with a probe page reporting `CSS.supports` and
`getComputedStyle`:

| declaration | iOS 15.8.8 | iOS 18.6 |
| --- | --- | --- |
| `hsl(0 45 33)` | false → `rgba(0, 0, 0, 0)` | true → `rgb(122, 46, 46)` |
| `hsl(0 45% 33%)` | true → `rgb(122, 46, 46)` | true → `rgb(122, 46, 46)` |
| `hsla(0 45 33 / .93)` | false → `rgba(0, 0, 0, 0)` | true → `rgba(122, 46, 46, 0.93)` |
| `hsla(0 45% 33% / .93)` | true → `rgba(122, 46, 46, 0.93)` | true → `rgba(122, 46, 46, 0.93)` |

Per MDN's compat data the unitless form arrived in Safari 18, Chrome 121 and
Firefox 122, so it may be worth noting this affects every iOS below 18 rather
than only older hardware — and on iOS there's no alternative engine to fall back
to. The slash-alpha syntax itself is fine on iOS 15 once the components carry
units (last row above), so the `hsla(var(--x) / …)` sites are covered by the same
change.

What this touches:

- `ThemeCss::append_css`, the backend emitter.
- `fed_cm.rs`, which builds the same strings for the browser's FedCM UI. FedCM
  shipped in Chrome ~108 but unitless `hsl()` only parses from 121, so those
  branding colours were being dropped on 108–120.
- Three places the admin UI builds `hsl()` of its own, so the branding editor
  works on the same browsers as the pages it previews: the branding preview, the
  colour swatches, and the slider track gradients. The gradients matter most —
  one invalid colour stop invalidates the whole `linear-gradient`, so all three
  slider tracks render flat and you can't see the hue you're dragging toward.

The emails benefit too, without a change: `templates/email/base.html` and
`email/custom.rs` consume the same variables, and `%` is the older and more
widely supported form.

A second commit fixes an unrelated stray digit on a line I was already touching
(`hsl(3600 …)` → `hsl(360 …)` in the hue gradient). Kept separate so you can
drop it independently.

One caveat, with no code change proposed since it's your call: the theme
endpoint is served `max-age=31104000` and busts on `last_update`. For the default
theme that's `BUILD_TIME`, so an upgrade fixes it. For a client with a row in
`themes`, `last_update` isn't touched by an upgrade, so a browser that cached the
unitless CSS keeps it until the theme is next saved. Server-side caching is fine
— `Cache::Html` is cleared at startup.

Checks: `cargo fmt --check` and `prettier -c` are clean on the changed files. I
have not run `cargo clippy -D warnings` or `just pre-pr-checks` — the Hiqlite and
Postgres tests need more than my current setup. Only literal text inside the
format strings moved, with arity and types unchanged, but please treat those as
unverified on my side. I also looked for anything that parses the emitted CSS or
reads these variables back and didn't find any — the admin editor round-trips
through the JSON API as numbers — though a second opinion there is worth more
than mine.

Unrelated, and only in case it's news: `ThemeCss::validate` looks like it calls
`validate_hsl(self.accent)` twice and never checks `self.action`. It doesn't
affect this change, since both forms clamp out-of-range values identically.

Happy to add a CHANGELOG entry, or to take this a different way if you'd prefer
— for instance leaving the variables unitless and adding units at the point of
use instead.
