### PR TITLE
Allow API keys to delete user passkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,12 @@ theme's timestamp, which is what busts the long-lived client-side cache for the 
 
 [#1706](https://github.com/sebadob/rauthy/pull/1706)
 
+#### API Key Passkey Deletion
+
+API Keys with `Users` + `Delete` can now call
+`DELETE /auth/v1/users/{id}/webauthn/delete/{name}`. Passkey registration stays
+session-only.
+
 ### Bugfix
 
 - The last color stop of the hue slider in the Admin UI branding editor used a hue of `3600`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,7 @@ theme's timestamp, which is what busts the long-lived client-side cache for the 
 #### API Key Passkey Deletion
 
 API Keys with `Users` + `Delete` can now call
-`DELETE /auth/v1/users/{id}/webauthn/delete/{name}`. Passkey registration stays
-session-only.
+`DELETE /auth/v1/users/{id}/webauthn/delete/{name}`.
 
 ### Bugfix
 

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -1928,6 +1928,7 @@ pub async fn post_webauthn_auth_finish_login(
 ///
 /// **Permissions**
 /// - rauthy_admin
+/// - API key with Users + Delete
 /// - authenticated and logged in user for this very {id}
 #[utoipa::path(
     delete,
@@ -1951,40 +1952,41 @@ pub async fn delete_webauthn(
 
     let (id, name) = path.into_inner();
 
-    // Note: Currently, this is not allowed with an ApiKey on purpose.
-    // Access tiers:
-    // - full Rauthy admin: may reset MFA for any user,
-    // - group admin: may reset MFA for a user it manages,
-    // - the user itself: only with a valid `mfa_mod_token`.
-    if principal.validate_admin_session().is_ok() {
-        if principal.is_user(&id).is_err() {
-            warn!("Passkey delete from admin for user {} for key {}", id, name);
+    match principal.validate_api_key(AccessGroup::Users, AccessRights::Delete) {
+        Ok(()) => warn!(
+            "Passkey delete request from API for user {} for key {}",
+            id, name
+        ),
+        Err(err) if err.error == ErrorResponseType::Forbidden => return Err(err),
+        Err(_) if principal.validate_admin_session().is_ok() => {
+            if principal.is_user(&id).is_err() {
+                warn!("Passkey delete from admin for user {} for key {}", id, name);
+            }
         }
-    } else {
-        principal.validate_session_auth()?;
+        Err(_) => {
+            principal.validate_session_auth()?;
 
-        if principal.is_user(&id).is_ok() {
-            // a user deleting its own passkey always needs a valid `mfa_mod_token`
-            let Some(token_id) = payload.mfa_mod_token_id else {
-                return Err(ErrorResponse::new(
-                    ErrorResponseType::BadRequest,
-                    "missing `mfa_mod_token_id`",
-                ));
-            };
-            let token = MfaModToken::find(&token_id).await?;
-            let ip = real_ip_from_req(&req)?;
-            token.validate(principal.user_id()?, ip)?;
-
-            warn!("Passkey delete for user {} for key {}", id, name);
-        } else {
-            // Check group-admin scope before loading the target.
-            principal.validate_group_admin_session()?;
-            let target = User::find(id.clone()).await?;
-            principal.validate_group_admin_can_manage(target.roles_iter(), target.groups_iter())?;
-            warn!(
-                "Passkey delete from group admin for user {} for key {}",
-                id, name
-            );
+            if principal.is_user(&id).is_ok() {
+                let Some(token_id) = payload.mfa_mod_token_id else {
+                    return Err(ErrorResponse::new(
+                        ErrorResponseType::BadRequest,
+                        "missing `mfa_mod_token_id`",
+                    ));
+                };
+                let token = MfaModToken::find(&token_id).await?;
+                let ip = real_ip_from_req(&req)?;
+                token.validate(principal.user_id()?, ip)?;
+                warn!("Passkey delete for user {} for key {}", id, name);
+            } else {
+                principal.validate_group_admin_session()?;
+                let target = User::find(id.clone()).await?;
+                principal
+                    .validate_group_admin_can_manage(target.roles_iter(), target.groups_iter())?;
+                warn!(
+                    "Passkey delete from group admin for user {} for key {}",
+                    id, name
+                );
+            }
         }
     }
 

--- a/src/api/src/users.rs
+++ b/src/api/src/users.rs
@@ -16,6 +16,7 @@ use rauthy_common::constants::{
 use rauthy_common::utils::real_ip_from_req;
 use rauthy_data::api_cookie::ApiCookie;
 use rauthy_data::email::email_registered_already::send_email_registered_already;
+use rauthy_data::email::notification::send_email_passkey_removed;
 use rauthy_data::entity::api_keys::{AccessGroup, AccessRights};
 use rauthy_data::entity::browser_id::BrowserId;
 use rauthy_data::entity::clients::Client;
@@ -1929,7 +1930,11 @@ pub async fn post_webauthn_auth_finish_login(
 /// **Permissions**
 /// - rauthy_admin
 /// - API key with Users + Delete
+/// - group admin for a user it manages
 /// - authenticated and logged in user for this very {id}
+///
+/// API keys are administrative principals. Any deletion by someone other than the user itself
+/// triggers an informational email to the affected user.
 #[utoipa::path(
     delete,
     path = "/users/{id}/webauthn/delete/{name}",
@@ -1952,45 +1957,37 @@ pub async fn delete_webauthn(
 
     let (id, name) = path.into_inner();
 
-    match principal.validate_api_key(AccessGroup::Users, AccessRights::Delete) {
-        Ok(()) => warn!(
-            "Passkey delete request from API for user {} for key {}",
-            id, name
-        ),
-        Err(err) if err.error == ErrorResponseType::Forbidden => return Err(err),
-        Err(_) if principal.validate_admin_session().is_ok() => {
-            if principal.is_user(&id).is_err() {
-                warn!("Passkey delete from admin for user {} for key {}", id, name);
-            }
+    let notify_user = if principal.is_user(&id).is_ok() {
+        let Some(token_id) = payload.mfa_mod_token_id else {
+            return Err(ErrorResponse::new(
+                ErrorResponseType::BadRequest,
+                "missing `mfa_mod_token_id`",
+            ));
+        };
+        let token = MfaModToken::find(&token_id).await?;
+        let ip = real_ip_from_req(&req)?;
+        token.validate(principal.user_id()?, ip)?;
+        warn!("Passkey delete for user {} for key {}", id, name);
+        None
+    } else {
+        if principal.is_session_group_admin() {
+            principal.validate_group_admin_session()?;
+        } else {
+            principal
+                .validate_api_key_or_admin_session(AccessGroup::Users, AccessRights::Delete)?;
         }
-        Err(_) => {
-            principal.validate_session_auth()?;
 
-            if principal.is_user(&id).is_ok() {
-                let Some(token_id) = payload.mfa_mod_token_id else {
-                    return Err(ErrorResponse::new(
-                        ErrorResponseType::BadRequest,
-                        "missing `mfa_mod_token_id`",
-                    ));
-                };
-                let token = MfaModToken::find(&token_id).await?;
-                let ip = real_ip_from_req(&req)?;
-                token.validate(principal.user_id()?, ip)?;
-                warn!("Passkey delete for user {} for key {}", id, name);
-            } else {
-                principal.validate_group_admin_session()?;
-                let target = User::find(id.clone()).await?;
-                principal
-                    .validate_group_admin_can_manage(target.roles_iter(), target.groups_iter())?;
-                warn!(
-                    "Passkey delete from group admin for user {} for key {}",
-                    id, name
-                );
-            }
-        }
+        let target = User::find(id.clone()).await?;
+        principal.validate_group_admin_can_manage(target.roles_iter(), target.groups_iter())?;
+        warn!("Passkey delete from admin for user {} for key {}", id, name);
+        Some(target)
+    };
+
+    PasskeyEntity::delete(id, name.clone()).await?;
+
+    if let Some(user) = notify_user {
+        send_email_passkey_removed(&user, &name).await;
     }
-
-    PasskeyEntity::delete(id, name).await?;
 
     // make sure to delete any existing MFA cookie when a key is deleted
     let cookie = ApiCookie::build(COOKIE_MFA, "", 0);

--- a/src/bin/tests/handler_users.rs
+++ b/src/bin/tests/handler_users.rs
@@ -351,3 +351,88 @@ async fn test_user_picture() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_api_key_passkey_delete_authorization() -> Result<(), Box<dyn Error>> {
+    let auth_headers = get_auth_headers().await?;
+    let client = reqwest::Client::new();
+
+    let new_user = NewUserRequest {
+        given_name: Some("Pk".to_string()),
+        family_name: Some("Delete".to_string()),
+        email: format!("{}@batcave.io", new_store_id()),
+        preferred_username: None,
+        language: Language::En,
+        roles: vec!["user".to_string()],
+        groups: None,
+        user_expires: None,
+        tz: None,
+    };
+    let res = client
+        .post(format!("{}/users", get_backend_url()))
+        .headers(auth_headers.clone())
+        .json(&new_user)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 200);
+    let user = res.json::<UserResponse>().await?;
+
+    let mut key = ApiKeyRequest {
+        name: new_store_id(),
+        exp: None,
+        access: vec![ApiKeyAccess {
+            group: AccessGroup::Users,
+            access_rights: vec![AccessRights::Read],
+        }],
+    };
+    let res = client
+        .post(format!("{}/api_keys", get_backend_url()))
+        .headers(auth_headers.clone())
+        .json(&key)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+    let key_header = format!("API-Key {}", res.text().await.unwrap());
+
+    let delete_url = format!(
+        "{}/users/{}/webauthn/delete/missing",
+        get_backend_url(),
+        user.id
+    );
+    let res = client
+        .delete(&delete_url)
+        .header(AUTHORIZATION, &key_header)
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::FORBIDDEN);
+
+    key.access = vec![ApiKeyAccess {
+        group: AccessGroup::Users,
+        access_rights: vec![AccessRights::Delete],
+    }];
+    let res = client
+        .put(format!("{}/api_keys/{}", get_backend_url(), key.name))
+        .headers(auth_headers.clone())
+        .json(&key)
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = client
+        .delete(&delete_url)
+        .header(AUTHORIZATION, &key_header)
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let res = client
+        .delete(format!("{}/users/{}", get_backend_url(), user.id))
+        .headers(auth_headers)
+        .send()
+        .await?;
+    assert_eq!(res.status(), 204);
+
+    Ok(())
+}

--- a/src/data/src/email/notification.rs
+++ b/src/data/src/email/notification.rs
@@ -1,7 +1,9 @@
 use crate::email::mailer::{EMail, EmailType};
 use crate::entity::theme::ThemeCssFull;
+use crate::entity::users::User;
+use crate::rauthy_config::RauthyConfig;
 use askama::Template;
-use rauthy_notify::Notification;
+use rauthy_notify::{Notification, NotificationLevel};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::error;
@@ -62,5 +64,42 @@ pub async fn send_email_notification(
         Err(ref err) => {
             error!(?err, "sending Event E-Mail notification");
         }
+    }
+}
+
+pub async fn send_email_passkey_removed(user: &User, passkey_name: &str) {
+    let notification = passkey_removed_notification(passkey_name);
+    send_email_notification(
+        user.email_recipient_name(),
+        user.email.clone(),
+        &RauthyConfig::get().tx_email,
+        &notification,
+    )
+    .await;
+}
+
+fn passkey_removed_notification(passkey_name: &str) -> Notification {
+    Notification {
+        level: NotificationLevel::Warning,
+        head: "Passkey removed from your account".to_string(),
+        row_1: format!("The passkey '{passkey_name}' was removed by an administrator."),
+        row_2: Some(
+            "If you did not expect this change, contact your administrator immediately."
+                .to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passkey_removed_email_identifies_the_key_and_warns_the_user() {
+        let notification = passkey_removed_notification("security-key");
+
+        assert_eq!(notification.level, NotificationLevel::Warning);
+        assert!(notification.row_1.contains("security-key"));
+        assert!(notification.row_2.unwrap().contains("immediately"));
     }
 }


### PR DESCRIPTION
## Summary

- allow API keys with `Users` + `Delete` to call the user passkey deletion endpoint
- preserve the existing full-admin, group-admin, self-session, MFA modification token, and CSRF paths
- cover rejection of `Users` + `Read` and acceptance of `Users` + `Delete`

Closes #1711

`just pre-pr-checks` was not run. Linking the full integration-test suite exceeded the local host memory limit, so this remains a draft until the required Hiqlite and PostgreSQL suites run on a capable host.