### PR TITLE
fix(webauthn): use user-specific start for password reset

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -39,3 +39,9 @@ jobs:
       - name: Code Style UI
         working-directory: ./frontend
         run: npm run check
+      - name: Frontend Contract Tests
+        working-directory: ./frontend
+        run: npm run test:webauthn
+        # The Chromium reset-page test (npm run test:password-reset) is not
+        # wired here: it needs a browser binary plus the already-built
+        # frontend. Run it locally after `just build-ui`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -383,6 +383,19 @@ In such a case, you can `just test-backend`, which will start the test backend w
 you then `just test your_unit_test`, it will only run the single integration test without starting
 the backend automatically.
 
+### Password Reset UI Checks
+
+From `frontend/`, run `npm run test:webauthn` for the endpoint-routing checks.
+After generating the WASM modules with `just build-wasm` from the repository root,
+run `npm run test:password-reset` for the built reset page in Chromium. Install
+Playwright's Chromium or set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to an existing binary.
+
+These checks intercept all browser requests and use an in-memory virtual authenticator;
+they do not contact Rauthy or create accounts. Keep browser/protocol debug logging off.
+Reset context and credentials are generated in memory, without traces or fixtures.
+Backend authorization, token expiry/replay, and subsequent real-account login require
+separate isolated integration tests; the UI checks do not prove those properties.
+
 ## Building a Container Image
 
 If you want to build a container image for testing, you cannot `just build`, because you won't have

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,10 +385,11 @@ the backend automatically.
 
 ### Password Reset UI Checks
 
