### PR TITLE
Fix: Reset a manually initialized users password if a passkey was added with the initial link

### DIFF
--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -518,6 +518,11 @@ pub async fn post_users_register_handle(
 /// Validates a registration or password-reset redirect URI against configured clients.
 #[inline]
 async fn validate_reg_redirect_uri(redirect_uri: &str) -> Result<(), ErrorResponse> {
+    // Rauthys own relative links are always safe
+    if redirect_uri.starts_with("/") {
+        return Ok(());
+    }
+
     for uri in Client::find_all_client_uris().await? {
         let matches = match redirect_uri.strip_prefix(&uri) {
             None => false,
@@ -2085,7 +2090,7 @@ pub async fn post_webauthn_reg_finish(
         let id = id.into_inner();
         principal.is_user(&id)?;
 
-        webauthn::reg_finish(id, payload).await?;
+        webauthn::reg_finish(id, payload, false).await?;
 
         // The registration ceremony is a fresh proof of possession for this very session, and
         // starting it already required an `MfaModToken`. Upgrade the session in place so the user
@@ -2268,6 +2273,7 @@ pub async fn post_user_password_request_reset(
             .user_registration
             .allow_open_redirect
     {
+        warn!("{redirect_uri}");
         validate_reg_redirect_uri(redirect_uri).await?;
     }
 

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -2273,7 +2273,6 @@ pub async fn post_user_password_request_reset(
             .user_registration
             .allow_open_redirect
     {
-        warn!("{redirect_uri}");
         validate_reg_redirect_uri(redirect_uri).await?;
     }
 

--- a/src/data/src/entity/webauthn.rs
+++ b/src/data/src/entity/webauthn.rs
@@ -965,6 +965,7 @@ pub async fn reg_start(
 pub async fn reg_finish(
     id: String,
     payload: WebauthnRegFinishRequest,
+    is_new_user: bool,
 ) -> Result<(), ErrorResponse> {
     let mut user = User::find(id).await?;
 
@@ -1006,6 +1007,22 @@ pub async fn reg_finish(
             let user_id = user.id.clone();
             let create_user = if user.webauthn_user_id.is_none() {
                 user.webauthn_user_id = Some(reg_data.passkey_user_id.to_string());
+
+                // We need to check if the user is a possibly manually initialized one, and we
+                // need to reset a password. This can happen when an admin adds a user, does a
+                // manual init to prevent auto-removal, and then the initial password reset link
+                // is used to add a passkey instead. In such a situation, the user would have a
+                // random password but never logged in even once, and the Magic Link Usage is
+                // NewUser.
+                if is_new_user && user.password.is_some() && user.last_login.is_none() {
+                    info!(
+                        "Resetting manually initialized password for user {}",
+                        user.email
+                    );
+                    user.password = None;
+                    user.save(None).await?;
+                }
+
                 if user.password.is_none() || cfg.no_password_exp {
                     user.password_expires = None;
                 }

--- a/src/service/src/password_reset.rs
+++ b/src/service/src/password_reset.rs
@@ -104,7 +104,11 @@ pub async fn handle_put_user_passkey_finish(
 
     // finish webauthn request -> always force UV for passkey only accounts
     debug!("ml is valid - finishing webauthn request");
-    webauthn::reg_finish(user_id.clone(), req_data).await?;
+    let is_new_user = matches!(
+        MagicLinkUsage::try_from(&ml.usage),
+        Ok(MagicLinkUsage::NewUser(_))
+    );
+    webauthn::reg_finish(user_id.clone(), req_data, is_new_user).await?;
 
     // validate csrf token
     match req.headers().get(PWD_CSRF_HEADER) {


### PR DESCRIPTION
fixes #1699