-From `frontend/`, run `npm run test:webauthn` for the endpoint-routing checks.
-After generating the WASM modules with `just build-wasm` from the repository root,
-run `npm run test:password-reset` for the built reset page in Chromium. Install
-Playwright's Chromium or set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to an existing binary.
+From `frontend/`, run `npm run test:webauthn` for the endpoint-routing checks
+(CI runs this too). After generating the WASM modules with `just build-wasm`
+from the repository root, run `npm run test:password-reset` for the built reset
+page in Chromium. Install Playwright's Chromium or set
+`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to an existing binary.
 
 These checks intercept all browser requests and use an in-memory virtual authenticator;
 they do not contact Rauthy or create accounts. Keep browser/protocol debug logging off.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
         "check": "./node_modules/svelte-check/bin/svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
         "test": "playwright test",
+        "test:webauthn": "svelte-kit sync && node --test tests/webauthn-auth.node.mjs",
+        "test:password-reset": "npm run build && node --test tests/password-reset.node.mjs",
         "lint": "prettier --check . && eslint .",
         "format": "./node_modules/prettier/bin/prettier.cjs --write .",
         "format-check": "./node_modules/prettier/bin/prettier.cjs -c ."

--- a/frontend/src/lib/WebauthnRequest.svelte
+++ b/frontend/src/lib/WebauthnRequest.svelte
@@ -8,10 +8,12 @@
 
     let {
         purpose,
+        resetUserId,
         onError,
         onSuccess,
     }: {
         purpose: MfaPurpose;
+        resetUserId?: string;
         onError: (error: string) => void;
         onSuccess: (res?: WebauthnAdditionalData) => void;
     } = $props();
@@ -25,6 +27,7 @@
             purpose,
             t.authorize.invalidKeyUsed,
             t.authorize.requestExpired,
+            resetUserId,
         );
     });
 

--- a/frontend/src/mfa/webauthn/authentication.ts
+++ b/frontend/src/mfa/webauthn/authentication.ts
@@ -18,14 +18,20 @@ export async function webauthnAuth(
     purpose: MfaPurpose,
     errorI18nInvalidKey: string,
     errorI18nTimeout: string,
+    resetUserId?: string,
 ): Promise<WebauthnAuthResult> {
+    let startUri = '/auth/v1/users/webauthn_start';
+    if (purpose === 'PasswordReset') {
+        if (!resetUserId) {
+            return { error: 'Missing user context for password reset' };
+        }
+        startUri = `/auth/v1/users/${encodeURIComponent(resetUserId)}/webauthn/auth/start`;
+    }
+
     let payloadStart: WebauthnAuthStartRequest = {
         purpose,
     };
-    let res = await fetchPost<WebauthnAuthStartResponse>(
-        `/auth/v1/users/webauthn_start`,
-        payloadStart,
-    );
+    let res = await fetchPost<WebauthnAuthStartResponse>(startUri, payloadStart);
     if (res.error) {
         console.error(res.error);
         return {

--- a/frontend/src/routes/users/{id}/reset/reset/+page.svelte
+++ b/frontend/src/routes/users/{id}/reset/reset/+page.svelte
@@ -277,6 +277,7 @@
         {#if mfaPurpose && tplData}
             <WebauthnRequest
                 purpose={mfaPurpose}
+                resetUserId={tplData.user_id}
                 onSuccess={onWebauthnSuccess}
                 onError={onWebauthnError}
             />

--- a/frontend/tests/password-reset.node.mjs
+++ b/frontend/tests/password-reset.node.mjs
@@ -23,7 +23,15 @@ before(async () => {
 });
 after(async () => browser?.close());
 
-for (const scenario of ['password-only', 'passkey', 'start-rejected', 'finish-rejected']) {
+for (const scenario of [
+    'password-only',
+    'passkey',
+    'non-resident-key',
+    'start-rejected',
+    'finish-rejected',
+    'put-rejected',
+    'cancelled',
+]) {
     test(`reset page: ${scenario}`, async t => {
         const context = await browser.newContext({ serviceWorkers: 'block' });
         t.after(() => context.close());
@@ -44,7 +52,10 @@ for (const scenario of ['password-only', 'passkey', 'start-rejected', 'finish-re
         };
         let challengeCode;
         let mfaCode;
-        let rejected = false;
+        let createdCredId;
+        let startRejected = false;
+        let finishRejected = false;
+        let putRejected = false;
         const requests = [];
         const documentPath = '/auth/v1/users/reset-user/reset/reset';
         await context.route('**/*', async route => {
@@ -75,32 +86,36 @@ for (const scenario of ['password-only', 'passkey', 'start-rejected', 'finish-re
             requests.push(`${request.method()} ${url.pathname}`);
             if (url.pathname === '/auth/v1/users/reset-user/webauthn/auth/start') {
                 assert.deepEqual(request.postDataJSON(), { purpose: 'PasswordReset' });
-                if (scenario === 'start-rejected' && !rejected) {
-                    rejected = true;
+                if (scenario === 'start-rejected' && !startRejected) {
+                    startRejected = true;
                     return route.fulfill({
                         status: 400,
                         json: { message: 'Reset binding rejected' },
                     });
                 }
                 challengeCode = crypto.randomUUID();
+                const publicKey = {
+                    challenge: btoa(crypto.randomUUID()),
+                    rpId: 'localhost',
+                    userVerification: 'required',
+                };
+                if (createdCredId) {
+                    publicKey.allowCredentials = [{ id: createdCredId, type: 'public-key' }];
+                }
                 return route.fulfill({
+                    // Short expiry for the cancelled ceremony so the test does not
+                    // wait out the full WebAuthn timeout with no authenticator present.
                     json: {
                         code: challengeCode,
-                        exp: 60,
-                        rcr: {
-                            publicKey: {
-                                challenge: btoa(crypto.randomUUID()),
-                                rpId: 'localhost',
-                                userVerification: 'required',
-                            },
-                        },
+                        exp: scenario === 'cancelled' ? 6 : 60,
+                        rcr: { publicKey },
                     },
                 });
             }
             if (url.pathname === '/auth/v1/users/webauthn_finish') {
                 assert.ok(request.postDataJSON().code === challengeCode);
-                if (scenario === 'finish-rejected' && !rejected) {
-                    rejected = true;
+                if (scenario === 'finish-rejected' && !finishRejected) {
+                    finishRejected = true;
                     return route.fulfill({
                         status: 403,
                         json: { message: 'Verification rejected' },
@@ -119,6 +134,10 @@ for (const scenario of ['password-only', 'passkey', 'start-rejected', 'finish-re
                 assert.ok(request.headers()['x-pwd-csrf-token'] === tpl.csrf_token);
                 assert.ok(body.mfa_code === (tpl.needs_mfa ? mfaCode : undefined));
                 assert.ok(typeof body.password === 'string' && body.password.length >= 12);
+                if (scenario === 'put-rejected' && !putRejected) {
+                    putRejected = true;
+                    return route.fulfill({ status: 400, json: { message: 'Reset rejected' } });
+                }
                 return route.fulfill({ status: 202 });
             }
             return route.fulfill({ status: 400, json: { message: 'Unexpected endpoint' } });
@@ -127,7 +146,7 @@ for (const scenario of ['password-only', 'passkey', 'start-rejected', 'finish-re
         await page.locator('input[type=password]').first().waitFor();
         const cdp = await context.newCDPSession(page);
         await cdp.send('WebAuthn.enable');
-        await cdp.send('WebAuthn.addVirtualAuthenticator', {
+        const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
             options: {
                 protocol: 'ctap2',
                 transport: 'internal',
@@ -137,59 +156,97 @@ for (const scenario of ['password-only', 'passkey', 'start-rejected', 'finish-re
                 automaticPresenceSimulation: true,
             },
         });
-        await page.evaluate(async needsMfa => {
-            if (needsMfa) {
-                await navigator.credentials.create({
-                    publicKey: {
-                        challenge: crypto.getRandomValues(new Uint8Array(32)),
-                        rp: { name: 'Reset test', id: 'localhost' },
-                        user: {
-                            id: crypto.getRandomValues(new Uint8Array(16)),
-                            name: 'reset-user',
-                            displayName: 'Reset user',
-                        },
-                        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
-                        authenticatorSelection: {
-                            residentKey: 'required',
-                            userVerification: 'required',
-                        },
-                    },
-                });
-            }
-            const password = `${crypto.randomUUID()}aA1!`;
-            for (const input of document.querySelectorAll('input[type=password]')) {
-                input.value = password;
-                input.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-        }, tpl.needs_mfa);
+        if (scenario === 'cancelled') {
+            // No authenticator at ceremony time: the prompt fails and nothing
+            // must be sent beyond the already-issued start request.
+            await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+            await page.evaluate(() => {
+                const password = `${crypto.randomUUID()}aA1!`;
+                for (const input of document.querySelectorAll('input[type=password]')) {
+                    input.value = password;
+                    input.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+            });
+        } else {
+            createdCredId = await page.evaluate(
+                async ({ createCredential, residentKey }) => {
+                    let credentialId;
+                    if (createCredential) {
+                        const credential = await navigator.credentials.create({
+                            publicKey: {
+                                challenge: crypto.getRandomValues(new Uint8Array(32)),
+                                rp: { name: 'Reset test', id: 'localhost' },
+                                user: {
+                                    id: crypto.getRandomValues(new Uint8Array(16)),
+                                    name: 'reset-user',
+                                    displayName: 'Reset user',
+                                },
+                                pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+                                authenticatorSelection: {
+                                    residentKey,
+                                    userVerification: 'required',
+                                },
+                            },
+                        });
+                        credentialId = credential.id;
+                    }
+                    const password = `${crypto.randomUUID()}aA1!`;
+                    for (const input of document.querySelectorAll('input[type=password]')) {
+                        input.value = password;
+                        input.dispatchEvent(new Event('input', { bubbles: true }));
+                    }
+                    return credentialId;
+                },
+                {
+                    createCredential: tpl.needs_mfa,
+                    residentKey: scenario === 'non-resident-key' ? 'discouraged' : 'required',
+                },
+            );
+        }
         await page.getByRole('button', { name: 'Save', exact: true }).click();
-        if (scenario.endsWith('rejected')) {
+        const startReq = 'POST /auth/v1/users/reset-user/webauthn/auth/start';
+        const finishReq = 'POST /auth/v1/users/webauthn_finish';
+        const putReq = 'PUT /auth/v1/users/reset-user/reset';
+        if (scenario === 'cancelled') {
+            await page.locator('.err').first().waitFor();
+            assert.deepEqual(requests, [startReq]);
+            return;
+        }
+        if (scenario === 'start-rejected' || scenario === 'finish-rejected') {
             await page
                 .getByText(
                     scenario === 'start-rejected'
                         ? 'Reset binding rejected'
                         : 'Verification rejected',
-                    { exact: true },
+                    {
+                        exact: true,
+                    },
                 )
                 .first()
                 .waitFor();
-        } else {
-            await page.getByRole('link', { name: 'Account', exact: true }).waitFor();
-        }
-        const expected = [];
-        if (tpl.needs_mfa) expected.push('POST /auth/v1/users/reset-user/webauthn/auth/start');
-        if (tpl.needs_mfa && scenario !== 'start-rejected')
-            expected.push('POST /auth/v1/users/webauthn_finish');
-        if (!scenario.endsWith('rejected')) expected.push('PUT /auth/v1/users/reset-user/reset');
-        assert.deepEqual(requests, expected);
-        if (scenario.endsWith('rejected')) {
+            assert.deepEqual(
+                requests,
+                scenario === 'start-rejected' ? [startReq] : [startReq, finishReq],
+            );
             await page.getByRole('button', { name: 'Save', exact: true }).click();
             await page.getByRole('link', { name: 'Account', exact: true }).waitFor();
-            assert.deepEqual(requests.slice(expected.length), [
-                'POST /auth/v1/users/reset-user/webauthn/auth/start',
-                'POST /auth/v1/users/webauthn_finish',
-                'PUT /auth/v1/users/reset-user/reset',
-            ]);
+            assert.deepEqual(requests.slice(-3), [startReq, finishReq, putReq]);
+            return;
         }
+        if (scenario === 'put-rejected') {
+            await page.getByText('Reset rejected', { exact: true }).first().waitFor();
+            assert.ok(
+                (await page.getByRole('link', { name: 'Account', exact: true }).count()) === 0,
+            );
+            assert.deepEqual(requests, [startReq, finishReq, putReq]);
+            // A rejected update consumes the MFA proof: retry needs a fresh ceremony.
+            await page.getByRole('button', { name: 'Save', exact: true }).click();
+            await page.getByRole('link', { name: 'Account', exact: true }).waitFor();
+            assert.deepEqual(requests.slice(-3), [startReq, finishReq, putReq]);
+            return;
+        }
+        await page.getByRole('link', { name: 'Account', exact: true }).waitFor();
+        const expected = tpl.needs_mfa ? [startReq, finishReq, putReq] : [putReq];
+        assert.deepEqual(requests, expected);
     });
 }

--- a/frontend/tests/password-reset.node.mjs
+++ b/frontend/tests/password-reset.node.mjs
@@ -1,0 +1,195 @@
+// Built-UI contract tests, not backend authorization tests. All requests are intercepted;
+// credentials and reset context exist only in memory, without traces or a mail server.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { after, before, test } from 'node:test';
+import { chromium } from '@playwright/test';
+
+let browser;
+let html;
+before(async () => {
+    assert.ok(
+        !process.env.DEBUG && !process.env.PWDEBUG,
+        'Run without browser/protocol debug logging',
+    );
+    html = await readFile(
+        new URL('../../templates/html/users/{id}/reset/reset.html', import.meta.url),
+        'utf8',
+    );
+    browser = await chromium.launch({
+        executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+    });
+});
+after(async () => browser?.close());
+
+for (const scenario of ['password-only', 'passkey', 'start-rejected', 'finish-rejected']) {
+    test(`reset page: ${scenario}`, async t => {
+        const context = await browser.newContext({ serviceWorkers: 'block' });
+        t.after(() => context.close());
+        const page = await context.newPage();
+        const tpl = {
+            user_id: 'reset-user',
+            magic_link_id: crypto.randomUUID(),
+            csrf_token: crypto.randomUUID(),
+            needs_mfa: scenario !== 'password-only',
+            password_policy: {
+                length_min: 12,
+                length_max: 128,
+                include_lower_case: 1,
+                include_upper_case: 1,
+                include_digits: 1,
+                include_special: 1,
+            },
+        };
+        let challengeCode;
+        let mfaCode;
+        let rejected = false;
+        const requests = [];
+        const documentPath = '/auth/v1/users/reset-user/reset/reset';
+        await context.route('**/*', async route => {
+            const request = route.request();
+            const url = new URL(request.url());
+            if (url.origin !== 'http://localhost') return route.abort();
+            if (request.method() === 'GET' && url.pathname === documentPath) {
+                return route.fulfill({
+                    contentType: 'text/html',
+                    body: html.replace(
+                        /\{%- for tpl in templates -%\}[\s\S]*?\{%- endfor %\}/,
+                        `<template id="tpl_password_reset">${JSON.stringify(tpl)}</template>`,
+                    ),
+                });
+            }
+            if (
+                /^\/auth\/v1\/_app\/immutable\/(entry|chunks|nodes|assets)\/[\w.-]+\.(js|css|woff2)$/.test(
+                    url.pathname,
+                )
+            ) {
+                return route.fulfill({
+                    path: fileURLToPath(
+                        new URL(`../../static/v1/${url.pathname.slice(9)}`, import.meta.url),
+                    ),
+                });
+            }
+            if (request.method() === 'GET') return route.fulfill({ status: 404 });
+            requests.push(`${request.method()} ${url.pathname}`);
+            if (url.pathname === '/auth/v1/users/reset-user/webauthn/auth/start') {
+                assert.deepEqual(request.postDataJSON(), { purpose: 'PasswordReset' });
+                if (scenario === 'start-rejected' && !rejected) {
+                    rejected = true;
+                    return route.fulfill({
+                        status: 400,
+                        json: { message: 'Reset binding rejected' },
+                    });
+                }
+                challengeCode = crypto.randomUUID();
+                return route.fulfill({
+                    json: {
+                        code: challengeCode,
+                        exp: 60,
+                        rcr: {
+                            publicKey: {
+                                challenge: btoa(crypto.randomUUID()),
+                                rpId: 'localhost',
+                                userVerification: 'required',
+                            },
+                        },
+                    },
+                });
+            }
+            if (url.pathname === '/auth/v1/users/webauthn_finish') {
+                assert.ok(request.postDataJSON().code === challengeCode);
+                if (scenario === 'finish-rejected' && !rejected) {
+                    rejected = true;
+                    return route.fulfill({
+                        status: 403,
+                        json: { message: 'Verification rejected' },
+                    });
+                }
+                mfaCode = crypto.randomUUID();
+                return route.fulfill({
+                    status: 202,
+                    json: { code: mfaCode, user_id: tpl.user_id },
+                });
+            }
+            if (url.pathname === '/auth/v1/users/reset-user/reset') {
+                const body = request.postDataJSON();
+                assert.equal(request.method(), 'PUT');
+                assert.ok(body.magic_link_id === tpl.magic_link_id);
+                assert.ok(request.headers()['x-pwd-csrf-token'] === tpl.csrf_token);
+                assert.ok(body.mfa_code === (tpl.needs_mfa ? mfaCode : undefined));
+                assert.ok(typeof body.password === 'string' && body.password.length >= 12);
+                return route.fulfill({ status: 202 });
+            }
+            return route.fulfill({ status: 400, json: { message: 'Unexpected endpoint' } });
+        });
+        await page.goto(`http://localhost${documentPath}`);
+        await page.locator('input[type=password]').first().waitFor();
+        const cdp = await context.newCDPSession(page);
+        await cdp.send('WebAuthn.enable');
+        await cdp.send('WebAuthn.addVirtualAuthenticator', {
+            options: {
+                protocol: 'ctap2',
+                transport: 'internal',
+                hasResidentKey: true,
+                hasUserVerification: true,
+                isUserVerified: true,
+                automaticPresenceSimulation: true,
+            },
+        });
+        await page.evaluate(async needsMfa => {
+            if (needsMfa) {
+                await navigator.credentials.create({
+                    publicKey: {
+                        challenge: crypto.getRandomValues(new Uint8Array(32)),
+                        rp: { name: 'Reset test', id: 'localhost' },
+                        user: {
+                            id: crypto.getRandomValues(new Uint8Array(16)),
+                            name: 'reset-user',
+                            displayName: 'Reset user',
+                        },
+                        pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+                        authenticatorSelection: {
+                            residentKey: 'required',
+                            userVerification: 'required',
+                        },
+                    },
+                });
+            }
+            const password = `${crypto.randomUUID()}aA1!`;
+            for (const input of document.querySelectorAll('input[type=password]')) {
+                input.value = password;
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+        }, tpl.needs_mfa);
+        await page.getByRole('button', { name: 'Save', exact: true }).click();
+        if (scenario.endsWith('rejected')) {
+            await page
+                .getByText(
+                    scenario === 'start-rejected'
+                        ? 'Reset binding rejected'
+                        : 'Verification rejected',
+                    { exact: true },
+                )
+                .first()
+                .waitFor();
+        } else {
+            await page.getByRole('link', { name: 'Account', exact: true }).waitFor();
+        }
+        const expected = [];
+        if (tpl.needs_mfa) expected.push('POST /auth/v1/users/reset-user/webauthn/auth/start');
+        if (tpl.needs_mfa && scenario !== 'start-rejected')
+            expected.push('POST /auth/v1/users/webauthn_finish');
+        if (!scenario.endsWith('rejected')) expected.push('PUT /auth/v1/users/reset-user/reset');
+        assert.deepEqual(requests, expected);
+        if (scenario.endsWith('rejected')) {
+            await page.getByRole('button', { name: 'Save', exact: true }).click();
+            await page.getByRole('link', { name: 'Account', exact: true }).waitFor();
+            assert.deepEqual(requests.slice(expected.length), [
+                'POST /auth/v1/users/reset-user/webauthn/auth/start',
+                'POST /auth/v1/users/webauthn_finish',
+                'PUT /auth/v1/users/reset-user/reset',
+            ]);
+        }
+    });
+}

--- a/frontend/tests/password-reset.node.mjs
+++ b/frontend/tests/password-reset.node.mjs
@@ -30,7 +30,7 @@ for (const scenario of [
     'start-rejected',
     'finish-rejected',
     'put-rejected',
-    'cancelled',
+    'authenticator-timeout',
 ]) {
     test(`reset page: ${scenario}`, async t => {
         const context = await browser.newContext({ serviceWorkers: 'block' });
@@ -103,11 +103,11 @@ for (const scenario of [
                     publicKey.allowCredentials = [{ id: createdCredId, type: 'public-key' }];
                 }
                 return route.fulfill({
-                    // Short expiry for the cancelled ceremony so the test does not
+                    // Short expiry for the timeout scenario so the test does not
                     // wait out the full WebAuthn timeout with no authenticator present.
                     json: {
                         code: challengeCode,
-                        exp: scenario === 'cancelled' ? 6 : 60,
+                        exp: scenario === 'authenticator-timeout' ? 6 : 60,
                         rcr: { publicKey },
                     },
                 });
@@ -156,9 +156,9 @@ for (const scenario of [
                 automaticPresenceSimulation: true,
             },
         });
-        if (scenario === 'cancelled') {
-            // No authenticator at ceremony time: the prompt fails and nothing
-            // must be sent beyond the already-issued start request.
+        if (scenario === 'authenticator-timeout') {
+            // No authenticator is available, so the prompt times out and
+            // nothing must be sent beyond the already-issued start request.
             await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
             await page.evaluate(() => {
                 const password = `${crypto.randomUUID()}aA1!`;
@@ -207,7 +207,7 @@ for (const scenario of [
         const startReq = 'POST /auth/v1/users/reset-user/webauthn/auth/start';
         const finishReq = 'POST /auth/v1/users/webauthn_finish';
         const putReq = 'PUT /auth/v1/users/reset-user/reset';
-        if (scenario === 'cancelled') {
+        if (scenario === 'authenticator-timeout') {
             await page.locator('.err').first().waitFor();
             assert.deepEqual(requests, [startReq]);
             return;

--- a/frontend/tests/webauthn-auth.node.mjs
+++ b/frontend/tests/webauthn-auth.node.mjs
@@ -1,0 +1,91 @@
+// Run with: npm run test:webauthn
+// Frontend contract tests only: no backend, accounts, or network access.
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { after, before, test } from 'node:test';
+import { createServer } from 'vite';
+import config from '../svelte.config.js';
+
+let server;
+let webauthnAuth;
+const storageDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+before(async () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+        configurable: true,
+        value: { getItem: () => null },
+    });
+    server = await createServer({
+        configFile: false,
+        server: { middlewareMode: true, watch: null },
+        resolve: {
+            alias: Object.fromEntries(
+                Object.entries(config.kit.alias).map(([key, path]) => [key, resolve(path)]),
+            ),
+        },
+    });
+    ({ webauthnAuth } = await server.ssrLoadModule('/src/mfa/webauthn/authentication.ts'));
+});
+
+after(async () => {
+    await server?.close();
+    if (storageDescriptor) {
+        Object.defineProperty(globalThis, 'localStorage', storageDescriptor);
+    } else {
+        delete globalThis.localStorage;
+    }
+});
+
+test('password reset starts verification for the reset user', async t => {
+    const fetch = t.mock.method(globalThis, 'fetch', async (path, options) => {
+        assert.equal(path, '/auth/v1/users/reset-user/webauthn/auth/start');
+        assert.equal(options.method, 'POST');
+        assert.deepEqual(JSON.parse(options.body), { purpose: 'PasswordReset' });
+        return Response.json({ message: 'binding rejected' }, { status: 400 });
+    });
+    t.mock.method(console, 'error', () => {});
+    const result = await webauthnAuth('PasswordReset', 'invalid key', 'timeout', 'reset-user');
+    assert.equal(result.error, 'binding rejected');
+    assert.equal(fetch.mock.callCount(), 1);
+});
+
+test('missing reset user fails before any request', async t => {
+    const fetch = t.mock.method(globalThis, 'fetch', async () => {
+        throw new Error('must not send a reset request without its user');
+    });
+    for (const userId of [undefined, '']) {
+        const result = await webauthnAuth('PasswordReset', 'invalid key', 'timeout', userId);
+        assert.ok(result.error);
+    }
+    assert.equal(fetch.mock.callCount(), 0);
+});
+
+test('the reset user is encoded as one path segment', async t => {
+    t.mock.method(globalThis, 'fetch', async path => {
+        assert.equal(
+            path,
+            '/auth/v1/users/user%2Fwith%3Freserved%23characters/webauthn/auth/start',
+        );
+        return Response.json({ message: 'invalid user' }, { status: 400 });
+    });
+    t.mock.method(console, 'error', () => {});
+    await webauthnAuth('PasswordReset', 'invalid key', 'timeout', 'user/with?reserved#characters');
+});
+
+test('login and authenticated service purposes keep the generic endpoint', async t => {
+    // Generate login context at runtime; never persist it in a fixture or assertion output.
+    const login = { Login: crypto.randomUUID() };
+    for (const purpose of [login, 'Discover', 'PasswordNew', 'MfaModToken', 'Test']) {
+        const fetch = t.mock.method(globalThis, 'fetch', async (path, options) => {
+            assert.equal(path, '/auth/v1/users/webauthn_start');
+            assert.equal(options.method, 'POST');
+            assert.ok(JSON.stringify(JSON.parse(options.body).purpose) === JSON.stringify(purpose));
+            return Response.json({ message: 'verification rejected' }, { status: 403 });
+        });
+        t.mock.method(console, 'error', () => {});
+        const result = await webauthnAuth(purpose, 'invalid key', 'timeout', 'ignored-user');
+        assert.equal(result.error, 'verification rejected');
+        assert.equal(fetch.mock.callCount(), 1);
+        t.mock.restoreAll();
+    }
+});


### PR DESCRIPTION
## Problem

Password reset for an account with a registered passkey fails with:

> Password requests must use the user-specific webauthn start endpoint

When the reset page has `needs_mfa`, it sets `mfaPurpose = 'PasswordReset'` and renders `WebauthnRequest`, but the shared `webauthnAuth()` helper always POSTs `{"purpose":"PasswordReset"}` to the generic `/auth/v1/users/webauthn_start` endpoint — which explicitly rejects that purpose (`post_webauthn_auth_start_login`). The ceremony never starts: no challenge, no `navigator.credentials.get()`, no finish call, no password update.

Introduced by #1625 (ba32f522, "Rework MFA login to not require a UserID"), which removed the reset page's `userId` and switched the helper to the generic endpoint. Password-only accounts never take this branch; passkey/MFA accounts always do.

## Fix

Three frontend files, backend untouched:

- `frontend/src/mfa/webauthn/authentication.ts`: `PasswordReset` uses `/auth/v1/users/{id}/webauthn/auth/start` with the reset user; missing user context fails locally before any request. `Login` / `Discover` / `PasswordNew` / `MfaModToken` / `Test` keep the generic endpoint.
- `frontend/src/lib/WebauthnRequest.svelte`: forwards an optional `resetUserId`.
- `frontend/src/routes/users/{id}/reset/reset/+page.svelte`: passes the server-rendered `tplData.user_id`.

The `PasswordReset` purpose is preserved, and all existing backend authorization checks (reset binding cookie, magic-link validation, MFA user binding) are unchanged.

## Tests

- `frontend/tests/webauthn-auth.node.mjs` (`npm run test:webauthn`): reset purpose hits the user-specific path, missing/empty user sends no request, user id is encoded as one path segment, login and service purposes keep the generic endpoint.
- `frontend/tests/password-reset.node.mjs` (`npm run test:password-reset`): built reset page in Chromium with a virtual authenticator — password-only skips WebAuthn, passkey flow completes the UI ceremony, rejected start/finish stop before password update, and a retry after rejection succeeds. All backend responses are intercepted; these are frontend contract tests, not backend authorization proofs.
- `npm run check`, `npm run build`, Prettier: clean.

## Out of scope

Backend proof-binding redesign, the sibling OTP start message, token expiry/replay integration tests against a live backend.